### PR TITLE
[Workspace] Docker sandbox: RunMode enum and Workspace config field

### DIFF
--- a/src/main/scala/shared/web/WorkspacesView.scala
+++ b/src/main/scala/shared/web/WorkspacesView.scala
@@ -1,7 +1,7 @@
 package shared.web
 
 import scalatags.Text.all.*
-import workspace.entity.{ RunStatus, Workspace, WorkspaceRun }
+import workspace.entity.{ RunMode, RunStatus, Workspace, WorkspaceRun }
 
 object WorkspacesView:
 
@@ -63,6 +63,7 @@ object WorkspacesView:
           ws.defaultAgent.map(a =>
             p(cls := "mt-1 text-xs text-slate-500")(s"Default agent: $a")
           ).getOrElse(frag()),
+          p(cls := "mt-1 text-xs text-slate-500")(runModeLabel(ws.runMode)),
           ws.description.map(d =>
             p(cls := "mt-1 text-sm text-slate-400")(d)
           ).getOrElse(frag()),
@@ -110,6 +111,11 @@ object WorkspacesView:
       ws = Some(ws),
     )
 
+  private def runModeLabel(runMode: RunMode): String =
+    runMode match
+      case RunMode.Host                     => "Run mode: Host"
+      case RunMode.Docker(image, _, _, _)   => s"Run mode: \uD83D\uDC33 Docker ($image)"
+
   private def modalForm(
     title: String,
     formId: String,
@@ -141,6 +147,7 @@ object WorkspacesView:
         formField("localPath", "Local path", ws.flatMap(v => Some(v.localPath)).getOrElse(""), required = true),
         formField("defaultAgent", "Default agent", ws.flatMap(_.defaultAgent).getOrElse(""), required = false),
         formField("description", "Description", ws.flatMap(_.description).getOrElse(""), required = false),
+        runModeField(ws.map(_.runMode).getOrElse(RunMode.Host), formId),
         div(cls := "flex gap-3 pt-2")(
           button(
             `type` := "submit",
@@ -153,6 +160,80 @@ object WorkspacesView:
         ),
       ),
     ).render
+
+  private def runModeField(currentMode: RunMode, scopeId: String): Frag =
+    val isDocker = currentMode.isInstanceOf[RunMode.Docker]
+    val (dockerImage, dockerNetwork, dockerMount) = currentMode match
+      case RunMode.Docker(img, _, mount, net) => (img, net.getOrElse(""), mount)
+      case RunMode.Host                       => ("", "", true)
+    div(cls := "space-y-2")(
+      label(cls := "mb-1 block text-sm font-semibold text-slate-200")("Run mode"),
+      div(cls := "flex gap-4")(
+        label(cls := "flex items-center gap-1.5 text-sm text-slate-200")(
+          input(
+            `type` := "radio",
+            name   := s"runModeType-$scopeId",
+            value  := "host",
+            if !isDocker then checked else (),
+            attr("onchange") := s"document.getElementById('docker-fields-$scopeId').style.display='none'",
+          ),
+          "Host",
+        ),
+        label(cls := "flex items-center gap-1.5 text-sm text-slate-200")(
+          input(
+            `type` := "radio",
+            name   := s"runModeType-$scopeId",
+            value  := "docker",
+            if isDocker then checked else (),
+            attr("onchange") := s"document.getElementById('docker-fields-$scopeId').style.display='block'",
+          ),
+          "Docker",
+        ),
+      ),
+      div(
+        id    := s"docker-fields-$scopeId",
+        style := s"display:${if isDocker then "block" else "none"}",
+        cls   := "space-y-2 pl-2 border-l border-white/10",
+      )(
+        div(
+          label(cls := "mb-1 block text-xs font-semibold text-slate-300", `for` := s"dockerImage-$scopeId")(
+            "Docker image"
+          ),
+          input(
+            `type`       := "text",
+            id           := s"dockerImage-$scopeId",
+            name         := s"dockerImage-$scopeId",
+            value        := dockerImage,
+            placeholder  := "e.g. ghcr.io/opencode-ai/opencode:latest",
+            cls          := "w-full rounded-lg border border-white/15 bg-slate-800/80 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:border-indigo-400/40 focus:outline-none",
+          ),
+        ),
+        div(cls := "flex items-center gap-2")(
+          input(
+            `type` := "checkbox",
+            id     := s"dockerMount-$scopeId",
+            name   := s"dockerMount-$scopeId",
+            if dockerMount then checked else (),
+          ),
+          label(cls := "text-xs text-slate-300", `for` := s"dockerMount-$scopeId")(
+            "Mount worktree at /workspace"
+          ),
+        ),
+        div(
+          label(cls := "mb-1 block text-xs font-semibold text-slate-300", `for` := s"dockerNetwork-$scopeId")(
+            "Network (optional)"
+          ),
+          input(
+            `type`      := "text",
+            id          := s"dockerNetwork-$scopeId",
+            name        := s"dockerNetwork-$scopeId",
+            value       := dockerNetwork,
+            placeholder := "e.g. none",
+            cls         := "w-full rounded-lg border border-white/15 bg-slate-800/80 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:border-indigo-400/40 focus:outline-none",
+          ),
+        ),
+      ),
+    )
 
   private def formField(fieldName: String, labelText: String, fieldValue: String, required: Boolean): Frag =
     div(

--- a/src/main/scala/workspace/boundary/WorkspacesController.scala
+++ b/src/main/scala/workspace/boundary/WorkspacesController.scala
@@ -70,6 +70,7 @@ object WorkspacesController:
                      defaultAgent = patch.defaultAgent,
                      description = patch.description,
                      enabled = true,
+                     runMode = patch.runMode,
                      createdAt = now,
                      updatedAt = now,
                    )
@@ -95,6 +96,7 @@ object WorkspacesController:
                             localPath = patch.localPath,
                             defaultAgent = patch.defaultAgent,
                             description = patch.description,
+                            runMode = patch.runMode,
                             updatedAt = now,
                           )
                           for
@@ -164,4 +166,5 @@ case class WorkspaceCreateRequest(
   localPath: String,
   defaultAgent: Option[String],
   description: Option[String],
+  runMode: RunMode = RunMode.Host,
 ) derives JsonCodec

--- a/src/main/scala/workspace/control/CliAgentRunner.scala
+++ b/src/main/scala/workspace/control/CliAgentRunner.scala
@@ -3,12 +3,14 @@ import java.nio.file.Paths
 
 import zio.*
 
+import workspace.entity.RunMode
+
 object CliAgentRunner:
 
-  /** Map agent name → argv list. `worktreePath` is passed as the working directory for agents that use cwd, or as an
-    * explicit argument for agents that require it.
+  /** Map agent name → argv list for host execution. `worktreePath` is passed as the working directory for agents that
+    * use cwd, or as an explicit argument for agents that require it.
     */
-  def buildArgv(agentName: String, prompt: String, worktreePath: String): List[String] =
+  private def buildArgvForHost(agentName: String, prompt: String, worktreePath: String): List[String] =
     agentName match
       case "gemini-cli" => List("gemini", "-p", prompt, worktreePath)
       case "opencode"   => List("opencode", "run", "--prompt", prompt, worktreePath)
@@ -16,6 +18,24 @@ object CliAgentRunner:
       case "codex"      => List("codex", prompt)
       case "copilot"    => List("gh", "copilot", "suggest", "-t", "shell", prompt)
       case other        => List(other, prompt)
+
+  /** Build the full argv list, wrapping in `docker run` when `runMode` is `RunMode.Docker`. */
+  def buildArgv(
+    agentName: String,
+    prompt: String,
+    worktreePath: String,
+    runMode: RunMode = RunMode.Host,
+  ): List[String] =
+    runMode match
+      case RunMode.Host =>
+        buildArgvForHost(agentName, prompt, worktreePath)
+      case RunMode.Docker(image, extraArgs, mountWorktree, network) =>
+        val containerPath = if mountWorktree then "/workspace" else worktreePath
+        val innerArgv     = buildArgvForHost(agentName, prompt, containerPath)
+        val mountFlags    = if mountWorktree then List("-v", s"$worktreePath:/workspace", "--workdir", "/workspace")
+                            else List.empty
+        val networkFlags  = network.map(n => List("--network", n)).getOrElse(List.empty)
+        List("docker", "run", "--rm") ++ mountFlags ++ networkFlags ++ extraArgs ++ List(image) ++ innerArgv
 
   /** Run argv as a subprocess with `cwd` as working directory. Returns (stdout+stderr lines, exit code). Merges stderr
     * into stdout via redirectErrorStream. Runs blocking IO on ZIO's blocking thread pool.

--- a/src/main/scala/workspace/control/DockerSupport.scala
+++ b/src/main/scala/workspace/control/DockerSupport.scala
@@ -1,0 +1,35 @@
+package workspace.control
+
+import zio.*
+
+import workspace.entity.WorkspaceError
+
+object DockerSupport:
+
+  private val cachedResult: Ref[Option[Boolean]] =
+    Unsafe.unsafe(implicit u => Runtime.default.unsafe.run(Ref.make(Option.empty[Boolean])).getOrThrowFiberFailure())
+
+  /** Returns true if `docker info` exits 0. Cached in a Ref after first call. */
+  val isAvailable: Task[Boolean] =
+    cachedResult.get.flatMap {
+      case Some(result) => ZIO.succeed(result)
+      case None         =>
+        ZIO
+          .attemptBlockingIO {
+            val pb      = new ProcessBuilder("docker", "info")
+            pb.redirectErrorStream(true)
+            val process = pb.start()
+            // discard output — only care about exit code
+            val _       = scala.io.Source.fromInputStream(process.getInputStream).getLines().toList
+            process.waitFor() == 0
+          }
+          .catchAll(_ => ZIO.succeed(false))
+          .tap(result => cachedResult.set(Some(result)))
+    }
+
+  /** Fails with `WorkspaceError.DockerNotAvailable` if Docker is not present. */
+  val requireDocker: IO[WorkspaceError, Unit] =
+    isAvailable.orDie.flatMap { available =>
+      if available then ZIO.unit
+      else ZIO.fail(WorkspaceError.DockerNotAvailable("docker info returned non-zero exit code"))
+    }

--- a/src/main/scala/workspace/control/WorkspaceRunService.scala
+++ b/src/main/scala/workspace/control/WorkspaceRunService.scala
@@ -52,6 +52,8 @@ final case class WorkspaceRunServiceLive(
   // Injectable for testing: (repoPath, worktreePath, branch) => effect
   worktreeAdd: (String, String, String) => IO[WorkspaceError, Unit] = WorkspaceRunServiceLive.defaultWorktreeAdd,
   worktreeRemove: String => Task[Unit] = WorkspaceRunServiceLive.defaultWorktreeRemove,
+  // Injectable for testing: checks Docker availability
+  dockerCheck: IO[WorkspaceError, Unit] = DockerSupport.requireDocker,
 ) extends WorkspaceRunService:
 
   override def assign(workspaceId: String, req: AssignRunRequest): IO[WorkspaceError, WorkspaceRun] =
@@ -63,6 +65,9 @@ final case class WorkspaceRunServiceLive(
                     _.fold[IO[WorkspaceError, Workspace]](ZIO.fail(WorkspaceError.NotFound(workspaceId)))(ZIO.succeed)
                   )
       _      <- ZIO.unless(ws.enabled)(ZIO.fail(WorkspaceError.Disabled(workspaceId)))
+      _      <- ws.runMode match
+                  case RunMode.Docker(_, _, _, _) => dockerCheck
+                  case RunMode.Host               => ZIO.unit
       runId   = java.util.UUID.randomUUID().toString
       short   = runId.take(8)
       branch  = s"agent/${req.issueRef.stripPrefix("#")}-$short"
@@ -94,7 +99,7 @@ final case class WorkspaceRunServiceLive(
       _      <- wsRepo
                   .saveRun(run)
                   .mapError(e => WorkspaceError.PersistenceFailure(RuntimeException(e.toString)))
-      _      <- executeInFiber(run).forkDaemon
+      _      <- executeInFiber(run, ws.runMode).forkDaemon
     yield run
 
   override def continueRun(runId: String, followUpPrompt: String): IO[WorkspaceError, Unit] =
@@ -105,11 +110,17 @@ final case class WorkspaceRunServiceLive(
                .flatMap(
                  _.fold[IO[WorkspaceError, WorkspaceRun]](ZIO.fail(WorkspaceError.NotFound(runId)))(ZIO.succeed)
                )
-      _   <- executeInFiber(run.copy(prompt = followUpPrompt)).forkDaemon
+      ws  <- wsRepo
+               .get(run.workspaceId)
+               .mapError(e => WorkspaceError.PersistenceFailure(RuntimeException(e.toString)))
+               .flatMap(
+                 _.fold[IO[WorkspaceError, Workspace]](ZIO.fail(WorkspaceError.NotFound(run.workspaceId)))(ZIO.succeed)
+               )
+      _   <- executeInFiber(run.copy(prompt = followUpPrompt), ws.runMode).forkDaemon
     yield ()
 
-  private def executeInFiber(run: WorkspaceRun): IO[WorkspaceError, Unit] =
-    val argv = CliAgentRunner.buildArgv(run.agentName, run.prompt, run.worktreePath)
+  private def executeInFiber(run: WorkspaceRun, runMode: RunMode): IO[WorkspaceError, Unit] =
+    val argv = CliAgentRunner.buildArgv(run.agentName, run.prompt, run.worktreePath, runMode)
     for
       _                <- wsRepo
                             .updateRunStatus(run.id, RunStatus.Running)

--- a/src/main/scala/workspace/entity/WorkspaceModels.scala
+++ b/src/main/scala/workspace/entity/WorkspaceModels.scala
@@ -5,6 +5,19 @@ import java.time.Instant
 import zio.json.*
 import zio.schema.{ Schema, derived }
 
+sealed trait RunMode derives JsonCodec, Schema
+object RunMode:
+  /** Run the agent directly on the host (default, current behaviour). */
+  case object Host extends RunMode
+
+  /** Run the agent inside a Docker container. */
+  final case class Docker(
+    image: String,
+    extraArgs: List[String] = List.empty,
+    mountWorktree: Boolean = true,
+    network: Option[String] = None,
+  ) extends RunMode
+
 case class Workspace(
   id: String,
   name: String,
@@ -12,6 +25,7 @@ case class Workspace(
   defaultAgent: Option[String],
   description: Option[String],
   enabled: Boolean = true,
+  runMode: RunMode = RunMode.Host,
   createdAt: Instant,
   updatedAt: Instant,
 ) derives JsonCodec, Schema
@@ -44,3 +58,4 @@ enum WorkspaceError:
   case AgentNotFound(name: String)
   case RunTimeout(runId: String)
   case PersistenceFailure(cause: Throwable)
+  case DockerNotAvailable(reason: String)

--- a/src/test/scala/shared/web/WorkspacesViewSpec.scala
+++ b/src/test/scala/shared/web/WorkspacesViewSpec.scala
@@ -4,10 +4,10 @@ import java.time.Instant
 
 import zio.test.*
 
-import workspace.entity.{ RunStatus, Workspace, WorkspaceRun }
+import workspace.entity.{ RunMode, RunStatus, Workspace, WorkspaceRun }
 
 object WorkspacesViewSpec extends ZIOSpecDefault:
-  private val sampleWs  = Workspace(
+  private val sampleWs = Workspace(
     id = "ws-1",
     name = "my-api",
     localPath = "/home/user/my-api",
@@ -16,6 +16,11 @@ object WorkspacesViewSpec extends ZIOSpecDefault:
     enabled = true,
     createdAt = Instant.parse("2026-02-24T10:00:00Z"),
     updatedAt = Instant.parse("2026-02-24T10:00:00Z"),
+  )
+
+  private val dockerWs = sampleWs.copy(
+    id = "ws-docker",
+    runMode = RunMode.Docker(image = "gemini:latest", network = Some("none")),
   )
   private val sampleRun = WorkspaceRun(
     id = "run-1",
@@ -56,5 +61,13 @@ object WorkspacesViewSpec extends ZIOSpecDefault:
     test("runsFragment renders empty state") {
       val html = WorkspacesView.runsFragment(List.empty)
       assertTrue(html.contains("No runs"))
+    },
+    test("workspace card with RunMode.Host renders 'Host'") {
+      val html = WorkspacesView.page(List(sampleWs))
+      assertTrue(html.contains("Host"))
+    },
+    test("workspace card with RunMode.Docker renders 'Docker' and image name") {
+      val html = WorkspacesView.page(List(dockerWs))
+      assertTrue(html.contains("Docker") && html.contains("gemini:latest"))
     },
   )

--- a/src/test/scala/workspace/boundary/WorkspacesControllerSpec.scala
+++ b/src/test/scala/workspace/boundary/WorkspacesControllerSpec.scala
@@ -4,6 +4,7 @@ import java.time.Instant
 
 import zio.*
 import zio.http.*
+import zio.json.*
 import zio.test.*
 
 import workspace.control.{ AssignRunRequest, WorkspaceRunService }
@@ -78,5 +79,26 @@ object WorkspacesControllerSpec extends ZIOSpecDefault:
         req    = Request.get(URL(Path.decode("/api/workspaces/ws-1/runs")))
         resp  <- routes.runZIO(req)
       yield assertTrue(resp.status == Status.Ok)
+    },
+    test("WorkspaceCreateRequest with default RunMode.Host round-trips through JSON") {
+      val req     = WorkspaceCreateRequest(
+        name = "my-api",
+        localPath = "/tmp/my-api",
+        defaultAgent = Some("gemini-cli"),
+        description = None,
+      )
+      val decoded = req.toJson.fromJson[WorkspaceCreateRequest]
+      assertTrue(decoded == Right(req) && decoded.exists(_.runMode == RunMode.Host))
+    },
+    test("WorkspaceCreateRequest with RunMode.Docker round-trips through JSON") {
+      val req     = WorkspaceCreateRequest(
+        name = "sandboxed",
+        localPath = "/tmp/sandboxed",
+        defaultAgent = Some("opencode"),
+        description = None,
+        runMode = RunMode.Docker(image = "opencode:latest", network = Some("none")),
+      )
+      val decoded = req.toJson.fromJson[WorkspaceCreateRequest]
+      assertTrue(decoded == Right(req))
     },
   )

--- a/src/test/scala/workspace/control/CliAgentRunnerSpec.scala
+++ b/src/test/scala/workspace/control/CliAgentRunnerSpec.scala
@@ -3,8 +3,11 @@ package workspace.control
 import zio.*
 import zio.test.*
 
+import workspace.entity.RunMode
+
 object CliAgentRunnerSpec extends ZIOSpecDefault:
   def spec: Spec[TestEnvironment & Scope, Any] = suite("CliAgentRunnerSpec")(
+    // RunMode.Host — same as before
     test("buildArgv for echo agent returns [echo, prompt]") {
       val argv = CliAgentRunner.buildArgv("echo", "hello world", "/tmp/wt")
       assertTrue(argv == List("echo", "hello world"))
@@ -32,6 +35,41 @@ object CliAgentRunnerSpec extends ZIOSpecDefault:
     test("buildArgv for unknown agent passes prompt as single arg") {
       val argv = CliAgentRunner.buildArgv("my-agent", "do something", "/tmp/wt")
       assertTrue(argv == List("my-agent", "do something"))
+    },
+    test("buildArgv with RunMode.Host is identical to default") {
+      val argvDefault  = CliAgentRunner.buildArgv("gemini-cli", "fix it", "/tmp/wt")
+      val argvExplicit = CliAgentRunner.buildArgv("gemini-cli", "fix it", "/tmp/wt", RunMode.Host)
+      assertTrue(argvDefault == argvExplicit)
+    },
+    test("buildArgv with RunMode.Docker wraps in docker run with mount and workdir") {
+      val argv = CliAgentRunner.buildArgv(
+        "gemini-cli",
+        "fix it",
+        "/tmp/wt",
+        RunMode.Docker("gemini:latest", Nil, mountWorktree = true, None),
+      )
+      assertTrue(
+        argv == List("docker", "run", "--rm", "-v", "/tmp/wt:/workspace", "--workdir", "/workspace", "gemini:latest",
+          "gemini", "-p", "fix it", "/workspace")
+      )
+    },
+    test("buildArgv with RunMode.Docker and network includes --network flag") {
+      val argv = CliAgentRunner.buildArgv(
+        "gemini-cli",
+        "fix it",
+        "/tmp/wt",
+        RunMode.Docker("gemini:latest", Nil, mountWorktree = true, network = Some("none")),
+      )
+      assertTrue(argv.containsSlice(List("--network", "none")))
+    },
+    test("buildArgv with RunMode.Docker and mountWorktree=false omits -v and --workdir") {
+      val argv = CliAgentRunner.buildArgv(
+        "gemini-cli",
+        "fix it",
+        "/tmp/wt",
+        RunMode.Docker("gemini:latest", Nil, mountWorktree = false, None),
+      )
+      assertTrue(!argv.contains("-v") && !argv.contains("--workdir"))
     },
     test("runProcess with echo collects output line and returns exit 0") {
       for

--- a/src/test/scala/workspace/control/DockerSupportSpec.scala
+++ b/src/test/scala/workspace/control/DockerSupportSpec.scala
@@ -1,0 +1,30 @@
+package workspace.control
+
+import zio.*
+import zio.test.*
+
+import workspace.entity.WorkspaceError
+
+object DockerSupportSpec extends ZIOSpecDefault:
+
+  /** Simulates the requireDocker logic with an injectable availability check. */
+  private def requireDockerWith(available: Boolean): IO[WorkspaceError, Unit] =
+    if available then ZIO.unit
+    else ZIO.fail(WorkspaceError.DockerNotAvailable("docker not available (stubbed)"))
+
+  def spec: Spec[TestEnvironment & Scope, Any] = suite("DockerSupportSpec")(
+    test("isAvailable returns a Boolean without throwing") {
+      for result <- DockerSupport.isAvailable.either
+      yield assertTrue(result.isRight)
+    },
+    test("requireDocker succeeds when Docker is available (stubbed true)") {
+      for result <- requireDockerWith(true).either
+      yield assertTrue(result.isRight)
+    },
+    test("requireDocker fails with DockerNotAvailable when Docker is unavailable (stubbed false)") {
+      for result <- requireDockerWith(false).either
+      yield assertTrue(result match
+        case Left(WorkspaceError.DockerNotAvailable(_)) => true
+        case _                                          => false)
+    },
+  )

--- a/src/test/scala/workspace/control/WorkspaceRunServiceSpec.scala
+++ b/src/test/scala/workspace/control/WorkspaceRunServiceSpec.scala
@@ -66,13 +66,22 @@ object WorkspaceRunServiceSpec extends ZIOSpecDefault:
     updatedAt = Instant.parse("2026-02-24T10:00:00Z"),
   )
 
+  private val dockerWs = sampleWs.copy(
+    id = "ws-docker",
+    runMode = RunMode.Docker(image = "my-agent:latest"),
+  )
+
   // Stub git ops: worktree add is a no-op, remove is a no-op
   private val noopWorktreeAdd: (String, String, String) => IO[WorkspaceError, Unit] =
     (_, _, _) => ZIO.unit
   private val noopWorktreeRemove: String => Task[Unit]                              =
     _ => ZIO.unit
 
-  private def makeService(ws: Workspace = sampleWs) =
+  private val dockerAvailable: IO[WorkspaceError, Unit]   = ZIO.unit
+  private val dockerUnavailable: IO[WorkspaceError, Unit] =
+    ZIO.fail(WorkspaceError.DockerNotAvailable("docker not available (stubbed)"))
+
+  private def makeService(ws: Workspace = sampleWs, dockerCheck: IO[WorkspaceError, Unit] = dockerAvailable) =
     for
       messages <- Ref.make(List.empty[String])
       wsMap    <- Ref.make(Map(ws.id -> ws))
@@ -80,7 +89,13 @@ object WorkspaceRunServiceSpec extends ZIOSpecDefault:
       chatRepo  = StubChatRepo(messages)
       wsRepo    = StubWorkspaceRepo(wsMap, runMap)
       svc       =
-        WorkspaceRunServiceLive(wsRepo, chatRepo, worktreeAdd = noopWorktreeAdd, worktreeRemove = noopWorktreeRemove)
+        WorkspaceRunServiceLive(
+          wsRepo,
+          chatRepo,
+          worktreeAdd = noopWorktreeAdd,
+          worktreeRemove = noopWorktreeRemove,
+          dockerCheck = dockerCheck,
+        )
     yield (svc, wsRepo, messages)
 
   def spec: Spec[TestEnvironment & Scope, Any] = suite("WorkspaceRunServiceSpec")(
@@ -147,4 +162,20 @@ object WorkspaceRunServiceSpec extends ZIOSpecDefault:
       // Status is either Failed (timeout fired) or Pending (git worktree add failed before fork)
       yield assertTrue(runs.isEmpty || runs.forall(r => r.status == RunStatus.Failed || r.status == RunStatus.Pending))
     } @@ TestAspect.withLiveClock,
+    test("assign succeeds when workspace has RunMode.Host even when dockerCheck would fail") {
+      for
+        (svc, _, _) <- makeService(sampleWs, dockerCheck = dockerUnavailable)
+        req          = AssignRunRequest(issueRef = "#1", prompt = "echo hello", agentName = "echo")
+        run         <- svc.assign("ws-1", req)
+      yield assertTrue(run.workspaceId == "ws-1")
+    },
+    test("assign fails with DockerNotAvailable when RunMode.Docker and Docker is unavailable") {
+      for
+        (svc, _, _) <- makeService(dockerWs, dockerCheck = dockerUnavailable)
+        req          = AssignRunRequest(issueRef = "#1", prompt = "echo hello", agentName = "echo")
+        result      <- svc.assign("ws-docker", req).either
+      yield assertTrue(result match
+        case Left(WorkspaceError.DockerNotAvailable(_)) => true
+        case _                                          => false)
+    },
   )

--- a/src/test/scala/workspace/entity/WorkspaceModelsSpec.scala
+++ b/src/test/scala/workspace/entity/WorkspaceModelsSpec.scala
@@ -8,6 +8,23 @@ import zio.test.*
 
 object WorkspaceModelsSpec extends ZIOSpecDefault:
   def spec: Spec[Environment & (TestEnvironment & Scope), Any] = suite("WorkspaceModelsSpec")(
+    test("RunMode.Host round-trips through JSON") {
+      val mode: RunMode = RunMode.Host
+      assertTrue(mode.toJson.fromJson[RunMode] == Right(mode))
+    },
+    test("RunMode.Docker round-trips through JSON with all optional fields") {
+      val mode: RunMode = RunMode.Docker(
+        image = "ghcr.io/opencode-ai/opencode:latest",
+        extraArgs = List("--env", "FOO=bar"),
+        mountWorktree = true,
+        network = Some("none"),
+      )
+      assertTrue(mode.toJson.fromJson[RunMode] == Right(mode))
+    },
+    test("RunMode.Docker round-trips through JSON with defaults") {
+      val mode: RunMode = RunMode.Docker(image = "gemini:latest")
+      assertTrue(mode.toJson.fromJson[RunMode] == Right(mode))
+    },
     test("Workspace round-trips through JSON") {
       val ws      = Workspace(
         id = "ws-1",
@@ -16,6 +33,22 @@ object WorkspaceModelsSpec extends ZIOSpecDefault:
         defaultAgent = Some("gemini-cli"),
         description = None,
         enabled = true,
+        createdAt = Instant.parse("2026-02-24T10:00:00Z"),
+        updatedAt = Instant.parse("2026-02-24T10:00:00Z"),
+      )
+      val json    = ws.toJson
+      val decoded = json.fromJson[Workspace]
+      assertTrue(decoded == Right(ws))
+    },
+    test("Workspace with RunMode.Docker round-trips through JSON") {
+      val ws      = Workspace(
+        id = "ws-docker",
+        name = "sandboxed-api",
+        localPath = "/home/user/projects/sandboxed-api",
+        defaultAgent = Some("opencode"),
+        description = None,
+        enabled = true,
+        runMode = RunMode.Docker(image = "ghcr.io/opencode-ai/opencode:latest", network = Some("none")),
         createdAt = Instant.parse("2026-02-24T10:00:00Z"),
         updatedAt = Instant.parse("2026-02-24T10:00:00Z"),
       )

--- a/src/test/scala/workspace/entity/WorkspaceRepositorySpec.scala
+++ b/src/test/scala/workspace/entity/WorkspaceRepositorySpec.scala
@@ -45,6 +45,18 @@ object WorkspaceRepositorySpec extends ZIOSpecDefault:
     updatedAt = Instant.parse("2026-02-24T10:00:00Z"),
   )
 
+  private val dockerWs = Workspace(
+    id = "ws-docker",
+    name = "sandboxed-api",
+    localPath = "/tmp/sandboxed-api",
+    defaultAgent = Some("opencode"),
+    description = None,
+    enabled = true,
+    runMode = RunMode.Docker("my-image:latest", Nil, mountWorktree = true, network = Some("none")),
+    createdAt = Instant.parse("2026-02-24T10:00:00Z"),
+    updatedAt = Instant.parse("2026-02-24T10:00:00Z"),
+  )
+
   private val sampleRun = WorkspaceRun(
     id = "run-1",
     workspaceId = "ws-1",
@@ -154,6 +166,15 @@ object WorkspaceRepositorySpec extends ZIOSpecDefault:
             _      <- repo.updateRunStatus("run-1", RunStatus.Completed)
             loaded <- repo.getRun("run-1")
           yield assertTrue(loaded.exists(_.status == RunStatus.Completed))).provideLayer(layerFor(dir))
+        }
+      },
+      test("Workspace with RunMode.Docker round-trips through TypedStore") {
+        withTempDir { dir =>
+          (for
+            svc    <- ZIO.service[ConfigStoreModule.ConfigStoreService]
+            _      <- svc.store.store("workspace:ws-docker", dockerWs)
+            loaded <- svc.store.fetch[String, Workspace]("workspace:ws-docker")
+          yield assertTrue(loaded.contains(dockerWs))).provideLayer(layerFor(dir))
         }
       },
     )


### PR DESCRIPTION
Fixes #350 [Workspace] Docker sandbox: extend CliAgentRunner to build docker run argv Fixes #351 [Workspace] Docker sandbox: detect Docker availability at runtime Fixes #352 [Workspace] Docker sandbox: UI — RunMode selector in workspace create/edit form Fixes #353 [Workspace] Docker sandbox: pass RunMode through WorkspaceRunService Fixes #354 [Workspace] Docker sandbox: EclipseStore codec for RunMode Fixes #355