### PR TITLE
Add property-based tests for ResponseParser, RetryPolicy, Models, MigrationOrchestrator, and PromptTemplates

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -57,11 +57,13 @@ lazy val root = (project in file("."))
       "io.opentelemetry" % "opentelemetry-exporter-otlp" % "1.44.1",
       "io.opentelemetry" % "opentelemetry-exporter-logging-otlp" % "1.44.1",
       "dev.zio" %% "zio-test" % "2.1.24" % Test,
-      "dev.zio" %% "zio-test-sbt" % "2.1.24" % Test
+      "dev.zio" %% "zio-test-sbt" % "2.1.24" % Test,
+      "dev.zio" %% "zio-test-magnolia" % "2.1.24" % Test
     ),
     testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
-    coverageExcludedPackages := ".*\\.example\\..*",
-    coverageMinimumStmtTotal := 70,
+    coverageExcludedPackages := "<empty>;.*\\.example\\..*",
+    coverageExcludedFiles := ".*Main\\.scala",
+    coverageMinimumStmtTotal := 80,
     coverageFailOnMinimum := true,
     coverageHighlighting := true,
     run / javaOptions ++= Seq(

--- a/src/test/scala/config/ConfigLoaderSpec.scala
+++ b/src/test/scala/config/ConfigLoaderSpec.scala
@@ -1,0 +1,295 @@
+package config
+
+import java.nio.file.Paths
+
+import zio.*
+import zio.test.*
+
+import models.MigrationConfig
+
+object ConfigLoaderSpec extends ZIOSpecDefault:
+
+  /** Default valid config for testing */
+  private val validConfig: MigrationConfig = MigrationConfig(
+    sourceDir = Paths.get("/tmp/cobol-source"),
+    outputDir = Paths.get("/tmp/java-output"),
+  )
+
+  def spec: Spec[Any, Any] = suite("ConfigLoaderSpec")(
+    suite("validate")(
+      test("accepts valid default config") {
+        for result <- ConfigLoader.validate(validConfig)
+        yield assertTrue(result == validConfig)
+      },
+      // Parallelism validation
+      test("rejects parallelism below 1") {
+        for result <- ConfigLoader.validate(validConfig.copy(parallelism = 0)).either
+        yield assertTrue(
+          result.isLeft,
+          result.left.exists(_.contains("Parallelism")),
+        )
+      },
+      test("rejects parallelism above 64") {
+        for result <- ConfigLoader.validate(validConfig.copy(parallelism = 65)).either
+        yield assertTrue(
+          result.isLeft,
+          result.left.exists(_.contains("Parallelism")),
+        )
+      },
+      test("accepts parallelism boundary value 1") {
+        for result <- ConfigLoader.validate(validConfig.copy(parallelism = 1))
+        yield assertTrue(result.parallelism == 1)
+      },
+      test("accepts parallelism boundary value 64") {
+        for result <- ConfigLoader.validate(validConfig.copy(parallelism = 64))
+        yield assertTrue(result.parallelism == 64)
+      },
+      // Batch size validation
+      test("rejects batch size below 1") {
+        for result <- ConfigLoader.validate(validConfig.copy(batchSize = 0)).either
+        yield assertTrue(
+          result.isLeft,
+          result.left.exists(_.contains("Batch size")),
+        )
+      },
+      test("rejects batch size above 100") {
+        for result <- ConfigLoader.validate(validConfig.copy(batchSize = 101)).either
+        yield assertTrue(
+          result.isLeft,
+          result.left.exists(_.contains("Batch size")),
+        )
+      },
+      test("accepts batch size boundary values") {
+        for
+          r1 <- ConfigLoader.validate(validConfig.copy(batchSize = 1))
+          r2 <- ConfigLoader.validate(validConfig.copy(batchSize = 100))
+        yield assertTrue(r1.batchSize == 1, r2.batchSize == 100)
+      },
+      // Retries validation
+      test("rejects retries below 0") {
+        for result <- ConfigLoader.validate(validConfig.copy(geminiMaxRetries = -1)).either
+        yield assertTrue(
+          result.isLeft,
+          result.left.exists(_.contains("retries")),
+        )
+      },
+      test("rejects retries above 10") {
+        for result <- ConfigLoader.validate(validConfig.copy(geminiMaxRetries = 11)).either
+        yield assertTrue(
+          result.isLeft,
+          result.left.exists(_.contains("retries")),
+        )
+      },
+      test("accepts retries boundary values") {
+        for
+          r1 <- ConfigLoader.validate(validConfig.copy(geminiMaxRetries = 0))
+          r2 <- ConfigLoader.validate(validConfig.copy(geminiMaxRetries = 10))
+        yield assertTrue(r1.geminiMaxRetries == 0, r2.geminiMaxRetries == 10)
+      },
+      // Timeout validation
+      test("rejects timeout below 1 second") {
+        for result <- ConfigLoader.validate(validConfig.copy(geminiTimeout = Duration.Zero)).either
+        yield assertTrue(
+          result.isLeft,
+          result.left.exists(_.contains("Timeout")),
+        )
+      },
+      test("rejects timeout above 10 minutes") {
+        for result <- ConfigLoader.validate(validConfig.copy(geminiTimeout = Duration.fromSeconds(601))).either
+        yield assertTrue(
+          result.isLeft,
+          result.left.exists(_.contains("Timeout")),
+        )
+      },
+      test("accepts timeout boundary values") {
+        for
+          r1 <- ConfigLoader.validate(validConfig.copy(geminiTimeout = Duration.fromSeconds(1)))
+          r2 <- ConfigLoader.validate(validConfig.copy(geminiTimeout = Duration.fromSeconds(600)))
+        yield assertTrue(
+          r1.geminiTimeout.toSeconds == 1L,
+          r2.geminiTimeout.toSeconds == 600L,
+        )
+      },
+      // Rate limiter validation
+      test("rejects requests per minute below 1") {
+        for result <- ConfigLoader.validate(validConfig.copy(geminiRequestsPerMinute = 0)).either
+        yield assertTrue(
+          result.isLeft,
+          result.left.exists(_.contains("requests per minute")),
+        )
+      },
+      test("rejects requests per minute above 600") {
+        for result <- ConfigLoader.validate(validConfig.copy(geminiRequestsPerMinute = 601)).either
+        yield assertTrue(
+          result.isLeft,
+          result.left.exists(_.contains("requests per minute")),
+        )
+      },
+      test("rejects burst size below 1") {
+        for result <- ConfigLoader.validate(validConfig.copy(geminiBurstSize = 0)).either
+        yield assertTrue(
+          result.isLeft,
+          result.left.exists(_.contains("burst size")),
+        )
+      },
+      test("rejects burst size above 100") {
+        for result <- ConfigLoader.validate(validConfig.copy(geminiBurstSize = 101)).either
+        yield assertTrue(
+          result.isLeft,
+          result.left.exists(_.contains("burst size")),
+        )
+      },
+      test("rejects acquire timeout below 1 second") {
+        for result <- ConfigLoader
+                        .validate(validConfig.copy(geminiAcquireTimeout = Duration.fromMillis(500)))
+                        .either
+        yield assertTrue(
+          result.isLeft,
+          result.left.exists(_.contains("acquire timeout")),
+        )
+      },
+      test("rejects acquire timeout above 300 seconds") {
+        for result <- ConfigLoader
+                        .validate(validConfig.copy(geminiAcquireTimeout = Duration.fromSeconds(301)))
+                        .either
+        yield assertTrue(
+          result.isLeft,
+          result.left.exists(_.contains("acquire timeout")),
+        )
+      },
+      // Discovery validation
+      test("rejects discovery max depth below 1") {
+        for result <- ConfigLoader.validate(validConfig.copy(discoveryMaxDepth = 0)).either
+        yield assertTrue(
+          result.isLeft,
+          result.left.exists(_.contains("max depth")),
+        )
+      },
+      test("rejects discovery max depth above 100") {
+        for result <- ConfigLoader.validate(validConfig.copy(discoveryMaxDepth = 101)).either
+        yield assertTrue(
+          result.isLeft,
+          result.left.exists(_.contains("max depth")),
+        )
+      },
+      test("rejects empty exclude patterns") {
+        for result <- ConfigLoader
+                        .validate(validConfig.copy(discoveryExcludePatterns = List("valid", "", "also-valid")))
+                        .either
+        yield assertTrue(
+          result.isLeft,
+          result.left.exists(_.contains("empty values")),
+        )
+      },
+      test("rejects whitespace-only exclude patterns") {
+        for result <- ConfigLoader
+                        .validate(validConfig.copy(discoveryExcludePatterns = List("valid", "  ", "also-valid")))
+                        .either
+        yield assertTrue(
+          result.isLeft,
+          result.left.exists(_.contains("empty values")),
+        )
+      },
+      test("accepts empty exclude patterns list") {
+        for result <- ConfigLoader.validate(validConfig.copy(discoveryExcludePatterns = List.empty))
+        yield assertTrue(result.discoveryExcludePatterns.isEmpty)
+      },
+    ),
+    suite("validate - property-based")(
+      test("valid parallelism range always passes") {
+        check(Gen.int(1, 64)) { parallelism =>
+          for result <- ConfigLoader.validate(validConfig.copy(parallelism = parallelism))
+          yield assertTrue(result.parallelism == parallelism)
+        }
+      },
+      test("invalid parallelism always fails") {
+        check(Gen.oneOf(Gen.int(Int.MinValue, 0), Gen.int(65, Int.MaxValue))) { parallelism =>
+          for result <- ConfigLoader.validate(validConfig.copy(parallelism = parallelism)).either
+          yield assertTrue(result.isLeft)
+        }
+      },
+      test("valid batch size range always passes") {
+        check(Gen.int(1, 100)) { batchSize =>
+          for result <- ConfigLoader.validate(validConfig.copy(batchSize = batchSize))
+          yield assertTrue(result.batchSize == batchSize)
+        }
+      },
+      test("invalid batch size always fails") {
+        check(Gen.oneOf(Gen.int(Int.MinValue, 0), Gen.int(101, Int.MaxValue))) { batchSize =>
+          for result <- ConfigLoader.validate(validConfig.copy(batchSize = batchSize)).either
+          yield assertTrue(result.isLeft)
+        }
+      },
+      test("valid retries range always passes") {
+        check(Gen.int(0, 10)) { retries =>
+          for result <- ConfigLoader.validate(validConfig.copy(geminiMaxRetries = retries))
+          yield assertTrue(result.geminiMaxRetries == retries)
+        }
+      },
+      test("invalid retries always fails") {
+        check(Gen.oneOf(Gen.int(Int.MinValue, -1), Gen.int(11, Int.MaxValue))) { retries =>
+          for result <- ConfigLoader.validate(validConfig.copy(geminiMaxRetries = retries)).either
+          yield assertTrue(result.isLeft)
+        }
+      },
+      test("valid requests per minute range always passes") {
+        check(Gen.int(1, 600)) { rpm =>
+          for result <- ConfigLoader.validate(validConfig.copy(geminiRequestsPerMinute = rpm))
+          yield assertTrue(result.geminiRequestsPerMinute == rpm)
+        }
+      },
+      test("valid burst size range always passes") {
+        check(Gen.int(1, 100)) { burst =>
+          for result <- ConfigLoader.validate(validConfig.copy(geminiBurstSize = burst))
+          yield assertTrue(result.geminiBurstSize == burst)
+        }
+      },
+      test("valid discovery max depth range always passes") {
+        check(Gen.int(1, 100)) { depth =>
+          for result <- ConfigLoader.validate(validConfig.copy(discoveryMaxDepth = depth))
+          yield assertTrue(result.discoveryMaxDepth == depth)
+        }
+      },
+      test("non-empty exclude patterns always pass") {
+        check(Gen.listOfBounded(0, 5)(Gen.alphaNumericStringBounded(1, 20))) { patterns =>
+          for result <- ConfigLoader.validate(validConfig.copy(discoveryExcludePatterns = patterns))
+          yield assertTrue(result.discoveryExcludePatterns == patterns)
+        }
+      },
+    ),
+    suite("loadFromFile")(
+      test("fails for missing config file") {
+        for result <- ConfigLoader.loadFromFile(Paths.get("/nonexistent/path/config.conf")).either
+        yield assertTrue(result.isLeft)
+      }
+    ),
+    suite("load and loadWithEnvOverrides")(
+      test("load fails when no config is available") {
+        for result <- ConfigLoader.load.either
+        yield assertTrue(result.isLeft)
+      },
+      test("loadWithEnvOverrides fails when required fields missing") {
+        for result <- ConfigLoader.loadWithEnvOverrides.either
+        yield assertTrue(result.isLeft)
+      },
+    ),
+    suite("MigrationConfig defaults")(
+      test("default config has expected default values") {
+        val config = MigrationConfig(
+          sourceDir = Paths.get("/tmp/src"),
+          outputDir = Paths.get("/tmp/out"),
+        )
+        assertTrue(
+          config.geminiModel == "gemini-2.0-flash",
+          config.geminiMaxRetries == 3,
+          config.parallelism == 4,
+          config.batchSize == 10,
+          config.enableCheckpointing,
+          !config.dryRun,
+          !config.verbose,
+          config.discoveryMaxDepth == 25,
+          config.discoveryExcludePatterns.nonEmpty,
+        )
+      }
+    ),
+  )

--- a/src/test/scala/core/LoggerPropertySpec.scala
+++ b/src/test/scala/core/LoggerPropertySpec.scala
@@ -1,0 +1,163 @@
+package core
+
+import java.nio.file.{ Files, Path }
+
+import zio.*
+import zio.test.*
+import zio.test.TestAspect.*
+
+/** Tests for Logger service accessors and file/combined logger implementations. */
+object LoggerPropertySpec extends ZIOSpecDefault:
+
+  private def withTempLogFile[A](test: Path => ZIO[Any, Any, A]): ZIO[Any, Any, A] =
+    ZIO.acquireReleaseWith(
+      ZIO.attempt(Files.createTempFile("logger-test", ".log"))
+    )(path => ZIO.attempt(Files.deleteIfExists(path)).ignore)(test)
+
+  def spec: Spec[Any, Any] = suite("LoggerPropertySpec")(
+    suite("Logger.service accessors")(
+      test("service.info logs via Logger service") {
+        withTempLogFile { logFile =>
+          for
+            _       <- Logger.service.info("service info test").provide(Logger.file(logFile.toString))
+            content <- ZIO.attempt(Files.readString(logFile))
+          yield assertTrue(content.contains("service info test"))
+        }
+      },
+      test("service.debug logs via Logger service") {
+        withTempLogFile { logFile =>
+          for
+            _       <- Logger.service.debug("service debug test").provide(Logger.file(logFile.toString))
+            content <- ZIO.attempt(Files.readString(logFile))
+          yield assertTrue(content.contains("service debug test"))
+        }
+      },
+      test("service.trace logs via Logger service") {
+        withTempLogFile { logFile =>
+          for
+            _       <- Logger.service.trace("service trace test").provide(Logger.file(logFile.toString))
+            content <- ZIO.attempt(Files.readString(logFile))
+          yield assertTrue(content.contains("service trace test"))
+        }
+      },
+      test("service.warn logs via Logger service") {
+        withTempLogFile { logFile =>
+          for
+            _       <- Logger.service.warn("service warn test").provide(Logger.file(logFile.toString))
+            content <- ZIO.attempt(Files.readString(logFile))
+          yield assertTrue(content.contains("service warn test"))
+        }
+      },
+      test("service.error logs via Logger service") {
+        withTempLogFile { logFile =>
+          for
+            _       <- Logger.service.error("service error test").provide(Logger.file(logFile.toString))
+            content <- ZIO.attempt(Files.readString(logFile))
+          yield assertTrue(content.contains("service error test"))
+        }
+      },
+      test("service.error with cause logs via Logger service") {
+        withTempLogFile { logFile =>
+          val cause = new RuntimeException("service test exception")
+          for
+            _       <- Logger.service
+                         .error("service error with cause", cause)
+                         .provide(Logger.file(logFile.toString))
+            content <- ZIO.attempt(Files.readString(logFile))
+          yield assertTrue(content.contains("service error with cause"))
+        }
+      },
+      test("service.withContext returns contextual logger") {
+        withTempLogFile { logFile =>
+          for
+            logger  <- Logger.service.withContext("key", "value").provide(Logger.file(logFile.toString))
+            _       <- logger.info("context logger test")
+            content <- ZIO.attempt(Files.readString(logFile))
+          yield assertTrue(
+            content.contains("context logger test"),
+            content.contains("\"key\":\"value\""),
+          )
+        }
+      },
+      test("service.withRunId returns run-scoped logger") {
+        withTempLogFile { logFile =>
+          for
+            logger  <- Logger.service.withRunId("run-test-1").provide(Logger.file(logFile.toString))
+            _       <- logger.info("run scoped test")
+            content <- ZIO.attempt(Files.readString(logFile))
+          yield assertTrue(content.contains("\"runId\":\"run-test-1\""))
+        }
+      },
+      test("service.withAgentName returns agent-scoped logger") {
+        withTempLogFile { logFile =>
+          for
+            logger  <- Logger.service.withAgentName("TestAgent").provide(Logger.file(logFile.toString))
+            _       <- logger.info("agent scoped test")
+            content <- ZIO.attempt(Files.readString(logFile))
+          yield assertTrue(content.contains("\"agentName\":\"TestAgent\""))
+        }
+      },
+      test("service.withStep returns step-scoped logger") {
+        withTempLogFile { logFile =>
+          for
+            logger  <- Logger.service.withStep("Analysis").provide(Logger.file(logFile.toString))
+            _       <- logger.info("step scoped test")
+            content <- ZIO.attempt(Files.readString(logFile))
+          yield assertTrue(content.contains("\"step\":\"Analysis\""))
+        }
+      },
+    ),
+    suite("Logger.combined")(
+      test("combined logger writes to file") {
+        withTempLogFile { logFile =>
+          for
+            _       <- Logger.service.info("combined test").provide(Logger.combined(logFile.toString))
+            content <- ZIO.attempt(Files.readString(logFile))
+          yield assertTrue(content.contains("combined test"))
+        }
+      },
+      test("combined logger supports context propagation") {
+        withTempLogFile { logFile =>
+          for
+            logger  <- Logger.service.withRunId("combined-run").provide(Logger.combined(logFile.toString))
+            _       <- logger.info("combined context test")
+            content <- ZIO.attempt(Files.readString(logFile))
+          yield assertTrue(content.contains("\"runId\":\"combined-run\""))
+        }
+      },
+      test("combined logger withAgentName propagates to both") {
+        withTempLogFile { logFile =>
+          for
+            logger  <- Logger.service.withAgentName("CombinedAgent").provide(Logger.combined(logFile.toString))
+            _       <- logger.info("combined agent test")
+            content <- ZIO.attempt(Files.readString(logFile))
+          yield assertTrue(content.contains("\"agentName\":\"CombinedAgent\""))
+        }
+      },
+      test("combined logger withStep propagates to both") {
+        withTempLogFile { logFile =>
+          for
+            logger  <- Logger.service.withStep("Validation").provide(Logger.combined(logFile.toString))
+            _       <- logger.info("combined step test")
+            content <- ZIO.attempt(Files.readString(logFile))
+          yield assertTrue(content.contains("\"step\":\"Validation\""))
+        }
+      },
+    ),
+    suite("Logger.console")(
+      test("console logger can be created and used") {
+        for _ <- Logger.service.info("console test").provide(Logger.console)
+        yield assertTrue(true)
+      }
+    ),
+    suite("Codecs round-trip via Duration")(
+      test("Duration codec round-trips via milliseconds") {
+        check(Gen.long(0L, 1000000L)) { millis =>
+          val duration  = Duration.fromMillis(millis)
+          val asMillis  = duration.toMillis
+          val roundTrip = Duration.fromMillis(asMillis)
+          assertTrue(roundTrip == duration)
+        }
+      }
+    ),
+  ) @@ sequential

--- a/src/test/scala/core/ObservableLoggerSpec.scala
+++ b/src/test/scala/core/ObservableLoggerSpec.scala
@@ -1,0 +1,189 @@
+package core
+
+import java.nio.file.{ Files, Path }
+
+import zio.*
+import zio.test.*
+import zio.test.TestAspect.*
+
+/** Tests for ObservableLogger - structured logging with OpenTelemetry trace correlation */
+object ObservableLoggerSpec extends ZIOSpecDefault:
+
+  private def withTempLogFile[A](test: Path => ZIO[Any, Any, A]): ZIO[Any, Any, A] =
+    ZIO.acquireReleaseWith(
+      ZIO.attempt(Files.createTempFile("observable-log-test", ".log"))
+    )(path => ZIO.attempt(Files.deleteIfExists(path)).ignore)(test)
+
+  def spec: Spec[Any, Any] = suite("ObservableLoggerSpec")(
+    suite("log level methods")(
+      test("info writes JSON log entry to file") {
+        withTempLogFile { logFile =>
+          for
+            _       <- ObservableLogger.info("test info message").provide(ObservableLogger.live(logFile.toString))
+            content <- ZIO.attempt(Files.readString(logFile))
+          yield assertTrue(
+            content.contains("\"level\":\"INFO\""),
+            content.contains("\"message\":\"test info message\""),
+            content.contains("\"timestamp\":"),
+          )
+        }
+      },
+      test("error writes JSON log entry with ERROR level") {
+        withTempLogFile { logFile =>
+          for
+            _       <- ObservableLogger.error("test error").provide(ObservableLogger.live(logFile.toString))
+            content <- ZIO.attempt(Files.readString(logFile))
+          yield assertTrue(
+            content.contains("\"level\":\"ERROR\""),
+            content.contains("\"message\":\"test error\""),
+          )
+        }
+      },
+      test("error with cause includes cause in JSON") {
+        withTempLogFile { logFile =>
+          val cause = new RuntimeException("test exception")
+          for
+            _       <- ObservableLogger
+                         .error("error with cause", cause)
+                         .provide(ObservableLogger.live(logFile.toString))
+            content <- ZIO.attempt(Files.readString(logFile))
+          yield assertTrue(
+            content.contains("\"level\":\"ERROR\""),
+            content.contains("\"cause\":\"test exception\""),
+          )
+        }
+      },
+      test("debug writes JSON log entry with DEBUG level") {
+        withTempLogFile { logFile =>
+          for
+            _       <- ObservableLogger.debug("debug msg").provide(ObservableLogger.live(logFile.toString))
+            content <- ZIO.attempt(Files.readString(logFile))
+          yield assertTrue(content.contains("\"level\":\"DEBUG\""))
+        }
+      },
+      test("warn writes JSON log entry with WARN level") {
+        withTempLogFile { logFile =>
+          for
+            _       <- ObservableLogger.warn("warning msg").provide(ObservableLogger.live(logFile.toString))
+            content <- ZIO.attempt(Files.readString(logFile))
+          yield assertTrue(content.contains("\"level\":\"WARN\""))
+        }
+      },
+      test("trace writes JSON log entry with TRACE level") {
+        withTempLogFile { logFile =>
+          for
+            _       <- ObservableLogger.trace("trace msg").provide(ObservableLogger.live(logFile.toString))
+            content <- ZIO.attempt(Files.readString(logFile))
+          yield assertTrue(content.contains("\"level\":\"TRACE\""))
+        }
+      },
+    ),
+    suite("context propagation")(
+      test("withContext adds annotations to log output") {
+        withTempLogFile { logFile =>
+          for
+            logger       <- ZIO.service[ObservableLogger].provide(ObservableLogger.live(logFile.toString))
+            contextLogger = logger.withContext("myKey", "myValue")
+            _            <- contextLogger.info("context test")
+            content      <- ZIO.attempt(Files.readString(logFile))
+          yield assertTrue(
+            content.contains("\"myKey\":\"myValue\""),
+            content.contains("context test"),
+          )
+        }
+      },
+      test("withRunId adds runId to log context") {
+        withTempLogFile { logFile =>
+          for
+            logger   <- ZIO.service[ObservableLogger].provide(ObservableLogger.live(logFile.toString))
+            runLogger = logger.withRunId("run-123")
+            _        <- runLogger.info("run test")
+            content  <- ZIO.attempt(Files.readString(logFile))
+          yield assertTrue(content.contains("\"runId\":\"run-123\""))
+        }
+      },
+      test("withAgentName adds agentName to log context") {
+        withTempLogFile { logFile =>
+          for
+            logger     <- ZIO.service[ObservableLogger].provide(ObservableLogger.live(logFile.toString))
+            agentLogger = logger.withAgentName("CobolAnalyzer")
+            _          <- agentLogger.info("agent test")
+            content    <- ZIO.attempt(Files.readString(logFile))
+          yield assertTrue(content.contains("\"agentName\":\"CobolAnalyzer\""))
+        }
+      },
+      test("withStep adds step to log context") {
+        withTempLogFile { logFile =>
+          for
+            logger    <- ZIO.service[ObservableLogger].provide(ObservableLogger.live(logFile.toString))
+            stepLogger = logger.withStep("Discovery")
+            _         <- stepLogger.info("step test")
+            content   <- ZIO.attempt(Files.readString(logFile))
+          yield assertTrue(content.contains("\"step\":\"Discovery\""))
+        }
+      },
+      test("multiple context values are accumulated") {
+        withTempLogFile { logFile =>
+          for
+            logger  <- ZIO.service[ObservableLogger].provide(ObservableLogger.live(logFile.toString))
+            enriched = logger.withRunId("run-456").withAgentName("Mapper").withStep("Mapping")
+            _       <- enriched.info("multi-context")
+            content <- ZIO.attempt(Files.readString(logFile))
+          yield assertTrue(
+            content.contains("\"runId\":\"run-456\""),
+            content.contains("\"agentName\":\"Mapper\""),
+            content.contains("\"step\":\"Mapping\""),
+          )
+        }
+      },
+    ),
+    suite("logWithTraceContext")(
+      test("logs with trace context when no active span") {
+        withTempLogFile { logFile =>
+          for
+            logger  <- ZIO.service[ObservableLogger].provide(ObservableLogger.live(logFile.toString))
+            _       <- logger.logWithTraceContext(LogLevel.Info, "trace context test")
+            content <- ZIO.attempt(Files.readString(logFile))
+          yield assertTrue(
+            content.contains("\"level\":\"INFO\""),
+            content.contains("trace context test"),
+          )
+        }
+      }
+    ),
+    suite("message escaping")(
+      test("escapes quotes in messages") {
+        withTempLogFile { logFile =>
+          for
+            _       <- ObservableLogger
+                         .info("""message with "quotes" inside""")
+                         .provide(ObservableLogger.live(logFile.toString))
+            content <- ZIO.attempt(Files.readString(logFile))
+          yield assertTrue(content.contains("\\\"quotes\\\""))
+        }
+      },
+      test("escapes newlines in messages") {
+        withTempLogFile { logFile =>
+          for
+            _       <- ObservableLogger
+                         .info("line1\nline2")
+                         .provide(ObservableLogger.live(logFile.toString))
+            content <- ZIO.attempt(Files.readString(logFile))
+          yield assertTrue(content.contains("line1\\nline2"))
+        }
+      },
+    ),
+    suite("multiple log entries")(
+      test("appends multiple entries to same file") {
+        withTempLogFile { logFile =>
+          for
+            _       <- ObservableLogger.info("first").provide(ObservableLogger.live(logFile.toString))
+            _       <- ObservableLogger.info("second").provide(ObservableLogger.live(logFile.toString))
+            _       <- ObservableLogger.info("third").provide(ObservableLogger.live(logFile.toString))
+            content <- ZIO.attempt(Files.readString(logFile))
+            lines    = content.split("\n").filter(_.nonEmpty)
+          yield assertTrue(lines.length == 3)
+        }
+      }
+    ),
+  ) @@ sequential

--- a/src/test/scala/core/RateLimiterPropertySpec.scala
+++ b/src/test/scala/core/RateLimiterPropertySpec.scala
@@ -1,0 +1,174 @@
+package core
+
+import zio.*
+import zio.test.*
+import zio.test.TestAspect.*
+
+import models.RateLimitError
+
+/** Property-based tests for RateLimiter and RateLimiterConfig. */
+object RateLimiterPropertySpec extends ZIOSpecDefault:
+
+  def spec: Spec[Any, Any] = suite("RateLimiterPropertySpec")(
+    suite("RateLimiterConfig")(
+      test("fromMigrationConfig maps all fields correctly") {
+        check(Gen.int(1, 600), Gen.int(1, 100), Gen.long(1000L, 300000L)) { (rpm, burst, timeoutMs) =>
+          val migrationConfig   = models.MigrationConfig(
+            sourceDir = java.nio.file.Paths.get("/tmp/src"),
+            outputDir = java.nio.file.Paths.get("/tmp/out"),
+            geminiRequestsPerMinute = rpm,
+            geminiBurstSize = burst,
+            geminiAcquireTimeout = Duration.fromMillis(timeoutMs),
+          )
+          val rateLimiterConfig = RateLimiterConfig.fromMigrationConfig(migrationConfig)
+          assertTrue(
+            rateLimiterConfig.requestsPerMinute == rpm,
+            rateLimiterConfig.burstSize == burst,
+            rateLimiterConfig.acquireTimeout == Duration.fromMillis(timeoutMs),
+          )
+        }
+      },
+      test("default config has sensible values") {
+        val config = RateLimiterConfig()
+        assertTrue(
+          config.requestsPerMinute == 60,
+          config.burstSize == 10,
+          config.acquireTimeout == 30.seconds,
+        )
+      },
+    ),
+    suite("RateLimiter.make")(
+      test("acquire succeeds within burst size") {
+        check(Gen.int(1, 20)) { burstSize =>
+          ZIO.scoped {
+            for
+              limiter <- RateLimiter.make(RateLimiterConfig(requestsPerMinute = 600, burstSize = burstSize))
+              results <- ZIO.foreach(1 to burstSize)(_ => limiter.acquire.either)
+            yield assertTrue(results.forall(_.isRight))
+          }
+        }
+      },
+      test("tryAcquire returns true within burst") {
+        ZIO.scoped {
+          for
+            limiter <- RateLimiter.make(RateLimiterConfig(requestsPerMinute = 600, burstSize = 5))
+            results <- ZIO.foreach(1 to 5)(_ => limiter.tryAcquire)
+          yield assertTrue(results.forall(_ == true))
+        }
+      },
+      test("tryAcquire returns false when burst exhausted") {
+        ZIO.scoped {
+          for
+            limiter <- RateLimiter.make(RateLimiterConfig(requestsPerMinute = 600, burstSize = 2))
+            _       <- limiter.acquire
+            _       <- limiter.acquire
+            result  <- limiter.tryAcquire
+          yield assertTrue(!result)
+        }
+      },
+      test("metrics track total requests") {
+        ZIO.scoped {
+          for
+            limiter <- RateLimiter.make(RateLimiterConfig(requestsPerMinute = 600, burstSize = 10))
+            _       <- limiter.acquire
+            _       <- limiter.acquire
+            _       <- limiter.acquire
+            m       <- limiter.metrics
+          yield assertTrue(m.totalRequests == 3L)
+        }
+      },
+      test("metrics track throttled requests via tryAcquire") {
+        ZIO.scoped {
+          for
+            limiter <- RateLimiter.make(RateLimiterConfig(requestsPerMinute = 600, burstSize = 1))
+            _       <- limiter.tryAcquire // succeeds
+            _       <- limiter.tryAcquire // throttled
+            m       <- limiter.metrics
+          yield assertTrue(m.throttledRequests == 1L)
+        }
+      },
+    ),
+    suite("RateLimiter invalid config")(
+      test("acquire fails with InvalidConfig for zero requestsPerMinute") {
+        ZIO.scoped {
+          for
+            limiter <- RateLimiter.make(RateLimiterConfig(requestsPerMinute = 0, burstSize = 10))
+            result  <- limiter.acquire.either
+          yield assertTrue(result.left.exists {
+            case RateLimitError.InvalidConfig(_) => true
+            case _                               => false
+          })
+        }
+      },
+      test("acquire fails with InvalidConfig for zero burstSize") {
+        ZIO.scoped {
+          for
+            limiter <- RateLimiter.make(RateLimiterConfig(requestsPerMinute = 60, burstSize = 0))
+            result  <- limiter.acquire.either
+          yield assertTrue(result.left.exists {
+            case RateLimitError.InvalidConfig(_) => true
+            case _                               => false
+          })
+        }
+      },
+      test("tryAcquire returns false for invalid config") {
+        ZIO.scoped {
+          for
+            limiter <- RateLimiter.make(RateLimiterConfig(requestsPerMinute = 0, burstSize = 0))
+            result  <- limiter.tryAcquire
+          yield assertTrue(!result)
+        }
+      },
+    ),
+    suite("RateLimiter with TestClock")(
+      test("tokens refill over time") {
+        ZIO.scoped {
+          for
+            limiter <- RateLimiter.make(RateLimiterConfig(requestsPerMinute = 60, burstSize = 2))
+            // Exhaust burst
+            _       <- limiter.acquire
+            _       <- limiter.acquire
+            // Advance time to allow refill (1 req/sec at 60 rpm)
+            _       <- TestClock.adjust(2.seconds)
+            // Should be able to acquire again
+            result  <- limiter.tryAcquire
+          yield assertTrue(result)
+        }
+      },
+      test("acquire times out when no tokens available and timeout expires") {
+        ZIO.scoped {
+          for
+            limiter <- RateLimiter.make(
+                         RateLimiterConfig(
+                           requestsPerMinute = 6, // 0.1 per second - very slow refill
+                           burstSize = 1,
+                           acquireTimeout = 100.millis,
+                         )
+                       )
+            // Exhaust the burst
+            _       <- limiter.acquire
+            // Try to acquire - should start waiting
+            fiber   <- limiter.acquire.either.fork
+            // Advance past the timeout
+            _       <- TestClock.adjust(200.millis)
+            result  <- fiber.join
+          yield assertTrue(result.left.exists {
+            case RateLimitError.AcquireTimeout(_) => true
+            case _                                => false
+          })
+        }
+      },
+    ),
+    suite("RateLimiter.live layer")(
+      test("provides limiter via ZLayer") {
+        val config = RateLimiterConfig(requestsPerMinute = 600, burstSize = 5)
+        ZIO.scoped {
+          for
+            limiter <- ZIO.service[RateLimiter].provide(ZLayer.succeed(config) >>> RateLimiter.live)
+            _       <- limiter.acquire
+            m       <- limiter.metrics
+          yield assertTrue(m.totalRequests == 1L)
+        }
+      }
+    ),
+  )

--- a/src/test/scala/core/ResponseParserPropertySpec.scala
+++ b/src/test/scala/core/ResponseParserPropertySpec.scala
@@ -1,0 +1,128 @@
+package core
+
+import zio.*
+import zio.json.*
+import zio.test.*
+
+import models.{ GeminiResponse, ParseError }
+
+/** Property-based tests for ResponseParser.
+  *
+  * Tests extraction and parsing invariants with generated inputs.
+  */
+object ResponseParserPropertySpec extends ZIOSpecDefault:
+
+  private val parser = ResponseParser.live
+
+  def spec: Spec[Any, Any] = suite("ResponseParserPropertySpec")(
+    suite("extractJson - code block wrapping")(
+      test("extracts any valid JSON from json code block") {
+        check(Gen.alphaNumericStringBounded(1, 20), Gen.int) { (name, count) =>
+          val jsonContent = s"""{"name":"$name","count":$count}"""
+          val response    = GeminiResponse(s"Result:\n```json\n$jsonContent\n```\nDone.", 0)
+          for json <- ResponseParser.extractJson(response).provide(parser)
+          yield assertTrue(json == jsonContent)
+        }
+      },
+      test("extracts JSON from generic code block when no json block exists") {
+        check(Gen.alphaNumericStringBounded(1, 15)) { value =>
+          val jsonContent = s"""{"value":"$value"}"""
+          val response    = GeminiResponse(s"```\n$jsonContent\n```", 0)
+          for json <- ResponseParser.extractJson(response).provide(parser)
+          yield assertTrue(json == jsonContent)
+        }
+      },
+      test("prefers json-tagged block over generic block") {
+        check(Gen.alphaNumericStringBounded(1, 10)) { value =>
+          val generic  = """{"generic":"data"}"""
+          val jsonData = s"""{"preferred":"$value"}"""
+          val response = GeminiResponse(s"```\n$generic\n```\n```json\n$jsonData\n```", 0)
+          for json <- ResponseParser.extractJson(response).provide(parser)
+          yield assertTrue(json == jsonData)
+        }
+      },
+      test("extracts inline JSON objects") {
+        check(Gen.alphaNumericStringBounded(1, 15)) { key =>
+          val jsonContent = s"""{"$key":42}"""
+          val response    = GeminiResponse(s"Result => $jsonContent end", 0)
+          for json <- ResponseParser.extractJson(response).provide(parser)
+          yield assertTrue(json == jsonContent)
+        }
+      },
+      test("extracts inline JSON arrays") {
+        val response = GeminiResponse("Result: [1,2,3] end", 0)
+        for json <- ResponseParser.extractJson(response).provide(parser)
+        yield assertTrue(json == "[1,2,3]")
+      },
+    ),
+    suite("parse - typed parsing")(
+      test("parses valid JSON into case class") {
+        check(Gen.alphaNumericStringBounded(1, 20), Gen.int) { (name, count) =>
+          val json     = s"""{"name":"$name","count":$count}"""
+          val response = GeminiResponse(s"```json\n$json\n```", 0)
+          for result <- ResponseParser.parse[TestPayload](response).provide(parser)
+          yield assertTrue(
+            result.name == name,
+            result.count == count,
+          )
+        }
+      },
+      test("InvalidJson for syntactically broken JSON") {
+        check(Gen.alphaNumericStringBounded(1, 20)) { garbage =>
+          val response = GeminiResponse(s"```json\n{not-valid: $garbage}\n```", 0)
+          for result <- ResponseParser.parse[TestPayload](response).provide(parser).either
+          yield assertTrue(result.left.exists {
+            case ParseError.InvalidJson(_, _) => true
+            case _                            => false
+          })
+        }
+      },
+      test("SchemaMismatch for valid JSON with wrong shape") {
+        check(Gen.alphaNumericStringBounded(1, 20)) { value =>
+          val response = GeminiResponse(s"""```json\n{"wrong_field":"$value"}\n```""", 0)
+          for result <- ResponseParser.parse[TestPayload](response).provide(parser).either
+          yield assertTrue(result.left.exists {
+            case ParseError.SchemaMismatch(_, _) => true
+            case _                               => false
+          })
+        }
+      },
+      test("NoJsonFound for empty response") {
+        val response = GeminiResponse("", 0)
+        for result <- ResponseParser.extractJson(response).provide(parser).either
+        yield assertTrue(result.left.exists {
+          case ParseError.NoJsonFound(_) => true
+          case _                         => false
+        })
+      },
+    ),
+    suite("extractJson - edge cases")(
+      test("handles response with only whitespace returns NoJsonFound") {
+        val response = GeminiResponse("   \n\n  ", 0)
+        for result <- ResponseParser.extractJson(response).provide(parser).either
+        yield assertTrue(result.left.exists {
+          case ParseError.NoJsonFound(_) => true
+          case _                         => false
+        })
+      },
+      test("handles nested JSON in code block") {
+        val nested   = """{"outer":{"inner":{"deep":"value"}}}"""
+        val response = GeminiResponse(s"```json\n$nested\n```", 0)
+        for json <- ResponseParser.extractJson(response).provide(parser)
+        yield assertTrue(json == nested)
+      },
+      test("handles JSON with arrays in code block") {
+        val withArrays = """{"items":[1,2,3],"names":["a","b"]}"""
+        val response   = GeminiResponse(s"```json\n$withArrays\n```", 0)
+        for json <- ResponseParser.extractJson(response).provide(parser)
+        yield assertTrue(json == withArrays)
+      },
+      test("handles multiple json blocks - takes first") {
+        val first    = """{"first":true}"""
+        val second   = """{"second":true}"""
+        val response = GeminiResponse(s"```json\n$first\n```\n```json\n$second\n```", 0)
+        for json <- ResponseParser.extractJson(response).provide(parser)
+        yield assertTrue(json == first)
+      },
+    ),
+  )

--- a/src/test/scala/core/RetryPolicyPropertySpec.scala
+++ b/src/test/scala/core/RetryPolicyPropertySpec.scala
@@ -1,0 +1,168 @@
+package core
+
+import zio.*
+import zio.test.*
+
+import models.GeminiError
+
+/** Property-based tests for RetryPolicy.
+  *
+  * Tests retry behavior, isRetryable classification, and policy configuration properties.
+  */
+object RetryPolicyPropertySpec extends ZIOSpecDefault:
+
+  def spec: Spec[Any, Any] = suite("RetryPolicyPropertySpec")(
+    suite("isRetryable classification")(
+      test("Timeout is always retryable") {
+        check(Gen.long(1L, 600000L)) { millis =>
+          val error = GeminiError.Timeout(Duration.fromMillis(millis))
+          assertTrue(RetryPolicy.isRetryable(error))
+        }
+      },
+      test("exit code 429 (rate limited) is retryable") {
+        check(Gen.alphaNumericStringBounded(0, 20)) { output =>
+          val error = GeminiError.NonZeroExit(429, output)
+          assertTrue(RetryPolicy.isRetryable(error))
+        }
+      },
+      test("exit codes >= 500 (server errors) are retryable") {
+        check(Gen.int(500, 599)) { code =>
+          val error = GeminiError.NonZeroExit(code, "server error")
+          assertTrue(RetryPolicy.isRetryable(error))
+        }
+      },
+      test("ProcessFailed is retryable") {
+        check(Gen.alphaNumericStringBounded(1, 30)) { cause =>
+          val error = GeminiError.ProcessFailed(cause)
+          assertTrue(RetryPolicy.isRetryable(error))
+        }
+      },
+      test("NotInstalled is not retryable") {
+        assertTrue(!RetryPolicy.isRetryable(GeminiError.NotInstalled))
+      },
+      test("ProcessStartFailed is not retryable") {
+        check(Gen.alphaNumericStringBounded(1, 30)) { cause =>
+          val error = GeminiError.ProcessStartFailed(cause)
+          assertTrue(!RetryPolicy.isRetryable(error))
+        }
+      },
+      test("OutputReadFailed is not retryable") {
+        check(Gen.alphaNumericStringBounded(1, 30)) { cause =>
+          val error = GeminiError.OutputReadFailed(cause)
+          assertTrue(!RetryPolicy.isRetryable(error))
+        }
+      },
+      test("InvalidResponse is not retryable") {
+        check(Gen.alphaNumericStringBounded(1, 30)) { output =>
+          val error = GeminiError.InvalidResponse(output)
+          assertTrue(!RetryPolicy.isRetryable(error))
+        }
+      },
+      test("client error codes (4xx except 429) are not retryable") {
+        check(Gen.int(400, 499).filter(_ != 429)) { code =>
+          val error = GeminiError.NonZeroExit(code, "client error")
+          assertTrue(!RetryPolicy.isRetryable(error))
+        }
+      },
+      test("low exit codes (1-99) are not retryable") {
+        check(Gen.int(1, 99)) { code =>
+          val error = GeminiError.NonZeroExit(code, "other error")
+          assertTrue(!RetryPolicy.isRetryable(error))
+        }
+      },
+    ),
+    suite("RetryPolicy defaults")(
+      test("default policy has sensible values") {
+        val default = RetryPolicy.default
+        assertTrue(
+          default.maxRetries == 3,
+          default.baseDelay == Duration.fromSeconds(1),
+          default.maxDelay == Duration.fromSeconds(30),
+          default.jitterFactor == 0.1,
+        )
+      },
+      test("custom policy preserves all values") {
+        check(Gen.int(0, 10), Gen.long(100L, 5000L), Gen.long(5000L, 60000L)) {
+          (retries, baseMs, maxMs) =>
+            val policy = RetryPolicy(
+              maxRetries = retries,
+              baseDelay = Duration.fromMillis(baseMs),
+              maxDelay = Duration.fromMillis(maxMs),
+              jitterFactor = 0.2,
+            )
+            assertTrue(
+              policy.maxRetries == retries,
+              policy.baseDelay == Duration.fromMillis(baseMs),
+              policy.maxDelay == Duration.fromMillis(maxMs),
+              policy.jitterFactor == 0.2,
+            )
+        }
+      },
+    ),
+    suite("withRetry behavior")(
+      test("succeeds immediately if effect succeeds") {
+        val policy = RetryPolicy(maxRetries = 3, baseDelay = 1.second, maxDelay = 5.seconds)
+        for
+          ref   <- Ref.make(0)
+          fiber <- RetryPolicy
+                     .withRetry(
+                       ref.update(_ + 1),
+                       policy,
+                       (_: Nothing) => true,
+                     )
+                     .fork
+          // Advance clock in case Schedule infrastructure touches time
+          _     <- TestClock.adjust(1.second)
+          _     <- fiber.join
+          count <- ref.get
+        yield assertTrue(count == 1)
+      },
+      test("retries on retryable errors up to maxRetries") {
+        val policy = RetryPolicy(maxRetries = 2, baseDelay = 10.millis, maxDelay = 50.millis, jitterFactor = 0.0)
+        for
+          ref    <- Ref.make(0)
+          fiber  <- RetryPolicy
+                      .withRetry(
+                        ref.updateAndGet(_ + 1).flatMap { count =>
+                          if count <= 3 then ZIO.fail("transient")
+                          else ZIO.succeed(count)
+                        },
+                        policy,
+                        (_: String) => true,
+                      )
+                      .either
+                      .fork
+          // Advance clock enough for exponential backoff sleeps: 10ms, 20ms, 40ms
+          _      <- TestClock.adjust(100.millis)
+          _      <- TestClock.adjust(100.millis)
+          _      <- TestClock.adjust(100.millis)
+          result <- fiber.join
+          count  <- ref.get
+        yield assertTrue(
+          result.isLeft,
+          count == 3, // initial + 2 retries
+        )
+      },
+      test("does not retry non-retryable errors") {
+        val policy = RetryPolicy(maxRetries = 5, baseDelay = 10.millis, maxDelay = 50.millis, jitterFactor = 0.0)
+        for
+          ref    <- Ref.make(0)
+          fiber  <- RetryPolicy
+                      .withRetry(
+                        ref.update(_ + 1) *> ZIO.fail("permanent"),
+                        policy,
+                        (_: String) => false,
+                      )
+                      .either
+                      .fork
+          // Advance clock so it doesn't hang
+          _      <- TestClock.adjust(1.second)
+          result <- fiber.join
+          count  <- ref.get
+        yield assertTrue(
+          result.isLeft,
+          count == 1, // no retries
+        )
+      },
+    ),
+  )

--- a/src/test/scala/models/ModelsPropertySpec.scala
+++ b/src/test/scala/models/ModelsPropertySpec.scala
@@ -1,0 +1,527 @@
+package models
+
+import java.nio.file.Paths
+import java.time.Instant
+
+import zio.*
+import zio.json.*
+import zio.test.*
+
+import models.Codecs.given
+
+/** Property-based tests for domain models using ZIO Test generators.
+  *
+  * Verifies serialization invariants, model constraints, and error message properties using random data generation with
+  * automatic shrinking.
+  */
+object ModelsPropertySpec extends ZIOSpecDefault:
+
+  // ============================================================================
+  // Custom Generators
+  // ============================================================================
+
+  private val genPath = Gen.alphaNumericStringBounded(1, 20).map(s => Paths.get(s"/test/$s"))
+
+  private val genInstant = Gen.long(0L, 4102444800000L).map(Instant.ofEpochMilli)
+
+  private val genDuration = Gen.long(1L, 600000L).map(Duration.fromMillis)
+
+  private val genFileType = Gen.elements(FileType.Program, FileType.Copybook, FileType.JCL)
+
+  private val genNodeType = Gen.elements(NodeType.Program, NodeType.Copybook, NodeType.SharedService)
+
+  private val genEdgeType = Gen.elements(EdgeType.Includes, EdgeType.Calls, EdgeType.Uses)
+
+  private val genHttpMethod =
+    Gen.elements(HttpMethod.GET, HttpMethod.POST, HttpMethod.PUT, HttpMethod.DELETE, HttpMethod.PATCH)
+
+  private val genSeverity = Gen.elements(Severity.ERROR, Severity.WARNING, Severity.INFO)
+
+  private val genIssueCategory =
+    Gen.elements(
+      IssueCategory.Compile,
+      IssueCategory.Coverage,
+      IssueCategory.StaticAnalysis,
+      IssueCategory.Semantic,
+      IssueCategory.Convention,
+    )
+
+  private val genValidationStatus =
+    Gen.elements(ValidationStatus.Passed, ValidationStatus.PassedWithWarnings, ValidationStatus.Failed)
+
+  private val genMigrationStep = Gen.elements(
+    MigrationStep.Discovery,
+    MigrationStep.Analysis,
+    MigrationStep.Mapping,
+    MigrationStep.Transformation,
+    MigrationStep.Validation,
+    MigrationStep.Documentation,
+  )
+
+  private val genAgentType = Gen.elements(
+    AgentType.CobolDiscovery,
+    AgentType.CobolAnalyzer,
+    AgentType.DependencyMapper,
+    AgentType.JavaTransformer,
+    AgentType.Validation,
+    AgentType.Documentation,
+  )
+
+  private val genDiagramType = Gen.elements(DiagramType.Mermaid, DiagramType.PlantUML)
+
+  private val genCobolFile =
+    for
+      path     <- genPath
+      name     <- Gen.alphaNumericStringBounded(1, 15).map(_ + ".cbl")
+      size     <- Gen.long(0L, 1000000L)
+      lines    <- Gen.long(0L, 50000L)
+      modified <- genInstant
+      encoding <- Gen.elements("UTF-8", "EBCDIC", "ASCII")
+      fileType <- genFileType
+    yield CobolFile(path, name, size, lines, modified, encoding, fileType)
+
+  private val genVariable =
+    for
+      name     <- Gen.alphaNumericStringBounded(1, 20)
+      level    <- Gen.elements(1, 5, 10, 15, 77, 88)
+      dataType <- Gen.elements("NUMERIC", "ALPHANUMERIC", "GROUP", "CONDITION")
+      picture  <- Gen.option(Gen.elements("9(5)", "X(10)", "9(3)V99", "X(30)"))
+      usage    <- Gen.option(Gen.elements("COMP", "COMP-3", "DISPLAY"))
+    yield Variable(name, level, dataType, picture, usage)
+
+  private val genStatement =
+    for
+      line    <- Gen.int(1, 10000)
+      stype   <- Gen.elements("MOVE", "IF", "PERFORM", "EVALUATE", "CALL", "DISPLAY", "STOP")
+      content <- Gen.alphaNumericStringBounded(5, 50)
+    yield Statement(line, stype, content)
+
+  private val genComplexityMetrics =
+    for
+      cc  <- Gen.int(0, 1000)
+      loc <- Gen.int(0, 100000)
+      np  <- Gen.int(0, 500)
+    yield ComplexityMetrics(cc, loc, np)
+
+  private val genDependencyNode =
+    for
+      id         <- Gen.alphaNumericStringBounded(1, 15)
+      name       <- Gen.alphaNumericStringBounded(1, 15)
+      nodeType   <- genNodeType
+      complexity <- Gen.int(0, 100)
+    yield DependencyNode(id, name, nodeType, complexity)
+
+  private val genDependencyEdge =
+    for
+      from     <- Gen.alphaNumericStringBounded(1, 15)
+      to       <- Gen.alphaNumericStringBounded(1, 15)
+      edgeType <- genEdgeType
+    yield DependencyEdge(from, to, edgeType)
+
+  private val genValidationIssue =
+    for
+      severity   <- genSeverity
+      category   <- genIssueCategory
+      message    <- Gen.alphaNumericStringBounded(5, 50)
+      file       <- Gen.option(Gen.alphaNumericStringBounded(3, 20))
+      line       <- Gen.option(Gen.int(1, 10000))
+      suggestion <- Gen.option(Gen.alphaNumericStringBounded(5, 40))
+    yield ValidationIssue(severity, category, message, file, line, suggestion)
+
+  private val genCompileResult =
+    for
+      success  <- Gen.boolean
+      exitCode <- Gen.int(0, 255)
+      output   <- Gen.alphaNumericStringBounded(0, 50)
+    yield CompileResult(success, exitCode, output)
+
+  private val genCoverageMetrics =
+    for
+      vars     <- Gen.double(0.0, 100.0)
+      procs    <- Gen.double(0.0, 100.0)
+      fileSec  <- Gen.double(0.0, 100.0)
+      unmapped <- Gen.listOfBounded(0, 3)(Gen.alphaNumericStringBounded(1, 10))
+    yield CoverageMetrics(vars, procs, fileSec, unmapped)
+
+  private val genGeminiResponse =
+    for
+      output   <- Gen.alphaNumericStringBounded(1, 50)
+      exitCode <- Gen.int(0, 5)
+    yield GeminiResponse(output, exitCode)
+
+  private val genTestResults =
+    for
+      total  <- Gen.int(0, 1000)
+      passed <- Gen.int(0, 1000)
+      failed <- Gen.int(0, 1000)
+    yield TestResults(total, passed, failed)
+
+  def spec: Spec[Any, Nothing] = suite("ModelsPropertySpec")(
+    suite("Enum round-trip properties")(
+      test("all FileType values survive round-trip") {
+        check(genFileType) { ft =>
+          val json    = ft.toJson
+          val decoded = json.fromJson[FileType]
+          assertTrue(decoded == Right(ft))
+        }
+      },
+      test("all NodeType values survive round-trip") {
+        check(genNodeType) { nt =>
+          val json    = nt.toJson
+          val decoded = json.fromJson[NodeType]
+          assertTrue(decoded == Right(nt))
+        }
+      },
+      test("all EdgeType values survive round-trip") {
+        check(genEdgeType) { et =>
+          val json    = et.toJson
+          val decoded = json.fromJson[EdgeType]
+          assertTrue(decoded == Right(et))
+        }
+      },
+      test("all HttpMethod values survive round-trip") {
+        check(genHttpMethod) { hm =>
+          val json    = hm.toJson
+          val decoded = json.fromJson[HttpMethod]
+          assertTrue(decoded == Right(hm))
+        }
+      },
+      test("all Severity values survive round-trip") {
+        check(genSeverity) { s =>
+          val json    = s.toJson
+          val decoded = json.fromJson[Severity]
+          assertTrue(decoded == Right(s))
+        }
+      },
+      test("all IssueCategory values survive round-trip") {
+        check(genIssueCategory) { ic =>
+          val json    = ic.toJson
+          val decoded = json.fromJson[IssueCategory]
+          assertTrue(decoded == Right(ic))
+        }
+      },
+      test("all ValidationStatus values survive round-trip") {
+        check(genValidationStatus) { vs =>
+          val json    = vs.toJson
+          val decoded = json.fromJson[ValidationStatus]
+          assertTrue(decoded == Right(vs))
+        }
+      },
+      test("all MigrationStep values survive round-trip") {
+        check(genMigrationStep) { ms =>
+          val json    = ms.toJson
+          val decoded = json.fromJson[MigrationStep]
+          assertTrue(decoded == Right(ms))
+        }
+      },
+      test("all AgentType values survive round-trip") {
+        check(genAgentType) { at =>
+          val json    = at.toJson
+          val decoded = json.fromJson[AgentType]
+          assertTrue(decoded == Right(at))
+        }
+      },
+      test("all DiagramType values survive round-trip") {
+        check(genDiagramType) { dt =>
+          val json    = dt.toJson
+          val decoded = json.fromJson[DiagramType]
+          assertTrue(decoded == Right(dt))
+        }
+      },
+    ),
+    suite("Codec round-trip properties")(
+      test("Path codec survives round-trip for any valid path") {
+        check(Gen.alphaNumericStringBounded(1, 30)) { str =>
+          val path    = Paths.get(s"/$str")
+          val json    = path.toJson
+          val decoded = json.fromJson[java.nio.file.Path]
+          assertTrue(decoded == Right(path))
+        }
+      },
+      test("Instant codec survives round-trip") {
+        check(genInstant) { instant =>
+          val json    = instant.toJson
+          val decoded = json.fromJson[Instant]
+          assertTrue(decoded == Right(instant))
+        }
+      },
+      test("Duration codec survives round-trip") {
+        check(genDuration) { duration =>
+          val json    = duration.toJson
+          val decoded = json.fromJson[zio.Duration]
+          assertTrue(decoded == Right(duration))
+        }
+      },
+    ),
+    suite("Domain model round-trip properties")(
+      test("CobolFile survives round-trip") {
+        check(genCobolFile) { file =>
+          val json    = file.toJson
+          val decoded = json.fromJson[CobolFile]
+          assertTrue(decoded == Right(file))
+        }
+      },
+      test("Variable survives round-trip") {
+        check(genVariable) { variable =>
+          val json    = variable.toJson
+          val decoded = json.fromJson[Variable]
+          assertTrue(decoded == Right(variable))
+        }
+      },
+      test("Statement survives round-trip") {
+        check(genStatement) { stmt =>
+          val json    = stmt.toJson
+          val decoded = json.fromJson[Statement]
+          assertTrue(decoded == Right(stmt))
+        }
+      },
+      test("ComplexityMetrics survives round-trip") {
+        check(genComplexityMetrics) { metrics =>
+          val json    = metrics.toJson
+          val decoded = json.fromJson[ComplexityMetrics]
+          assertTrue(decoded == Right(metrics))
+        }
+      },
+      test("DependencyNode survives round-trip") {
+        check(genDependencyNode) { node =>
+          val json    = node.toJson
+          val decoded = json.fromJson[DependencyNode]
+          assertTrue(decoded == Right(node))
+        }
+      },
+      test("DependencyEdge survives round-trip") {
+        check(genDependencyEdge) { edge =>
+          val json    = edge.toJson
+          val decoded = json.fromJson[DependencyEdge]
+          assertTrue(decoded == Right(edge))
+        }
+      },
+      test("ValidationIssue survives round-trip") {
+        check(genValidationIssue) { issue =>
+          val json    = issue.toJson
+          val decoded = json.fromJson[ValidationIssue]
+          assertTrue(decoded == Right(issue))
+        }
+      },
+      test("CompileResult survives round-trip") {
+        check(genCompileResult) { cr =>
+          val json    = cr.toJson
+          val decoded = json.fromJson[CompileResult]
+          assertTrue(decoded == Right(cr))
+        }
+      },
+      test("CoverageMetrics survives round-trip") {
+        check(genCoverageMetrics) { cm =>
+          val json    = cm.toJson
+          val decoded = json.fromJson[CoverageMetrics]
+          assertTrue(decoded == Right(cm))
+        }
+      },
+      test("GeminiResponse survives round-trip") {
+        check(genGeminiResponse) { gr =>
+          val json    = gr.toJson
+          val decoded = json.fromJson[GeminiResponse]
+          assertTrue(decoded == Right(gr))
+        }
+      },
+      test("TestResults survives round-trip") {
+        check(genTestResults) { tr =>
+          val json    = tr.toJson
+          val decoded = json.fromJson[TestResults]
+          assertTrue(decoded == Right(tr))
+        }
+      },
+    ),
+    suite("Error type message properties")(
+      test("FileError.message always contains path information") {
+        check(genPath) { path =>
+          val errors = List(
+            FileError.NotFound(path),
+            FileError.PermissionDenied(path),
+            FileError.IOError(path, "test cause"),
+            FileError.DirectoryNotEmpty(path),
+            FileError.AlreadyExists(path),
+          )
+          assertTrue(errors.forall(e => e.message.contains(path.toString)))
+        }
+      },
+      test("FileError.InvalidPath message contains the invalid path string") {
+        check(Gen.alphaNumericStringBounded(1, 30)) { pathStr =>
+          val error = FileError.InvalidPath(pathStr)
+          assertTrue(error.message.contains(pathStr))
+        }
+      },
+      test("StateError.message always contains runId") {
+        check(Gen.alphaNumericStringBounded(1, 20)) { runId =>
+          val errors = List(
+            StateError.StateNotFound(runId),
+            StateError.InvalidState(runId, "reason"),
+            StateError.WriteError(runId, "cause"),
+            StateError.ReadError(runId, "cause"),
+            StateError.LockError(runId),
+          )
+          assertTrue(errors.forall(e => e.message.contains(runId)))
+        }
+      },
+      test("GeminiError variants all have non-empty messages") {
+        val errors: List[GeminiError] = List(
+          GeminiError.ProcessStartFailed("test"),
+          GeminiError.OutputReadFailed("test"),
+          GeminiError.Timeout(Duration.fromSeconds(30)),
+          GeminiError.NonZeroExit(1, "error"),
+          GeminiError.ProcessFailed("test"),
+          GeminiError.NotInstalled,
+          GeminiError.InvalidResponse("test"),
+          GeminiError.RateLimitExceeded(Duration.fromSeconds(30)),
+          GeminiError.RateLimitMisconfigured("test"),
+        )
+        assertTrue(errors.forall(e => e.message.nonEmpty))
+      },
+      test("ParseError variants all have non-empty messages") {
+        val errors: List[ParseError] = List(
+          ParseError.NoJsonFound("response"),
+          ParseError.InvalidJson("json", "error"),
+          ParseError.SchemaMismatch("expected", "actual"),
+        )
+        assertTrue(errors.forall(e => e.message.nonEmpty))
+      },
+      test("DiscoveryError variants all have non-empty messages") {
+        check(genPath) { path =>
+          val errors: List[DiscoveryError] = List(
+            DiscoveryError.SourceNotFound(path),
+            DiscoveryError.ScanFailed(path, "cause"),
+            DiscoveryError.MetadataFailed(path, "cause"),
+            DiscoveryError.EncodingDetectionFailed(path, "cause"),
+            DiscoveryError.ReportWriteFailed(path, "cause"),
+            DiscoveryError.InvalidConfig("details"),
+          )
+          assertTrue(errors.forall(e => e.message.nonEmpty))
+        }
+      },
+      test("AnalysisError variants all have non-empty messages") {
+        check(genPath) { path =>
+          val errors: List[AnalysisError] = List(
+            AnalysisError.FileReadFailed(path, "cause"),
+            AnalysisError.GeminiFailed("file", "cause"),
+            AnalysisError.ParseFailed("file", "cause"),
+            AnalysisError.ReportWriteFailed(path, "cause"),
+          )
+          assertTrue(errors.forall(e => e.message.nonEmpty))
+        }
+      },
+      test("MappingError variants all have non-empty messages") {
+        val errors: List[MappingError] = List(
+          MappingError.EmptyAnalysis,
+          MappingError.ReportWriteFailed(Paths.get("/test"), "cause"),
+        )
+        assertTrue(errors.forall(e => e.message.nonEmpty))
+      },
+      test("TransformError variants all have non-empty messages") {
+        val errors: List[TransformError] = List(
+          TransformError.GeminiFailed("file", "cause"),
+          TransformError.ParseFailed("file", "cause"),
+          TransformError.WriteFailed(Paths.get("/test"), "cause"),
+        )
+        assertTrue(errors.forall(e => e.message.nonEmpty))
+      },
+      test("ValidationError variants all have non-empty messages") {
+        val errors: List[ValidationError] = List(
+          ValidationError.CompileFailed("project", "cause"),
+          ValidationError.SemanticValidationFailed("project", "cause"),
+          ValidationError.ReportWriteFailed(Paths.get("/test"), "cause"),
+          ValidationError.InvalidProject("project", "reason"),
+        )
+        assertTrue(errors.forall(e => e.message.nonEmpty))
+      },
+      test("DocError variants all have non-empty messages") {
+        val errors: List[DocError] = List(
+          DocError.InvalidResult("reason"),
+          DocError.ReportWriteFailed(Paths.get("/test"), "cause"),
+          DocError.RenderFailed("cause"),
+        )
+        assertTrue(errors.forall(e => e.message.nonEmpty))
+      },
+      test("RateLimitError variants all have non-empty messages") {
+        val errors: List[RateLimitError] = List(
+          RateLimitError.AcquireTimeout(Duration.fromSeconds(30)),
+          RateLimitError.InvalidConfig("details"),
+        )
+        assertTrue(errors.forall(e => e.message.nonEmpty))
+      },
+    ),
+    suite("Empty/default model properties")(
+      test("CobolAnalysis.empty has expected defaults") {
+        val empty = CobolAnalysis.empty
+        assertTrue(
+          empty.variables.isEmpty,
+          empty.procedures.isEmpty,
+          empty.copybooks.isEmpty,
+          empty.complexity.cyclomaticComplexity == 0,
+        )
+      },
+      test("DependencyGraph.empty has empty collections") {
+        val empty = DependencyGraph.empty
+        assertTrue(
+          empty.nodes.isEmpty,
+          empty.edges.isEmpty,
+          empty.serviceCandidates.isEmpty,
+        )
+      },
+      test("SpringBootProject.empty has expected defaults") {
+        val empty = SpringBootProject.empty
+        assertTrue(
+          empty.projectName.isEmpty,
+          empty.entities.isEmpty,
+          empty.services.isEmpty,
+          empty.controllers.isEmpty,
+          empty.repositories.isEmpty,
+        )
+      },
+      test("ValidationReport.empty has failed status") {
+        val empty = ValidationReport.empty
+        assertTrue(
+          empty.overallStatus == ValidationStatus.Failed,
+          !empty.compileResult.success,
+          empty.issues.isEmpty,
+        )
+      },
+      test("MigrationDocumentation.empty has empty strings") {
+        val empty = MigrationDocumentation.empty
+        assertTrue(
+          empty.summaryReport.isEmpty,
+          empty.designDocument.isEmpty,
+          empty.diagrams.isEmpty,
+        )
+      },
+      test("MigrationState.empty creates with Discovery step") {
+        for state <- MigrationState.empty
+        yield assertTrue(
+          state.currentStep == MigrationStep.Discovery,
+          state.completedSteps.isEmpty,
+          state.errors.isEmpty,
+          state.fileInventory.isEmpty,
+          state.analyses.isEmpty,
+          state.dependencyGraph.isEmpty,
+          state.projects.isEmpty,
+          state.validationReports.isEmpty,
+        )
+      },
+    ),
+    suite("InventorySummary consistency")(
+      test("totalFiles is sum of categories") {
+        check(Gen.int(0, 100), Gen.int(0, 100), Gen.int(0, 100)) { (programs, copybooks, jclFiles) =>
+          val summary = InventorySummary(
+            totalFiles = programs + copybooks + jclFiles,
+            programFiles = programs,
+            copybooks = copybooks,
+            jclFiles = jclFiles,
+            totalLines = 0L,
+            totalBytes = 0L,
+          )
+          assertTrue(
+            summary.totalFiles == summary.programFiles + summary.copybooks + summary.jclFiles
+          )
+        }
+      }
+    ),
+  )

--- a/src/test/scala/orchestration/MigrationOrchestratorSpec.scala
+++ b/src/test/scala/orchestration/MigrationOrchestratorSpec.scala
@@ -1,0 +1,312 @@
+package orchestration
+
+import java.nio.file.{ Path, Paths }
+import java.time.Instant
+
+import zio.*
+import zio.stream.*
+import zio.test.*
+
+import agents.*
+import core.*
+import models.*
+
+object MigrationOrchestratorSpec extends ZIOSpecDefault:
+
+  // ============================================================================
+  // Mock Implementations
+  // ============================================================================
+
+  private val sampleFile = CobolFile(
+    path = Paths.get("/cobol/PROG1.cbl"),
+    name = "PROG1.cbl",
+    size = 1000L,
+    lineCount = 100,
+    lastModified = Instant.EPOCH,
+    encoding = "UTF-8",
+    fileType = FileType.Program,
+  )
+
+  private val sampleInventory = FileInventory(
+    discoveredAt = Instant.EPOCH,
+    sourceDirectory = Paths.get("/cobol"),
+    files = List(sampleFile),
+    summary = InventorySummary(1, 1, 0, 0, 100, 1000L),
+  )
+
+  private val sampleAnalysis = CobolAnalysis(
+    file = sampleFile,
+    divisions = CobolDivisions(Some("PROGRAM-ID. PROG1."), None, None, None),
+    variables = List.empty,
+    procedures = List.empty,
+    copybooks = List.empty,
+    complexity = ComplexityMetrics(1, 100, 1),
+  )
+
+  private val sampleGraph = DependencyGraph(
+    nodes = List(DependencyNode("PROG1", "PROG1", NodeType.Program, 1)),
+    edges = List.empty,
+    serviceCandidates = List.empty,
+  )
+
+  private val sampleProject = SpringBootProject(
+    projectName = "prog1-service",
+    sourceProgram = "PROG1.cbl",
+    generatedAt = Instant.EPOCH,
+    entities = List.empty,
+    services = List.empty,
+    controllers = List.empty,
+    repositories = List.empty,
+    configuration = ProjectConfiguration("com.example", "prog1", List.empty),
+    buildFile = BuildFile("maven", "<project/>"),
+  )
+
+  private val sampleValidation = ValidationReport(
+    projectName = "prog1-service",
+    validatedAt = Instant.EPOCH,
+    compileResult = CompileResult(success = true, exitCode = 0, output = ""),
+    coverageMetrics = CoverageMetrics(90.0, 85.0, 95.0, List.empty),
+    issues = List.empty,
+    semanticValidation = SemanticValidation(true, 0.95, "OK", List.empty),
+    overallStatus = ValidationStatus.Passed,
+  )
+
+  private val sampleDocs = MigrationDocumentation(
+    generatedAt = Instant.EPOCH,
+    summaryReport = "# Summary",
+    designDocument = "# Design",
+    apiDocumentation = "# API",
+    dataMappingReference = "# Data",
+    deploymentGuide = "# Deploy",
+    diagrams = List.empty,
+  )
+
+  private def mockDiscoveryAgent: ULayer[CobolDiscoveryAgent] =
+    ZLayer.succeed(new CobolDiscoveryAgent:
+      override def discover(sourcePath: Path): ZIO[Any, DiscoveryError, FileInventory] =
+        ZIO.succeed(sampleInventory))
+
+  private def mockAnalyzerAgent: ULayer[CobolAnalyzerAgent] =
+    ZLayer.succeed(new CobolAnalyzerAgent:
+      override def analyze(file: CobolFile): ZIO[Any, AnalysisError, CobolAnalysis]               =
+        ZIO.succeed(sampleAnalysis)
+      override def analyzeAll(files: List[CobolFile]): ZStream[Any, AnalysisError, CobolAnalysis] =
+        ZStream.fromIterable(files.map(_ => sampleAnalysis)))
+
+  private def mockMapperAgent: ULayer[DependencyMapperAgent] =
+    ZLayer.succeed(new DependencyMapperAgent:
+      override def mapDependencies(analyses: List[CobolAnalysis]): ZIO[Any, MappingError, DependencyGraph] =
+        ZIO.succeed(sampleGraph))
+
+  private def mockTransformerAgent: ULayer[JavaTransformerAgent] =
+    ZLayer.succeed(new JavaTransformerAgent:
+      override def transform(
+        analysis: CobolAnalysis,
+        graph: DependencyGraph,
+      ): ZIO[Any, TransformError, SpringBootProject] =
+        ZIO.succeed(sampleProject))
+
+  private def mockValidationAgent: ULayer[ValidationAgent] =
+    ZLayer.succeed(new ValidationAgent:
+      override def validate(
+        project: SpringBootProject,
+        analysis: CobolAnalysis,
+      ): ZIO[Any, ValidationError, ValidationReport] =
+        ZIO.succeed(sampleValidation))
+
+  private def mockDocumentationAgent: ULayer[DocumentationAgent] =
+    ZLayer.succeed(new DocumentationAgent:
+      override def generateDocs(result: MigrationResult): ZIO[Any, DocError, MigrationDocumentation] =
+        ZIO.succeed(sampleDocs))
+
+  private def mockStateService: ULayer[StateService] =
+    ZLayer.succeed(new StateService:
+      override def saveState(state: MigrationState): ZIO[Any, StateError, Unit]                     = ZIO.unit
+      override def loadState(runId: String): ZIO[Any, StateError, Option[MigrationState]]           = ZIO.succeed(None)
+      override def createCheckpoint(runId: String, step: MigrationStep): ZIO[Any, StateError, Unit] = ZIO.unit
+      override def getLastCheckpoint(runId: String): ZIO[Any, StateError, Option[MigrationStep]]    = ZIO.succeed(None)
+      override def listRuns(): ZIO[Any, StateError, List[MigrationRunSummary]]                      = ZIO.succeed(List.empty))
+
+  private def mockGeminiService: ULayer[GeminiService] =
+    ZLayer.succeed(new GeminiService:
+      override def execute(prompt: String): ZIO[Any, GeminiError, GeminiResponse]                             =
+        ZIO.succeed(GeminiResponse("mock", 0))
+      override def executeWithContext(prompt: String, context: String): ZIO[Any, GeminiError, GeminiResponse] =
+        ZIO.succeed(GeminiResponse("mock", 0))
+      override def isAvailable: ZIO[Any, Nothing, Boolean]                                                    = ZIO.succeed(true))
+
+  private val allMockLayers =
+    mockDiscoveryAgent ++
+      mockAnalyzerAgent ++
+      mockMapperAgent ++
+      mockTransformerAgent ++
+      mockValidationAgent ++
+      mockDocumentationAgent ++
+      mockStateService ++
+      mockGeminiService
+
+  def spec: Spec[Any, Any] = suite("MigrationOrchestratorSpec")(
+    suite("runFullMigration")(
+      test("completes full pipeline successfully") {
+        for
+          result <- MigrationOrchestrator
+                      .runFullMigration(Paths.get("/cobol"), Paths.get("/output"))
+                      .provide(MigrationOrchestrator.live, allMockLayers)
+        yield assertTrue(
+          result.success,
+          result.projects.length == 1,
+          result.projects.head.projectName == "prog1-service",
+          result.validationReports.length == 1,
+          result.validationReports.head.overallStatus == ValidationStatus.Passed,
+          result.documentation.summaryReport == "# Summary",
+        )
+      },
+      test("propagates discovery errors") {
+        val failingDiscovery = ZLayer.succeed(new CobolDiscoveryAgent:
+          override def discover(sourcePath: Path): ZIO[Any, DiscoveryError, FileInventory] =
+            ZIO.fail(DiscoveryError.SourceNotFound(sourcePath)))
+
+        for result <- MigrationOrchestrator
+                        .runFullMigration(Paths.get("/missing"), Paths.get("/output"))
+                        .provide(
+                          MigrationOrchestrator.live,
+                          failingDiscovery,
+                          mockAnalyzerAgent,
+                          mockMapperAgent,
+                          mockTransformerAgent,
+                          mockValidationAgent,
+                          mockDocumentationAgent,
+                          mockStateService,
+                          mockGeminiService,
+                        )
+                        .either
+        yield assertTrue(result.isLeft)
+      },
+      test("propagates analysis errors") {
+        val failingAnalyzer = ZLayer.succeed(new CobolAnalyzerAgent:
+          override def analyze(file: CobolFile): ZIO[Any, AnalysisError, CobolAnalysis]               =
+            ZIO.fail(AnalysisError.GeminiFailed(file.name, "timeout"))
+          override def analyzeAll(files: List[CobolFile]): ZStream[Any, AnalysisError, CobolAnalysis] =
+            ZStream.fromZIO(ZIO.fail(AnalysisError.GeminiFailed("test", "timeout"))))
+
+        for result <- MigrationOrchestrator
+                        .runFullMigration(Paths.get("/cobol"), Paths.get("/output"))
+                        .provide(
+                          MigrationOrchestrator.live,
+                          mockDiscoveryAgent,
+                          failingAnalyzer,
+                          mockMapperAgent,
+                          mockTransformerAgent,
+                          mockValidationAgent,
+                          mockDocumentationAgent,
+                          mockStateService,
+                          mockGeminiService,
+                        )
+                        .either
+        yield assertTrue(result.isLeft)
+      },
+      test("propagates mapping errors") {
+        val failingMapper = ZLayer.succeed(new DependencyMapperAgent:
+          override def mapDependencies(analyses: List[CobolAnalysis]): ZIO[Any, MappingError, DependencyGraph] =
+            ZIO.fail(MappingError.EmptyAnalysis))
+
+        for result <- MigrationOrchestrator
+                        .runFullMigration(Paths.get("/cobol"), Paths.get("/output"))
+                        .provide(
+                          MigrationOrchestrator.live,
+                          mockDiscoveryAgent,
+                          mockAnalyzerAgent,
+                          failingMapper,
+                          mockTransformerAgent,
+                          mockValidationAgent,
+                          mockDocumentationAgent,
+                          mockStateService,
+                          mockGeminiService,
+                        )
+                        .either
+        yield assertTrue(result.isLeft)
+      },
+      test("propagates transform errors") {
+        val failingTransformer = ZLayer.succeed(new JavaTransformerAgent:
+          override def transform(
+            analysis: CobolAnalysis,
+            graph: DependencyGraph,
+          ): ZIO[Any, TransformError, SpringBootProject] =
+            ZIO.fail(TransformError.GeminiFailed("PROG1", "timeout")))
+
+        for result <- MigrationOrchestrator
+                        .runFullMigration(Paths.get("/cobol"), Paths.get("/output"))
+                        .provide(
+                          MigrationOrchestrator.live,
+                          mockDiscoveryAgent,
+                          mockAnalyzerAgent,
+                          mockMapperAgent,
+                          failingTransformer,
+                          mockValidationAgent,
+                          mockDocumentationAgent,
+                          mockStateService,
+                          mockGeminiService,
+                        )
+                        .either
+        yield assertTrue(result.isLeft)
+      },
+      test("propagates validation errors") {
+        val failingValidation = ZLayer.succeed(new ValidationAgent:
+          override def validate(
+            project: SpringBootProject,
+            analysis: CobolAnalysis,
+          ): ZIO[Any, ValidationError, ValidationReport] =
+            ZIO.fail(ValidationError.CompileFailed("prog1", "compilation error")))
+
+        for result <- MigrationOrchestrator
+                        .runFullMigration(Paths.get("/cobol"), Paths.get("/output"))
+                        .provide(
+                          MigrationOrchestrator.live,
+                          mockDiscoveryAgent,
+                          mockAnalyzerAgent,
+                          mockMapperAgent,
+                          mockTransformerAgent,
+                          failingValidation,
+                          mockDocumentationAgent,
+                          mockStateService,
+                          mockGeminiService,
+                        )
+                        .either
+        yield assertTrue(result.isLeft)
+      },
+      test("propagates documentation errors") {
+        val failingDocs = ZLayer.succeed(new DocumentationAgent:
+          override def generateDocs(result: MigrationResult): ZIO[Any, DocError, MigrationDocumentation] =
+            ZIO.fail(DocError.InvalidResult("no projects")))
+
+        for result <- MigrationOrchestrator
+                        .runFullMigration(Paths.get("/cobol"), Paths.get("/output"))
+                        .provide(
+                          MigrationOrchestrator.live,
+                          mockDiscoveryAgent,
+                          mockAnalyzerAgent,
+                          mockMapperAgent,
+                          mockTransformerAgent,
+                          mockValidationAgent,
+                          failingDocs,
+                          mockStateService,
+                          mockGeminiService,
+                        )
+                        .either
+        yield assertTrue(result.isLeft)
+      },
+    ),
+    suite("runStep")(
+      test("returns success for any step") {
+        for
+          result <- ZIO
+                      .serviceWithZIO[MigrationOrchestrator](_.runStep(MigrationStep.Discovery))
+                      .provide(MigrationOrchestrator.live, allMockLayers)
+        yield assertTrue(
+          result.success,
+          result.step == MigrationStep.Discovery,
+          result.error.isEmpty,
+        )
+      }
+    ),
+  )

--- a/src/test/scala/prompts/PromptTemplatesReExportSpec.scala
+++ b/src/test/scala/prompts/PromptTemplatesReExportSpec.scala
@@ -1,0 +1,89 @@
+package prompts
+
+import zio.test.*
+
+/** Tests for PromptTemplates re-export wrappers (Schemas and Helpers objects).
+  *
+  * These tests exercise the re-exported methods via the PromptTemplates facade to ensure scoverage captures coverage on
+  * the re-export delegates.
+  */
+object PromptTemplatesReExportSpec extends ZIOSpecDefault:
+
+  def spec: Spec[Any, Any] = suite("PromptTemplatesReExportSpec")(
+    suite("PromptTemplates.Schemas re-exports")(
+      test("cobolAnalysis schema is accessible") {
+        val schema = PromptTemplates.Schemas.cobolAnalysis
+        assertTrue(schema.contains("file"), schema.contains("divisions"))
+      },
+      test("dependencyGraph schema is accessible") {
+        val schema = PromptTemplates.Schemas.dependencyGraph
+        assertTrue(schema.contains("nodes"), schema.contains("edges"))
+      },
+      test("javaEntity schema is accessible") {
+        val schema = PromptTemplates.Schemas.javaEntity
+        assertTrue(schema.contains("className"), schema.contains("fields"))
+      },
+      test("javaService schema is accessible") {
+        val schema = PromptTemplates.Schemas.javaService
+        assertTrue(schema.contains("name"), schema.contains("methods"))
+      },
+      test("javaController schema is accessible") {
+        val schema = PromptTemplates.Schemas.javaController
+        assertTrue(schema.contains("basePath"), schema.contains("endpoints"))
+      },
+      test("validationReport schema is accessible") {
+        val schema = PromptTemplates.Schemas.validationReport
+        assertTrue(schema.contains("compileResult"), schema.contains("overallStatus"))
+      },
+      test("migrationDocumentation schema is accessible") {
+        val schema = PromptTemplates.Schemas.migrationDocumentation
+        assertTrue(schema.contains("summaryReport"), schema.contains("diagrams"))
+      },
+      test("schemaMap contains all schemas") {
+        val map = PromptTemplates.Schemas.schemaMap
+        assertTrue(
+          map.contains("CobolAnalysis"),
+          map.contains("DependencyGraph"),
+          map.contains("JavaEntity"),
+        )
+      },
+      test("getSchema returns schema for known type") {
+        val schema = PromptTemplates.Schemas.getSchema("JavaService")
+        assertTrue(schema.contains("methods"))
+      },
+      test("getSchema returns error for unknown type") {
+        val schema = PromptTemplates.Schemas.getSchema("Unknown")
+        assertTrue(schema.contains("not found"))
+      },
+    ),
+    suite("PromptTemplates.Helpers re-exports")(
+      test("formatCobolCode wraps in cobol block") {
+        val result = PromptTemplates.Helpers.formatCobolCode("STOP RUN.")
+        assertTrue(result.contains("```cobol"), result.contains("STOP RUN."))
+      },
+      test("schemaReference generates instructions") {
+        val result = PromptTemplates.Helpers.schemaReference("TestClass")
+        assertTrue(result.contains("TestClass"), result.contains("OUTPUT FORMAT"))
+      },
+      test("chunkByDivision extracts divisions") {
+        val code   = "IDENTIFICATION DIVISION.\nPROGRAM-ID. TEST.\nPROCEDURE DIVISION.\nMAIN.\n    STOP RUN."
+        val chunks = PromptTemplates.Helpers.chunkByDivision(code)
+        assertTrue(chunks.contains("IDENTIFICATION"))
+      },
+      test("validationRules formats fields") {
+        val result = PromptTemplates.Helpers.validationRules(List("field1"))
+        assertTrue(result.contains("field1 is REQUIRED"))
+      },
+      test("fewShotExample formats correctly") {
+        val result = PromptTemplates.Helpers.fewShotExample("desc", "input", "output")
+        assertTrue(result.contains("EXAMPLE: desc"))
+      },
+      test("estimateTokens returns estimate") {
+        val result = PromptTemplates.Helpers.estimateTokens("test" * 100)
+        assertTrue(result == 100)
+      },
+      test("shouldChunk returns false for small text") {
+        assertTrue(!PromptTemplates.Helpers.shouldChunk("small"))
+      },
+    ),
+  )


### PR DESCRIPTION
- Implement ResponseParserPropertySpec to test JSON extraction and parsing invariants.
- Create RetryPolicyPropertySpec to validate retry behavior and policy configurations.
- Develop ModelsPropertySpec for domain model serialization invariants and error message properties.
- Introduce MigrationOrchestratorSpec to test the full migration pipeline and error propagation.
- Add PromptTemplatesReExportSpec to ensure re-exported schemas and helpers are accessible and function correctly.