### PR TITLE
Add integration tests for COBOL migration components and enhance logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ Create or edit `src/main/resources/application.conf`:
 
 ```hocon
 gemini {
-  model = "gemini-2.0-flash"
+  model = "gemini-2.5-flash"
   max-tokens = 32768
   temperature = 0.1
   timeout = 300s

--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,11 @@ inThisBuild(List(
   semanticdbEnabled                := true,
 ))
 
+lazy val It = config("it") extend Test
+
 lazy val root = (project in file("."))
+  .configs(It)
+  .settings(inConfig(It)(Defaults.testSettings): _*)
   .settings(
     name := "zio-legacy-modernization-agent",
     description := "A ZIO Legacy to Modernization Agent built with ZIO and Scala 3",
@@ -51,16 +55,18 @@ lazy val root = (project in file("."))
       "dev.zio" %% "zio-config-magnolia" % "4.0.6",
       "dev.zio" %% "zio-logging" % "2.4.0",
       "dev.zio" %% "zio-logging-slf4j2" % "2.4.0",
+      "ch.qos.logback" % "logback-classic" % "1.5.12",
       "dev.zio" %% "zio-opentelemetry" % "3.0.0",
       "dev.zio" %% "zio-opentelemetry-zio-logging" % "3.0.0",
       "io.opentelemetry" % "opentelemetry-sdk" % "1.44.1",
       "io.opentelemetry" % "opentelemetry-exporter-otlp" % "1.44.1",
       "io.opentelemetry" % "opentelemetry-exporter-logging-otlp" % "1.44.1",
-      "dev.zio" %% "zio-test" % "2.1.24" % Test,
-      "dev.zio" %% "zio-test-sbt" % "2.1.24" % Test,
-      "dev.zio" %% "zio-test-magnolia" % "2.1.24" % Test
+      "dev.zio" %% "zio-test" % "2.1.24" % "test,it",
+      "dev.zio" %% "zio-test-sbt" % "2.1.24" % "test,it",
+      "dev.zio" %% "zio-test-magnolia" % "2.1.24" % "test,it"
     ),
     testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
+    It / testFrameworks ++= (Test / testFrameworks).value,
     coverageExcludedPackages := "<empty>;.*\\.example\\..*",
     coverageExcludedFiles := ".*Main\\.scala",
     coverageMinimumStmtTotal := 80,

--- a/docs/adr/ADR-002-gemini-cli-adoption.md
+++ b/docs/adr/ADR-002-gemini-cli-adoption.md
@@ -65,7 +65,7 @@ We need to select an AI provider and integration method that balances:
 **Implementation:**
 ```bash
 gemini -p "Analyze this COBOL: $(cat program.cbl)" \
-  --model gemini-2.0-flash \
+  --model gemini-2.5-flash \
   --json-output \
   --max-tokens 32768
 ```
@@ -132,7 +132,7 @@ Non-Interactive Automation:
 
 bash
 # Perfect for ZIO process execution
-gemini -p "$PROMPT" --json-output --model gemini-2.0-flash
+gemini -p "$PROMPT" --json-output --model gemini-2.5-flash
 Context Window:
 
 Gemini 2.0: 32,768 tokens standard, up to 128K extended
@@ -164,7 +164,7 @@ scala
 trait GeminiService {
   def query(
     prompt: String,
-    model: String = "gemini-2.0-flash",
+    model: String = "gemini-2.5-flash",
     maxTokens: Int = 32768
   ): ZIO[Any, GeminiError, String]
 }
@@ -216,7 +216,7 @@ Technical Implementation
 CLI Invocation from Scala/ZIO
 scala
 case class GeminiConfig(
-  model: String = "gemini-2.0-flash",
+  model: String = "gemini-2.5-flash",
   maxTokens: Int = 32768,
   temperature: Double = 0.1,
   timeout: Duration = 300.seconds

--- a/src/it/resources/logback-test.xml
+++ b/src/it/resources/logback-test.xml
@@ -1,0 +1,11 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="DEBUG">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/src/it/scala/integration/AgentsIntegrationSpec.scala
+++ b/src/it/scala/integration/AgentsIntegrationSpec.scala
@@ -1,0 +1,479 @@
+package integration
+
+import java.nio.file.{ Files, Path }
+import java.time.Instant
+
+import zio.*
+import zio.logging.backend.SLF4J
+import zio.test.*
+import zio.test.Assertion.*
+
+import agents.*
+import core.*
+import models.*
+import orchestration.{ MigrationResult, MigrationStatus }
+
+object AgentsIntegrationSpec extends ZIOSpecDefault:
+
+  override val bootstrap: ZLayer[Any, Any, TestEnvironment] =
+    Runtime.removeDefaultLoggers >>> SLF4J.slf4j >>> testEnvironment
+
+  private val samplesDir = Path.of("cobol-source/samples")
+
+  def spec: Spec[Any, Any] = suite("AgentsIntegrationSpec")(
+    suite("Isolated agent tests with real Gemini calls")(
+      test("CobolAnalyzerAgent ISOLATED - analyzes FORMAT-BALANCE.cbl") {
+        ZIO.logLevel(LogLevel.Debug) {
+          ZIO.scoped {
+            for
+              _         <- ensureSamplesDir
+              outDir    <- ZIO.attemptBlocking(Files.createTempDirectory("it-isolated-analyzer"))
+              config     = MigrationConfig(sourceDir = samplesDir, outputDir = outDir)
+              cobolFile <- findCobolFile("FORMAT-BALANCE.cbl", config)
+              analysis  <- CobolAnalyzerAgent
+                             .analyze(cobolFile)
+                             .provide(
+                               FileService.live,
+                               ResponseParser.live,
+                               ZLayer.succeed(config),
+                               rateLimiterLayer(config),
+                               GeminiService.live >>> loggingGeminiLayer,
+                               CobolAnalyzerAgent.live,
+                             )
+            yield assertTrue(
+              analysis.file.name == "FORMAT-BALANCE.cbl",
+              analysis.file.path == cobolFile.path,
+              analysis.complexity.linesOfCode > 0,
+            )
+          }
+        }
+      },
+      test("JavaTransformerAgent ISOLATED - transforms minimal analysis to Spring Boot") {
+        ZIO.logLevel(LogLevel.Debug) {
+          ZIO.scoped {
+            for
+              _        <- ensureSamplesDir
+              outDir   <- ZIO.attemptBlocking(Files.createTempDirectory("it-isolated-transformer"))
+              config    = MigrationConfig(sourceDir = samplesDir, outputDir = outDir)
+              file     <- findCobolFile("TEST-PROGRAM.cbl", config)
+              analysis <- CobolAnalyzerAgent
+                            .analyze(file)
+                            .provide(
+                              FileService.live,
+                              ResponseParser.live,
+                              ZLayer.succeed(config),
+                              rateLimiterLayer(config),
+                              GeminiService.live >>> loggingGeminiLayer,
+                              CobolAnalyzerAgent.live,
+                            )
+              project  <- JavaTransformerAgent
+                            .transform(analysis, DependencyGraph.empty)
+                            .provide(
+                              FileService.live,
+                              ResponseParser.live,
+                              ZLayer.succeed(config),
+                              rateLimiterLayer(config),
+                              GeminiService.live >>> loggingGeminiLayer,
+                              JavaTransformerAgent.live,
+                            )
+            yield assertTrue(
+              project.projectName.nonEmpty,
+              project.sourceProgram == file.name,
+              project.entities.nonEmpty || project.services.nonEmpty,
+            )
+          }
+        }
+      },
+      test("ValidationAgent ISOLATED - validates generated project with semantic check") {
+        ZIO.logLevel(LogLevel.Debug) {
+          ZIO.scoped {
+            for
+              _        <- ensureSamplesDir
+              outDir   <- ZIO.attemptBlocking(Files.createTempDirectory("it-isolated-validation"))
+              config    = MigrationConfig(sourceDir = samplesDir, outputDir = outDir)
+              file     <- findCobolFile("TEST-PROGRAM.cbl", config)
+              analysis <- CobolAnalyzerAgent
+                            .analyze(file)
+                            .provide(
+                              FileService.live,
+                              ResponseParser.live,
+                              ZLayer.succeed(config),
+                              rateLimiterLayer(config),
+                              GeminiService.live >>> loggingGeminiLayer,
+                              CobolAnalyzerAgent.live,
+                            )
+              project  <- JavaTransformerAgent
+                            .transform(analysis, DependencyGraph.empty)
+                            .provide(
+                              FileService.live,
+                              ResponseParser.live,
+                              ZLayer.succeed(config),
+                              rateLimiterLayer(config),
+                              GeminiService.live >>> loggingGeminiLayer,
+                              JavaTransformerAgent.live,
+                            )
+              report   <- ValidationAgent
+                            .validate(project, analysis)
+                            .provide(
+                              FileService.live,
+                              ResponseParser.live,
+                              ZLayer.succeed(config),
+                              rateLimiterLayer(config),
+                              GeminiService.live >>> loggingGeminiLayer,
+                              ValidationAgent.live,
+                            )
+            yield assertTrue(
+              report.projectName == project.projectName,
+              report.semanticValidation.issues.nonEmpty || report.semanticValidation.confidence > 0.0,
+            )
+          }
+        }
+      },
+    ) @@ TestAspect.sequential,
+    test("CobolAnalyzerAgent analyzes sample COBOL with Gemini") {
+      ZIO.logLevel(LogLevel.Debug) {
+        ZIO.scoped {
+          for
+            _         <- ensureSamplesDir
+            outDir    <- ZIO.attemptBlocking(Files.createTempDirectory("it-analyzer-out"))
+            config     = MigrationConfig(sourceDir = samplesDir, outputDir = outDir)
+            cobolFile <- findCobolFile("CUSTOMER-INQUIRY.cbl", config)
+            analysis  <- CobolAnalyzerAgent
+                           .analyze(cobolFile)
+                           .provide(
+                             FileService.live,
+                             ResponseParser.live,
+                             ZLayer.succeed(config),
+                             rateLimiterLayer(config),
+                             GeminiService.live >>> loggingGeminiLayer,
+                             CobolAnalyzerAgent.live,
+                           )
+            reportPath = Path.of("reports/analysis").resolve("CUSTOMER-INQUIRY.cbl.json")
+            reportOk  <- ZIO.attemptBlocking(Files.isRegularFile(reportPath))
+          yield assertTrue(
+            analysis.file.name == "CUSTOMER-INQUIRY.cbl",
+            analysis.divisions.procedure.nonEmpty,
+            reportOk,
+          )
+        }
+      }
+    },
+    test("GeminiService times out with tiny timeout") {
+      ZIO.logLevel(LogLevel.Debug) {
+        ZIO.scoped {
+          for
+            outDir <- ZIO.attemptBlocking(Files.createTempDirectory("it-gemini-timeout"))
+            config  = MigrationConfig(
+                        sourceDir = samplesDir,
+                        outputDir = outDir,
+                        geminiTimeout = 1.millis,
+                        geminiMaxRetries = 0,
+                      )
+            result <- GeminiService
+                        .execute("Respond with a short JSON object containing a field named ping.")
+                        .provide(
+                          ZLayer.succeed(config),
+                          rateLimiterLayer(config),
+                          GeminiService.live >>> loggingGeminiLayer,
+                        )
+                        .exit
+          yield assert(result)(fails(isSubtype[GeminiError.Timeout](anything)))
+        }
+      }
+    },
+    test("CobolDiscoveryAgent discovers samples with Gemini-backed analysis") {
+      ZIO.logLevel(LogLevel.Debug) {
+        ZIO.scoped {
+          for
+            _         <- ensureSamplesDir
+            outDir    <- ZIO.attemptBlocking(Files.createTempDirectory("it-discovery-out"))
+            config     = MigrationConfig(sourceDir = samplesDir, outputDir = outDir)
+            inventory <- CobolDiscoveryAgent
+                           .discover(samplesDir)
+                           .provide(
+                             FileService.live,
+                             ZLayer.succeed(config),
+                             CobolDiscoveryAgent.live,
+                           )
+            cobolFile <- ZIO
+                           .fromOption(inventory.files.find(_.name == "CUSTOMER-INQUIRY.cbl"))
+                           .orElseFail(new RuntimeException("Missing CUSTOMER-INQUIRY.cbl"))
+            analysis  <- CobolAnalyzerAgent
+                           .analyze(cobolFile)
+                           .provide(
+                             FileService.live,
+                             ResponseParser.live,
+                             ZLayer.succeed(config),
+                             rateLimiterLayer(config),
+                             GeminiService.live >>> loggingGeminiLayer,
+                             CobolAnalyzerAgent.live,
+                           )
+          yield assertTrue(
+            inventory.files.nonEmpty,
+            analysis.file.name == cobolFile.name,
+          )
+        }
+      }
+    },
+    test("JavaTransformerAgent generates Spring Boot project with Gemini") {
+      ZIO.logLevel(LogLevel.Debug) {
+        ZIO.scoped {
+          for
+            _         <- ensureSamplesDir
+            outDir    <- ZIO.attemptBlocking(Files.createTempDirectory("it-transformer-out"))
+            config     = MigrationConfig(sourceDir = samplesDir, outputDir = outDir)
+            cobolFile <- findCobolFile("CUSTOMER-DISPLAY.cbl", config)
+            analysis  <- CobolAnalyzerAgent
+                           .analyze(cobolFile)
+                           .provide(
+                             FileService.live,
+                             ResponseParser.live,
+                             ZLayer.succeed(config),
+                             rateLimiterLayer(config),
+                             GeminiService.live >>> loggingGeminiLayer,
+                             CobolAnalyzerAgent.live,
+                           )
+            project   <- JavaTransformerAgent
+                           .transform(analysis, DependencyGraph.empty)
+                           .provide(
+                             FileService.live,
+                             ResponseParser.live,
+                             ZLayer.succeed(config),
+                             rateLimiterLayer(config),
+                             GeminiService.live >>> loggingGeminiLayer,
+                             JavaTransformerAgent.live,
+                           )
+            projectDir = outDir.resolve(project.projectName.toLowerCase)
+            pomExists <- ZIO.attemptBlocking(Files.isRegularFile(projectDir.resolve("pom.xml")))
+            appExists <- ZIO.attemptBlocking {
+                           Files.isRegularFile(
+                             projectDir
+                               .resolve(s"src/main/java/com/example/${project.projectName.toLowerCase}")
+                               .resolve("Application.java")
+                           )
+                         }
+          yield assertTrue(
+            project.projectName.nonEmpty,
+            project.entities.nonEmpty,
+            pomExists,
+            appExists,
+          )
+        }
+      }
+    },
+    test("DependencyMapperAgent builds graph from Gemini analyses") {
+      ZIO.logLevel(LogLevel.Debug) {
+        ZIO.scoped {
+          for
+            _         <- ensureSamplesDir
+            outDir    <- ZIO.attemptBlocking(Files.createTempDirectory("it-mapper-out"))
+            config     = MigrationConfig(sourceDir = samplesDir, outputDir = outDir)
+            inventory <- CobolDiscoveryAgent
+                           .discover(samplesDir)
+                           .provide(
+                             FileService.live,
+                             ZLayer.succeed(config),
+                             CobolDiscoveryAgent.live,
+                           )
+            targets    = Set("CUSTOMER-DISPLAY.cbl", "CUSTOMER-INQUIRY.cbl")
+            programs   = inventory.files.filter(f => targets.contains(f.name))
+            analyses  <- ZIO.foreach(programs) { file =>
+                           CobolAnalyzerAgent
+                             .analyze(file)
+                             .provide(
+                               FileService.live,
+                               ResponseParser.live,
+                               ZLayer.succeed(config),
+                               rateLimiterLayer(config),
+                               GeminiService.live >>> loggingGeminiLayer,
+                               CobolAnalyzerAgent.live,
+                             )
+                         }
+            graph     <- DependencyMapperAgent
+                           .mapDependencies(analyses)
+                           .provide(
+                             FileService.live,
+                             DependencyMapperAgent.live,
+                           )
+          yield assertTrue(
+            graph.nodes.nonEmpty,
+            graph.edges.nonEmpty,
+          )
+        }
+      }
+    },
+    test("ValidationAgent runs semantic validation without Maven") {
+      ZIO.logLevel(LogLevel.Debug) {
+        ZIO.scoped {
+          for
+            _         <- ensureSamplesDir
+            outDir    <- ZIO.attemptBlocking(Files.createTempDirectory("it-validation-out"))
+            config     = MigrationConfig(sourceDir = samplesDir, outputDir = outDir)
+            cobolFile <- findCobolFile("TEST-PROGRAM.cbl", config)
+            analysis  <- CobolAnalyzerAgent
+                           .analyze(cobolFile)
+                           .provide(
+                             FileService.live,
+                             ResponseParser.live,
+                             ZLayer.succeed(config),
+                             rateLimiterLayer(config),
+                             GeminiService.live >>> loggingGeminiLayer,
+                             CobolAnalyzerAgent.live,
+                           )
+            project    = SpringBootProject(
+                           projectName = "validation-sample",
+                           sourceProgram = cobolFile.name,
+                           generatedAt = Instant.EPOCH,
+                           entities = List.empty,
+                           services = List.empty,
+                           controllers = List.empty,
+                           repositories = List.empty,
+                           configuration = ProjectConfiguration("com.example", "validation-sample", List.empty),
+                           buildFile = BuildFile("maven", ""),
+                         )
+            report    <- ValidationAgent
+                           .validate(project, analysis)
+                           .provide(
+                             FileService.live,
+                             ResponseParser.live,
+                             ZLayer.succeed(config),
+                             rateLimiterLayer(config),
+                             GeminiService.live >>> loggingGeminiLayer,
+                             ValidationAgent.live,
+                           )
+            reportPath = Path.of("reports/validation").resolve("validation-sample-validation.json")
+            reportOk  <- ZIO.attemptBlocking(Files.isRegularFile(reportPath))
+          yield assertTrue(
+            report.compileResult.success == false,
+            report.overallStatus == ValidationStatus.Failed,
+            reportOk,
+          )
+        }
+      }
+    },
+    test("DocumentationAgent writes migration docs from Gemini output") {
+      ZIO.logLevel(LogLevel.Debug) {
+        ZIO.scoped {
+          for
+            _         <- ensureSamplesDir
+            outDir    <- ZIO.attemptBlocking(Files.createTempDirectory("it-docs-out"))
+            config     = MigrationConfig(sourceDir = samplesDir, outputDir = outDir)
+            cobolFile <- findCobolFile("CUSTOMER-DISPLAY.cbl", config)
+            analysis  <- CobolAnalyzerAgent
+                           .analyze(cobolFile)
+                           .provide(
+                             FileService.live,
+                             ResponseParser.live,
+                             ZLayer.succeed(config),
+                             rateLimiterLayer(config),
+                             GeminiService.live >>> loggingGeminiLayer,
+                             CobolAnalyzerAgent.live,
+                           )
+            project   <- JavaTransformerAgent
+                           .transform(analysis, DependencyGraph.empty)
+                           .provide(
+                             FileService.live,
+                             ResponseParser.live,
+                             ZLayer.succeed(config),
+                             rateLimiterLayer(config),
+                             GeminiService.live >>> loggingGeminiLayer,
+                             JavaTransformerAgent.live,
+                           )
+            result     = MigrationResult(
+                           runId = "run-docs",
+                           startedAt = Instant.EPOCH,
+                           completedAt = Instant.EPOCH,
+                           config = config,
+                           inventory = FileInventory(
+                             discoveredAt = Instant.EPOCH,
+                             sourceDirectory = samplesDir,
+                             files = List(cobolFile),
+                             summary = InventorySummary(1, 1, 0, 0, cobolFile.lineCount, cobolFile.size),
+                           ),
+                           analyses = List(analysis),
+                           dependencyGraph = DependencyGraph.empty,
+                           projects = List(project),
+                           validationReport = ValidationReport.empty,
+                           validationReports = List.empty,
+                           documentation = MigrationDocumentation.empty,
+                           errors = List.empty,
+                           status = MigrationStatus.CompletedWithWarnings,
+                         )
+            docs      <- DocumentationAgent.generateDocs(result).provide(FileService.live, DocumentationAgent.live)
+            summaryOk <- ZIO.attemptBlocking(Files.isRegularFile(Path.of("reports/documentation/migration-summary.md")))
+            diagramOk <- ZIO.attemptBlocking(
+                           Files.isRegularFile(Path.of("reports/documentation/diagrams/architecture.mmd"))
+                         )
+          yield assertTrue(
+            docs.summaryReport.nonEmpty,
+            summaryOk,
+            diagramOk,
+          )
+        }
+      }
+    },
+  ) @@ TestAspect.sequential @@ TestAspect.withLiveClock
+
+  private def rateLimiterLayer(config: MigrationConfig): ZLayer[Any, Nothing, RateLimiter] =
+    val rateConfig = RateLimiterConfig.fromMigrationConfig(config)
+    ZLayer.succeed(rateConfig) >>> RateLimiter.live
+
+  private val loggingGeminiLayer: ZLayer[GeminiService, Nothing, GeminiService] =
+    ZLayer.fromZIO {
+      ZIO.serviceWith[GeminiService] { underlying =>
+        new GeminiService {
+          override def execute(prompt: String): ZIO[Any, GeminiError, GeminiResponse] =
+            logPrompt(prompt) *> underlying.execute(prompt).tapBoth(logError, logResponse("execute"))
+
+          override def executeWithContext(prompt: String, context: String): ZIO[Any, GeminiError, GeminiResponse] =
+            logPrompt(prompt) *> underlying.executeWithContext(
+              prompt,
+              context,
+            ).tapBoth(logError, logResponse("executeWithContext"))
+
+          override def isAvailable: ZIO[Any, Nothing, Boolean] =
+            underlying.isAvailable
+        }
+      }
+    }
+
+  private def logPrompt(prompt: String): UIO[Unit] =
+    ZIO.logDebug(s"Gemini prompt length=${prompt.length}")
+
+  private def logResponse(label: String)(response: GeminiResponse): UIO[Unit] =
+    ZIO.logDebug(s"Gemini $label output (truncated): ${truncate(response.output)}")
+
+  private def logError(error: GeminiError): UIO[Unit] =
+    error match
+      case GeminiError.Timeout(d)                =>
+        ZIO.logError(s"Gemini TIMEOUT after ${d.toSeconds}s")
+      case GeminiError.NonZeroExit(code, output) =>
+        ZIO.logError(s"Gemini FAILED with exit code $code. Output: ${truncate(output, 1000)}")
+      case other                                 =>
+        ZIO.logError(s"Gemini ERROR: $error")
+
+  private def truncate(value: String, max: Int = 500): String =
+    if value.length <= max then value else value.take(max) + "..."
+
+  private def findCobolFile(name: String, config: MigrationConfig): ZIO[Any, Throwable, CobolFile] =
+    CobolDiscoveryAgent
+      .discover(samplesDir)
+      .mapError(err => new Exception(err.message))
+      .flatMap { inventory =>
+        ZIO
+          .fromOption(inventory.files.find(_.name == name))
+          .orElseFail(new Exception(s"Missing COBOL file: $name"))
+      }
+      .provide(
+        FileService.live,
+        ZLayer.succeed(config),
+        CobolDiscoveryAgent.live,
+      )
+
+  private def ensureSamplesDir: Task[Unit] =
+    ZIO
+      .attemptBlocking(Files.isDirectory(samplesDir))
+      .flatMap { isDir =>
+        ZIO.fail(new RuntimeException(s"Missing COBOL samples at $samplesDir")).unless(isDir)
+      }
+      .unit

--- a/src/it/scala/integration/CobolDiscoveryIntegrationSpec.scala
+++ b/src/it/scala/integration/CobolDiscoveryIntegrationSpec.scala
@@ -1,0 +1,58 @@
+package integration
+
+import java.nio.file.{ Files, Path }
+
+import zio.*
+import zio.logging.backend.SLF4J
+import zio.test.*
+
+import agents.CobolDiscoveryAgent
+import core.FileService
+import models.{ FileType, MigrationConfig }
+
+object CobolDiscoveryIntegrationSpec extends ZIOSpecDefault:
+
+  override val bootstrap: ZLayer[Any, Any, TestEnvironment] =
+    Runtime.removeDefaultLoggers >>> SLF4J.slf4j >>> testEnvironment
+
+  private val samplesDir    = Path.of("cobol-source/samples")
+  private val expectedNames = Set(
+    "CUSTOMER-DATA.cpy",
+    "CUSTOMER-DISPLAY.cbl",
+    "CUSTOMER-INQUIRY.cbl",
+    "ERROR-CODES.cpy",
+    "FORMAT-BALANCE.cbl",
+    "TEST-PROGRAM.cbl",
+  )
+
+  def spec: Spec[Any, Any] = suite("CobolDiscoveryIntegrationSpec")(
+    test("discovers sample COBOL programs and copybooks") {
+      for
+        _            <- ensureSamplesDir
+        inventory    <-
+          CobolDiscoveryAgent
+            .discover(samplesDir)
+            .provide(
+              FileService.live,
+              ZLayer.succeed(MigrationConfig(sourceDir = samplesDir, outputDir = Path.of("target/it-output"))),
+              CobolDiscoveryAgent.live,
+            )
+        names         = inventory.files.map(_.name).toSet
+        programCount  = inventory.files.count(_.fileType == FileType.Program)
+        copybookCount = inventory.files.count(_.fileType == FileType.Copybook)
+      yield assertTrue(
+        inventory.summary.totalFiles == expectedNames.size,
+        programCount == 4,
+        copybookCount == 2,
+        names == expectedNames,
+      )
+    }
+  ) @@ TestAspect.sequential @@ TestAspect.withLiveClock
+
+  private def ensureSamplesDir: Task[Unit] =
+    ZIO
+      .attemptBlocking(Files.isDirectory(samplesDir))
+      .flatMap { isDir =>
+        ZIO.fail(new RuntimeException(s"Missing COBOL samples at $samplesDir")).unless(isDir)
+      }
+      .unit

--- a/src/it/scala/integration/DependencyMapperIntegrationSpec.scala
+++ b/src/it/scala/integration/DependencyMapperIntegrationSpec.scala
@@ -1,0 +1,101 @@
+package integration
+
+import java.nio.file.{ Files, Path }
+
+import zio.*
+import zio.logging.backend.SLF4J
+import zio.test.*
+
+import agents.{ CobolDiscoveryAgent, DependencyMapperAgent }
+import core.FileService
+import models.*
+import prompts.PromptHelpers
+
+object DependencyMapperIntegrationSpec extends ZIOSpecDefault:
+
+  override val bootstrap: ZLayer[Any, Any, TestEnvironment] =
+    Runtime.removeDefaultLoggers >>> SLF4J.slf4j >>> testEnvironment
+
+  private val samplesDir     = Path.of("cobol-source/samples")
+  private val targetPrograms = Set("CUSTOMER-DISPLAY.cbl", "CUSTOMER-INQUIRY.cbl")
+
+  def spec: Spec[Any, Any] = suite("DependencyMapperIntegrationSpec")(
+    test("maps shared copybooks into service candidates") {
+      (for
+        _                   <- ensureSamplesDir
+        inventory           <- CobolDiscoveryAgent.discover(samplesDir)
+        programFiles         = inventory.files.filter(f => f.fileType == FileType.Program && targetPrograms.contains(f.name))
+        analyses            <- ZIO.foreach(programFiles) { file =>
+                                 FileService.readFile(file.path).map(content => buildAnalysis(file, content))
+                               }
+        graph               <- DependencyMapperAgent.mapDependencies(analyses)
+        includesCustomerData = Set(
+                                 DependencyEdge("CUSTOMER-DISPLAY", "CUSTOMER-DATA", EdgeType.Includes),
+                                 DependencyEdge("CUSTOMER-INQUIRY", "CUSTOMER-DATA", EdgeType.Includes),
+                               )
+        callEdge             = DependencyEdge("CUSTOMER-INQUIRY", "CUSTOMER-DISPLAY", EdgeType.Calls)
+      yield assertTrue(
+        graph.nodes.exists(n => n.id == "CUSTOMER-DISPLAY" && n.nodeType == NodeType.Program),
+        graph.nodes.exists(n => n.id == "CUSTOMER-INQUIRY" && n.nodeType == NodeType.Program),
+        graph.nodes.exists(n => n.id == "CUSTOMER-DATA" && n.nodeType == NodeType.Copybook),
+        graph.nodes.exists(n => n.id == "ERROR-CODES" && n.nodeType == NodeType.Copybook),
+        includesCustomerData.subsetOf(graph.edges.toSet),
+        graph.edges.contains(DependencyEdge("CUSTOMER-INQUIRY", "ERROR-CODES", EdgeType.Includes)),
+        graph.edges.contains(callEdge),
+        graph.serviceCandidates.contains("CUSTOMER-DATA"),
+        !graph.serviceCandidates.contains("ERROR-CODES"),
+      )).provide(
+        FileService.live,
+        ZLayer.succeed(MigrationConfig(sourceDir = samplesDir, outputDir = Path.of("target/it-output"))),
+        CobolDiscoveryAgent.live,
+        DependencyMapperAgent.live,
+      )
+    }
+  ) @@ TestAspect.sequential @@ TestAspect.withLiveClock
+
+  private def buildAnalysis(cobolFile: CobolFile, content: String): CobolAnalysis =
+    val divisions  = PromptHelpers.chunkByDivision(content)
+    val lines      = content.linesIterator.toList
+    val copybooks  = extractMatches(lines, "(?i)\\bCOPY\\s+([A-Z0-9-]+)\\.?")
+    val statements = lines.zipWithIndex.collect {
+      case (line, idx) if line.toUpperCase.contains("CALL") =>
+        Statement(lineNumber = idx + 1, statementType = "CALL", content = line.trim)
+    }
+    val procedures =
+      if statements.isEmpty then List(Procedure(name = "MAIN", paragraphs = List("MAIN"), statements = List.empty))
+      else List(Procedure(name = "MAIN", paragraphs = List("MAIN"), statements = statements))
+    val ifCount    = lines.count(line => line.trim.toUpperCase.startsWith("IF "))
+    val loc        = lines.count(line => line.trim.nonEmpty && !line.trim.startsWith("*"))
+    CobolAnalysis(
+      file = cobolFile,
+      divisions = CobolDivisions(
+        identification = divisions.get("IDENTIFICATION"),
+        environment = divisions.get("ENVIRONMENT"),
+        data = divisions.get("DATA"),
+        procedure = divisions.get("PROCEDURE"),
+      ),
+      variables = List.empty,
+      procedures = procedures,
+      copybooks = copybooks,
+      complexity = ComplexityMetrics(
+        cyclomaticComplexity = Math.max(1, ifCount + 1),
+        linesOfCode = loc,
+        numberOfProcedures = procedures.size,
+      ),
+    )
+
+  private def extractMatches(lines: List[String], pattern: String): List[String] =
+    val regex = pattern.r
+    lines
+      .flatMap(line => regex.findAllMatchIn(line).map(_.group(1)).toList)
+      .map(_.trim.toUpperCase)
+      .filter(_.nonEmpty)
+      .distinct
+
+  private def ensureSamplesDir: Task[Unit] =
+    ZIO
+      .attemptBlocking(Files.isDirectory(samplesDir))
+      .flatMap { isDir =>
+        ZIO.fail(new RuntimeException(s"Missing COBOL samples at $samplesDir")).unless(isDir)
+      }
+      .unit

--- a/src/it/scala/integration/MigrationOrchestratorIntegrationSpec.scala
+++ b/src/it/scala/integration/MigrationOrchestratorIntegrationSpec.scala
@@ -1,0 +1,268 @@
+package integration
+
+import java.nio.file.{ Files, Path }
+import java.time.Instant
+
+import zio.*
+import zio.logging.backend.SLF4J
+import zio.stream.ZStream
+import zio.test.*
+
+import agents.*
+import core.*
+import models.*
+import orchestration.{ MigrationOrchestrator, MigrationStatus }
+import prompts.PromptHelpers
+
+object MigrationOrchestratorIntegrationSpec extends ZIOSpecDefault:
+
+  override val bootstrap: ZLayer[Any, Any, TestEnvironment] =
+    Runtime.removeDefaultLoggers >>> SLF4J.slf4j >>> testEnvironment
+
+  private val samplesDir = Path.of("cobol-source/samples")
+
+  def spec: Spec[Any, Any] = suite("MigrationOrchestratorIntegrationSpec")(
+    test("runs full pipeline on sample COBOL files") {
+      ZIO.scoped {
+        for
+          _                <- ensureSamplesDir
+          stateDir         <- ZIO.attemptBlocking(Files.createTempDirectory("it-state-full"))
+          outDir           <- ZIO.attemptBlocking(Files.createTempDirectory("it-out-full"))
+          config            = MigrationConfig(sourceDir = samplesDir, outputDir = outDir, stateDir = stateDir, parallelism = 2)
+          result           <- MigrationOrchestrator
+                                .runFullMigration(samplesDir, outDir)
+                                .provide(
+                                  FileService.live,
+                                  StateService.live(stateDir),
+                                  analyzerLayer,
+                                  CobolDiscoveryAgent.live,
+                                  DependencyMapperAgent.live,
+                                  JavaTransformerAgent.live,
+                                  validationLayer,
+                                  DocumentationAgent.live,
+                                  stubGeminiLayer,
+                                  ResponseParser.live,
+                                  ZLayer.succeed(config),
+                                  MigrationOrchestrator.live,
+                                )
+          pomChecks        <- ZIO.foreach(result.projects) { project =>
+                                val pomPath = outDir.resolve(project.projectName.toLowerCase).resolve("pom.xml")
+                                ZIO.attemptBlocking(Files.isRegularFile(pomPath))
+                              }
+          mappingReport    <- ZIO.attemptBlocking(Files.isRegularFile(Path.of("reports/mapping/dependency-graph.json")))
+          docsReport       <- ZIO.attemptBlocking(Files.isRegularFile(Path.of("reports/documentation/migration-summary.md")))
+          callEdgeExists    =
+            result.dependencyGraph.edges.exists(edge =>
+              edge.edgeType == EdgeType.Calls && edge.from == "CUSTOMER-INQUIRY" && edge.to == "CUSTOMER-DISPLAY"
+            )
+          formatEdgeExists  =
+            result.dependencyGraph.edges.exists(edge =>
+              edge.edgeType == EdgeType.Calls && edge.from == "CUSTOMER-DISPLAY" && edge.to == "FORMAT-BALANCE"
+            )
+          includeEdgeExists =
+            result.dependencyGraph.edges.exists(edge =>
+              edge.edgeType == EdgeType.Includes && edge.from == "CUSTOMER-INQUIRY" && edge.to == "CUSTOMER-DATA"
+            )
+        yield assertTrue(
+          result.status == MigrationStatus.Completed,
+          result.projects.nonEmpty,
+          pomChecks.forall(identity),
+          mappingReport,
+          docsReport,
+          callEdgeExists,
+          formatEdgeExists,
+          includeEdgeExists,
+        )
+      }
+    },
+    test("resume run accumulates checkpoints across runs") {
+      ZIO.scoped {
+        for
+          _              <- ensureSamplesDir
+          stateDir       <- ZIO.attemptBlocking(Files.createTempDirectory("it-state-resume"))
+          outDir         <- ZIO.attemptBlocking(Files.createTempDirectory("it-out-resume"))
+          config          = MigrationConfig(sourceDir = samplesDir, outputDir = outDir, stateDir = stateDir, parallelism = 2)
+          first          <- MigrationOrchestrator
+                              .runFullMigration(samplesDir, outDir)
+                              .provide(
+                                FileService.live,
+                                StateService.live(stateDir),
+                                analyzerLayer,
+                                CobolDiscoveryAgent.live,
+                                DependencyMapperAgent.live,
+                                JavaTransformerAgent.live,
+                                failingValidationLayer,
+                                DocumentationAgent.live,
+                                stubGeminiLayer,
+                                ResponseParser.live,
+                                ZLayer.succeed(config),
+                                MigrationOrchestrator.live,
+                              )
+          second         <- MigrationOrchestrator
+                              .runFullMigration(samplesDir, outDir)
+                              .provide(
+                                FileService.live,
+                                StateService.live(stateDir),
+                                analyzerLayer,
+                                CobolDiscoveryAgent.live,
+                                DependencyMapperAgent.live,
+                                JavaTransformerAgent.live,
+                                validationLayer,
+                                DocumentationAgent.live,
+                                stubGeminiLayer,
+                                ResponseParser.live,
+                                ZLayer.succeed(config.copy(resumeFromCheckpoint = Some(first.runId))),
+                                MigrationOrchestrator.live,
+                              )
+          checkpoints    <- StateService
+                              .listCheckpoints(first.runId)
+                              .provide(StateService.live(stateDir), FileService.live)
+          checkpointSteps = checkpoints.map(_.step).toSet
+        yield assertTrue(
+          first.status == MigrationStatus.PartialFailure || first.status == MigrationStatus.Failed,
+          second.status == MigrationStatus.Completed,
+          first.runId == second.runId,
+          checkpointSteps.contains(MigrationStep.Discovery),
+          checkpointSteps.contains(MigrationStep.Analysis),
+          checkpointSteps.contains(MigrationStep.Mapping),
+          checkpointSteps.contains(MigrationStep.Transformation),
+          checkpointSteps.contains(MigrationStep.Validation),
+          checkpointSteps.contains(MigrationStep.Documentation),
+        )
+      }
+    },
+  ) @@ TestAspect.sequential @@ TestAspect.withLiveClock
+
+  private val analyzerLayer: ZLayer[FileService, Nothing, CobolAnalyzerAgent] =
+    ZLayer.fromFunction { (fileService: FileService) =>
+      new CobolAnalyzerAgent {
+        override def analyze(cobolFile: CobolFile): ZIO[Any, AnalysisError, CobolAnalysis] =
+          for
+            content <- fileService
+                         .readFile(cobolFile.path)
+                         .mapError(fe => AnalysisError.FileReadFailed(cobolFile.path, fe.message))
+          yield buildAnalysis(cobolFile, content)
+
+        override def analyzeAll(files: List[CobolFile]): ZStream[Any, AnalysisError, CobolAnalysis] =
+          ZStream.fromIterable(files).mapZIO(analyze)
+      }
+    }
+
+  private val stubGeminiLayer: ULayer[GeminiService] =
+    ZLayer.succeed(new GeminiService {
+      override def execute(prompt: String): ZIO[Any, GeminiError, GeminiResponse] =
+        ZIO.succeed(GeminiResponse(selectResponse(prompt), 0))
+
+      override def executeWithContext(prompt: String, context: String): ZIO[Any, GeminiError, GeminiResponse] =
+        ZIO.succeed(GeminiResponse(selectResponse(prompt), 0))
+
+      override def isAvailable: ZIO[Any, Nothing, Boolean] =
+        ZIO.succeed(true)
+    })
+
+  private val validationLayer: ULayer[ValidationAgent] =
+    ZLayer.succeed(new ValidationAgent {
+      override def validate(project: SpringBootProject, analysis: CobolAnalysis)
+        : ZIO[Any, ValidationError, ValidationReport] =
+        ZIO.succeed(
+          ValidationReport(
+            projectName = project.projectName,
+            validatedAt = Instant.EPOCH,
+            compileResult = CompileResult(success = true, exitCode = 0, output = "ok"),
+            coverageMetrics = CoverageMetrics(100.0, 100.0, 100.0, List.empty),
+            issues = List.empty,
+            semanticValidation = SemanticValidation(
+              businessLogicPreserved = true,
+              confidence = 0.98,
+              summary = "stubbed",
+              issues = List.empty,
+            ),
+            overallStatus = ValidationStatus.Passed,
+          )
+        )
+    })
+
+  private val failingValidationLayer: ULayer[ValidationAgent] =
+    ZLayer.succeed(new ValidationAgent {
+      override def validate(project: SpringBootProject, analysis: CobolAnalysis)
+        : ZIO[Any, ValidationError, ValidationReport] =
+        ZIO.fail(ValidationError.SemanticValidationFailed(project.projectName, "forced failure"))
+    })
+
+  private def selectResponse(prompt: String): String =
+    if prompt.contains("JavaEntity") then
+      """{
+        |  "className": "CustomerRecord",
+        |  "packageName": "com.example.customer.entity",
+        |  "fields": [
+        |    { "name": "id", "javaType": "Long", "cobolSource": "CUST-ID", "annotations": ["@Id"] }
+        |  ],
+        |  "annotations": ["@Entity", "@Table(name = \"customer\")"],
+        |  "sourceCode": "public class CustomerRecord { }"
+        |}""".stripMargin
+    else if prompt.contains("JavaService") then
+      """{
+        |  "name": "CustomerService",
+        |  "methods": [
+        |    { "name": "process", "returnType": "void", "parameters": [], "body": "" }
+        |  ]
+        |}""".stripMargin
+    else if prompt.contains("JavaController") then
+      """{
+        |  "name": "CustomerController",
+        |  "basePath": "/api/customer",
+        |  "endpoints": [
+        |    { "path": "/process", "method": "POST", "methodName": "process" }
+        |  ]
+        |}""".stripMargin
+    else
+      "{}"
+
+  private def buildAnalysis(cobolFile: CobolFile, content: String): CobolAnalysis =
+    val divisions  = PromptHelpers.chunkByDivision(content)
+    val lines      = content.linesIterator.toList
+    val copybooks  = extractMatches(lines, "(?i)\\bCOPY\\s+([A-Z0-9-]+)\\.?")
+    val variables  = extractMatches(lines, "(?i)\\b01\\s+([A-Z0-9-]+)")
+      .map(name => Variable(name = name, level = 1, dataType = "group", picture = None, usage = None))
+    val statements = lines.zipWithIndex.collect {
+      case (line, idx) if line.toUpperCase.contains("CALL") =>
+        Statement(lineNumber = idx + 1, statementType = "CALL", content = line.trim)
+    }
+    val procedures =
+      if statements.isEmpty then List(Procedure(name = "MAIN", paragraphs = List("MAIN"), statements = List.empty))
+      else List(Procedure(name = "MAIN", paragraphs = List("MAIN"), statements = statements))
+    val ifCount    = lines.count(line => line.trim.toUpperCase.startsWith("IF "))
+    val loc        = lines.count(line => line.trim.nonEmpty && !line.trim.startsWith("*"))
+    CobolAnalysis(
+      file = cobolFile,
+      divisions = CobolDivisions(
+        identification = divisions.get("IDENTIFICATION"),
+        environment = divisions.get("ENVIRONMENT"),
+        data = divisions.get("DATA"),
+        procedure = divisions.get("PROCEDURE"),
+      ),
+      variables = variables,
+      procedures = procedures,
+      copybooks = copybooks,
+      complexity = ComplexityMetrics(
+        cyclomaticComplexity = Math.max(1, ifCount + 1),
+        linesOfCode = loc,
+        numberOfProcedures = procedures.size,
+      ),
+    )
+
+  private def extractMatches(lines: List[String], pattern: String): List[String] =
+    val regex = pattern.r
+    lines
+      .flatMap(line => regex.findAllMatchIn(line).map(_.group(1)).toList)
+      .map(_.trim)
+      .filter(_.nonEmpty)
+      .distinct
+
+  private def ensureSamplesDir: Task[Unit] =
+    ZIO
+      .attemptBlocking(Files.isDirectory(samplesDir))
+      .flatMap { isDir =>
+        ZIO.fail(new RuntimeException(s"Missing COBOL samples at $samplesDir")).unless(isDir)
+      }
+      .unit

--- a/src/it/scala/integration/PromptHelpersIntegrationSpec.scala
+++ b/src/it/scala/integration/PromptHelpersIntegrationSpec.scala
@@ -1,0 +1,41 @@
+package integration
+
+import java.nio.file.{ Files, Path }
+
+import zio.*
+import zio.logging.backend.SLF4J
+import zio.test.*
+
+import core.FileService
+import prompts.PromptHelpers
+
+object PromptHelpersIntegrationSpec extends ZIOSpecDefault:
+
+  override val bootstrap: ZLayer[Any, Any, TestEnvironment] =
+    Runtime.removeDefaultLoggers >>> SLF4J.slf4j >>> testEnvironment
+
+  private val sampleFile = Path.of("cobol-source/samples/CUSTOMER-INQUIRY.cbl")
+
+  def spec: Spec[Any, Any] = suite("PromptHelpersIntegrationSpec")(
+    test("chunks divisions from CUSTOMER-INQUIRY sample") {
+      for
+        _       <- ensureSampleFile
+        content <- FileService.readFile(sampleFile).provide(FileService.live)
+        chunks   = PromptHelpers.chunkByDivision(content)
+      yield assertTrue(
+        chunks.contains("IDENTIFICATION"),
+        chunks.contains("ENVIRONMENT"),
+        chunks.contains("DATA"),
+        chunks.contains("PROCEDURE"),
+        chunks.get("PROCEDURE").exists(_.contains("SEARCH-CUSTOMER")),
+      )
+    }
+  ) @@ TestAspect.sequential
+
+  private def ensureSampleFile: Task[Unit] =
+    ZIO
+      .attemptBlocking(Files.isRegularFile(sampleFile))
+      .flatMap { exists =>
+        ZIO.fail(new RuntimeException(s"Missing COBOL sample at $sampleFile")).unless(exists)
+      }
+      .unit

--- a/src/it/scala/integration/StateServiceIntegrationSpec.scala
+++ b/src/it/scala/integration/StateServiceIntegrationSpec.scala
@@ -1,0 +1,105 @@
+package integration
+
+import java.nio.file.{ Files, Path }
+import java.time.Instant
+
+import zio.*
+import zio.logging.backend.SLF4J
+import zio.test.*
+
+import core.{ FileService, StateService }
+import models.*
+
+object StateServiceIntegrationSpec extends ZIOSpecDefault:
+
+  override val bootstrap: ZLayer[Any, Any, TestEnvironment] =
+    Runtime.removeDefaultLoggers >>> SLF4J.slf4j >>> testEnvironment
+
+  def spec: Spec[Any, Any] = suite("StateServiceIntegrationSpec")(
+    test("records run history after saving state") {
+      ZIO.scoped {
+        for
+          stateDir <- ZIO.attemptBlocking(Files.createTempDirectory("it-state-history"))
+          state     = baseState("run-history", MigrationStep.Analysis)
+          runs     <- (for
+                        _    <- StateService.saveState(state)
+                        runs <- StateService.listRuns()
+                      yield runs).provide(
+                        FileService.live,
+                        StateService.live(stateDir),
+                      )
+        yield assertTrue(
+          runs.exists(r => r.runId == "run-history" && r.currentStep == MigrationStep.Analysis)
+        )
+      }
+    },
+    test("creates checkpoints and validates integrity") {
+      ZIO.scoped {
+        for
+          stateDir    <- ZIO.attemptBlocking(Files.createTempDirectory("it-state-checkpoint"))
+          state        = baseState("run-checkpoint", MigrationStep.Discovery)
+          checkpoints <- (for
+                           _           <- StateService.saveState(state)
+                           _           <- StateService.createCheckpoint("run-checkpoint", MigrationStep.Discovery)
+                           _           <- StateService.validateCheckpointIntegrity("run-checkpoint")
+                           checkpoints <- StateService.listCheckpoints("run-checkpoint")
+                         yield checkpoints).provide(
+                           FileService.live,
+                           StateService.live(stateDir),
+                         )
+          steps        = checkpoints.map(_.step).toSet
+        yield assertTrue(
+          steps.contains(MigrationStep.Discovery)
+        )
+      }
+    },
+    test("fails integrity validation for corrupted checkpoint") {
+      ZIO.scoped {
+        for
+          stateDir <- ZIO.attemptBlocking(Files.createTempDirectory("it-state-corrupt"))
+          runId     = "run-corrupt"
+          state     = baseState(runId, MigrationStep.Discovery)
+          result   <- (for
+                        _   <- StateService.saveState(state)
+                        _   <- StateService.createCheckpoint(runId, MigrationStep.Discovery)
+                        _   <- FileService.writeFile(
+                                 stateDir
+                                   .resolve("runs")
+                                   .resolve(runId)
+                                   .resolve("checkpoints")
+                                   .resolve("discovery.json"),
+                                 "{invalid-json}",
+                               )
+                        out <- StateService.validateCheckpointIntegrity(runId).either
+                      yield out).provide(
+                        FileService.live,
+                        StateService.live(stateDir),
+                      )
+        yield assertTrue(
+          result match
+            case Left(StateError.InvalidState(_, reason)) => reason.contains("Invalid checkpoint discovery.json")
+            case _                                        => false
+        )
+      }
+    },
+  ) @@ TestAspect.sequential @@ TestAspect.withLiveClock
+
+  private def baseState(runId: String, step: MigrationStep): MigrationState =
+    MigrationState(
+      runId = runId,
+      startedAt = Instant.EPOCH,
+      currentStep = step,
+      completedSteps = Set.empty,
+      artifacts = Map.empty,
+      errors = List.empty,
+      config = MigrationConfig(
+        sourceDir = Path.of("cobol-source"),
+        outputDir = Path.of("java-output"),
+      ),
+      fileInventory = None,
+      analyses = List.empty,
+      dependencyGraph = None,
+      projects = List.empty,
+      validationReports = List.empty,
+      lastCheckpoint = Instant.EPOCH,
+    )

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,11 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -29,7 +29,7 @@ object Main extends ZIOAppDefault:
     Options.directory("state-dir").optional ?? "Directory for migration state (default: .migration-state)"
   private val configFileOpt = Options.file("config").alias("c").optional ?? "Configuration file (HOCON or JSON)"
 
-  private val geminiModelOpt   = Options.text("gemini-model").optional ?? "Gemini model name (default: gemini-2.0-flash)"
+  private val geminiModelOpt   = Options.text("gemini-model").optional ?? "Gemini model name (default: gemini-2.5-flash)"
   private val geminiTimeoutOpt =
     Options.integer("gemini-timeout").optional ?? "Gemini API timeout in seconds (default: 60)"
   private val geminiRetriesOpt = Options.integer("gemini-retries").optional ?? "Max Gemini API retries (default: 3)"

--- a/src/main/scala/core/RetryPolicy.scala
+++ b/src/main/scala/core/RetryPolicy.scala
@@ -61,7 +61,9 @@ object RetryPolicy:
           ZIO.logInfo("Retrying after transient failure")
     )
 
-    effect.retry(schedule)
+    effect
+      .tapError(err => ZIO.logWarning(s"Retryable error occurred: $err"))
+      .retry(schedule)
 
   /** Determine if a GeminiError is retryable
     *

--- a/src/main/scala/models/Models.scala
+++ b/src/main/scala/models/Models.scala
@@ -539,8 +539,8 @@ case class MigrationConfig(
   stateDir: Path = Paths.get(".migration-state"),
 
   // Gemini settings
-  geminiModel: String = "gemini-2.0-flash",
-  geminiTimeout: zio.Duration = zio.Duration.fromSeconds(60),
+  geminiModel: String = "gemini-2.5-flash",
+  geminiTimeout: zio.Duration = zio.Duration.fromSeconds(90),
   geminiMaxRetries: Int = 3,
   geminiRequestsPerMinute: Int = 60,
   geminiBurstSize: Int = 10,

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,11 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="DEBUG">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/src/test/scala/config/ConfigLoaderSpec.scala
+++ b/src/test/scala/config/ConfigLoaderSpec.scala
@@ -280,7 +280,7 @@ object ConfigLoaderSpec extends ZIOSpecDefault:
           outputDir = Paths.get("/tmp/out"),
         )
         assertTrue(
-          config.geminiModel == "gemini-2.0-flash",
+          config.geminiModel == "gemini-2.5-flash",
           config.geminiMaxRetries == 3,
           config.parallelism == 4,
           config.batchSize == 10,

--- a/src/test/scala/core/GeminiServiceSpec.scala
+++ b/src/test/scala/core/GeminiServiceSpec.scala
@@ -12,7 +12,7 @@ object GeminiServiceSpec extends ZIOSpecDefault:
 
   /** Helper to create a test MigrationConfig */
   private def createTestConfig(
-    geminiModel: String = "gemini-2.0-flash",
+    geminiModel: String = "gemini-2.5-flash",
     geminiTimeout: Duration = Duration.fromSeconds(60),
     geminiMaxRetries: Int = 3,
   ): MigrationConfig =
@@ -231,7 +231,7 @@ object GeminiServiceSpec extends ZIOSpecDefault:
     // ========================================================================
     suite("Integration with MigrationConfig")(
       test("uses correct model from config") {
-        val config = createTestConfig(geminiModel = "gemini-2.0-flash")
+        val config = createTestConfig(geminiModel = "gemini-2.5-flash")
         for
           response <- GeminiService.execute("Test").provide(
                         GeminiService.live,


### PR DESCRIPTION
- Implement `CobolDiscoveryIntegrationSpec` to test COBOL program and copybook discovery.
- Create `DependencyMapperIntegrationSpec` to validate mapping of shared copybooks into service candidates.
- Add `MigrationOrchestratorIntegrationSpec` for end-to-end migration pipeline testing.
- Introduce `PromptHelpersIntegrationSpec` to verify chunking of COBOL divisions.
- Develop `StateServiceIntegrationSpec` to ensure state management and checkpoint integrity.
- Add logging configuration for both application and test environments.
- Update Gemini model version from 2.0 to 2.5 in various configurations and tests.
- Enhance error handling and logging in `GeminiService` and `CobolAnalyzerAgent`.