### PR TITLE
feat(llm4zio): implement MCP server library layer (#390-#394)

### DIFF
--- a/llm4zio/src/main/scala/llm4zio/mcp/jsonrpc/JsonRpc.scala
+++ b/llm4zio/src/main/scala/llm4zio/mcp/jsonrpc/JsonRpc.scala
@@ -1,0 +1,87 @@
+package llm4zio.mcp.jsonrpc
+
+import zio.*
+import zio.json.*
+import zio.json.ast.Json
+
+/** JSON-RPC 2.0 request id — either a String or a Long number. */
+enum RequestId:
+  case Str(value: String)
+  case Num(value: Long)
+
+object RequestId:
+  given JsonDecoder[RequestId] = JsonDecoder[Json].mapOrFail {
+    case Json.Str(s)  => Right(RequestId.Str(s))
+    case Json.Num(n)  => Right(RequestId.Num(BigDecimal(n).toLongExact))
+    case other        => Left(s"RequestId must be a string or number, got: $other")
+  }
+  given JsonEncoder[RequestId] = JsonEncoder[Json].contramap {
+    case RequestId.Str(s) => Json.Str(s)
+    case RequestId.Num(n) => Json.Num(BigDecimal(n))
+  }
+
+/** A JSON-RPC 2.0 request or notification.
+  * When `id` is None this is a notification (no response expected).
+  */
+case class JsonRpcRequest(
+  jsonrpc: String = "2.0",
+  id: Option[RequestId] = None,
+  method: String,
+  params: Option[Json] = None,
+) derives JsonCodec
+
+/** Standard JSON-RPC 2.0 error object. */
+case class JsonRpcError(
+  code: Int,
+  message: String,
+  data: Option[Json] = None,
+) derives JsonCodec
+
+object JsonRpcError:
+  def parseError(msg: String): JsonRpcError      = JsonRpcError(-32700, s"Parse error: $msg")
+  def invalidRequest(msg: String): JsonRpcError  = JsonRpcError(-32600, s"Invalid request: $msg")
+  def methodNotFound(method: String): JsonRpcError =
+    JsonRpcError(-32601, s"Method not found: $method")
+  def invalidParams(msg: String): JsonRpcError   = JsonRpcError(-32602, s"Invalid params: $msg")
+  def internalError(msg: String): JsonRpcError   = JsonRpcError(-32603, s"Internal error: $msg")
+
+/** A JSON-RPC 2.0 response. Exactly one of `result` or `error` is set. */
+case class JsonRpcResponse(
+  jsonrpc: String = "2.0",
+  id: RequestId,
+  result: Option[Json] = None,
+  error: Option[JsonRpcError] = None,
+) derives JsonCodec
+
+object JsonRpcResponse:
+  def success(id: RequestId, result: Json): JsonRpcResponse =
+    JsonRpcResponse(id = id, result = Some(result))
+  def error(id: RequestId, err: JsonRpcError): JsonRpcResponse =
+    JsonRpcResponse(id = id, error = Some(err))
+
+/** A JSON-RPC 2.0 notification — no id, no response expected. */
+case class JsonRpcNotification(
+  jsonrpc: String = "2.0",
+  method: String,
+  params: Option[Json] = None,
+) derives JsonCodec
+
+/** Handles incoming JSON-RPC requests and returns responses. */
+trait JsonRpcHandler:
+  def handle(request: JsonRpcRequest): UIO[JsonRpcResponse]
+
+object JsonRpcHandler:
+  /** Build a handler from a partial function; falls back to method-not-found. */
+  def of(pf: PartialFunction[JsonRpcRequest, UIO[JsonRpcResponse]]): JsonRpcHandler =
+    request =>
+      pf.lift(request).getOrElse(
+        ZIO.succeed(
+          JsonRpcResponse.error(
+            request.id.getOrElse(RequestId.Num(0L)),
+            JsonRpcError.methodNotFound(request.method),
+          )
+        )
+      )
+
+  val empty: JsonRpcHandler =
+    of(PartialFunction.empty)

--- a/llm4zio/src/main/scala/llm4zio/mcp/protocol/McpProtocol.scala
+++ b/llm4zio/src/main/scala/llm4zio/mcp/protocol/McpProtocol.scala
@@ -1,0 +1,127 @@
+package llm4zio.mcp.protocol
+
+import zio.json.*
+import zio.json.ast.Json
+
+import llm4zio.core.ToolCall
+import llm4zio.mcp.jsonrpc.JsonRpcNotification
+import llm4zio.tools.Tool
+
+// ---------------------------------------------------------------------------
+// Initialize
+// ---------------------------------------------------------------------------
+
+case class ClientInfo(name: String, version: String) derives JsonCodec
+case class ClientCapabilities(roots: Option[Json] = None) derives JsonCodec
+
+case class McpInitializeRequest(
+  protocolVersion: String,
+  capabilities: ClientCapabilities = ClientCapabilities(),
+  clientInfo: ClientInfo,
+) derives JsonCodec
+
+case class ToolsCapability(listChanged: Boolean = true) derives JsonCodec
+case class ResourcesCapability(subscribe: Boolean = false) derives JsonCodec
+case class PromptsCapability(listChanged: Boolean = false) derives JsonCodec
+
+case class ServerCapabilities(
+  tools: Option[ToolsCapability] = None,
+  resources: Option[ResourcesCapability] = None,
+  prompts: Option[PromptsCapability] = None,
+) derives JsonCodec
+
+case class ServerInfo(name: String, version: String) derives JsonCodec
+
+case class McpInitializeResponse(
+  protocolVersion: String,
+  capabilities: ServerCapabilities,
+  serverInfo: ServerInfo,
+) derives JsonCodec
+
+// ---------------------------------------------------------------------------
+// Tools list
+// ---------------------------------------------------------------------------
+
+case class McpToolInfo(
+  name: String,
+  description: String,
+  inputSchema: Json,
+) derives JsonCodec
+
+object McpToolInfo:
+  def fromTool(tool: Tool): McpToolInfo =
+    McpToolInfo(name = tool.name, description = tool.description, inputSchema = tool.parameters)
+
+case class McpToolsListResponse(tools: List[McpToolInfo]) derives JsonCodec
+
+// ---------------------------------------------------------------------------
+// Tool call
+// ---------------------------------------------------------------------------
+
+case class McpToolCallRequest(name: String, arguments: Json = Json.Obj()) derives JsonCodec
+
+object McpToolCallRequest:
+  extension (req: McpToolCallRequest)
+    def toToolCall: ToolCall =
+      ToolCall(id = s"mcp-${req.name}", name = req.name, arguments = req.arguments.toJson)
+
+// ---------------------------------------------------------------------------
+// Content types
+// ---------------------------------------------------------------------------
+
+enum McpContent:
+  case Text(text: String)
+  case Image(data: String, mimeType: String)
+  case Resource(uri: String, text: String)
+
+object McpContent:
+  given JsonEncoder[McpContent] = JsonEncoder[Json].contramap {
+    case McpContent.Text(t)       => Json.Obj("type" -> Json.Str("text"), "text" -> Json.Str(t))
+    case McpContent.Image(d, m)   =>
+      Json.Obj("type" -> Json.Str("image"), "data" -> Json.Str(d), "mimeType" -> Json.Str(m))
+    case McpContent.Resource(u, t) =>
+      Json.Obj("type" -> Json.Str("resource"), "uri" -> Json.Str(u), "text" -> Json.Str(t))
+  }
+  given JsonDecoder[McpContent] = JsonDecoder[Json].mapOrFail {
+    case Json.Obj(fields) =>
+      val m = fields.toMap
+      m.get("type") match
+        case Some(Json.Str("text"))     =>
+          m.get("text").collect { case Json.Str(t) => McpContent.Text(t) }
+            .toRight("Missing 'text' field")
+        case Some(Json.Str("image"))    =>
+          for
+            d <- m.get("data").collect { case Json.Str(s) => s }.toRight("Missing 'data'")
+            mt <- m.get("mimeType").collect { case Json.Str(s) => s }.toRight("Missing 'mimeType'")
+          yield McpContent.Image(d, mt)
+        case Some(Json.Str("resource")) =>
+          for
+            u <- m.get("uri").collect { case Json.Str(s) => s }.toRight("Missing 'uri'")
+            t <- m.get("text").collect { case Json.Str(s) => s }.toRight("Missing 'text'")
+          yield McpContent.Resource(u, t)
+        case _ => Left("Unknown McpContent type")
+    case _ => Left("McpContent must be a JSON object")
+  }
+
+case class McpToolCallResponse(content: List[McpContent], isError: Boolean = false) derives JsonCodec
+
+// ---------------------------------------------------------------------------
+// Notifications
+// ---------------------------------------------------------------------------
+
+object McpNotifications:
+  val initialized: JsonRpcNotification =
+    JsonRpcNotification(method = "notifications/initialized")
+
+  val toolsListChanged: JsonRpcNotification =
+    JsonRpcNotification(method = "notifications/tools/list_changed")
+
+  def progress(progressToken: String, current: Int, total: Int): JsonRpcNotification =
+    JsonRpcNotification(
+      method = "notifications/progress",
+      params = Some(Json.Obj(
+        "progressToken" -> Json.Str(progressToken),
+        "progress"      -> Json.Num(BigDecimal(current)),
+        "total"         -> Json.Num(BigDecimal(total)),
+      )),
+    )

--- a/llm4zio/src/main/scala/llm4zio/mcp/server/McpServer.scala
+++ b/llm4zio/src/main/scala/llm4zio/mcp/server/McpServer.scala
@@ -1,0 +1,150 @@
+package llm4zio.mcp.server
+
+import zio.*
+import zio.json.*
+import zio.json.ast.Json
+import zio.stream.*
+
+import llm4zio.mcp.jsonrpc.*
+import llm4zio.mcp.protocol.*
+import llm4zio.tools.{ Tool, ToolRegistry }
+
+// ---------------------------------------------------------------------------
+// McpError
+// ---------------------------------------------------------------------------
+
+enum McpError:
+  case ProtocolError(message: String)
+  case TransportError(message: String)
+  case ToolExecutionError(message: String)
+
+// ---------------------------------------------------------------------------
+// McpTransport — transport-agnostic channel for JSON-RPC messages
+// ---------------------------------------------------------------------------
+
+trait McpTransport:
+  def receive: ZStream[Any, McpError, JsonRpcRequest]
+  def send(response: JsonRpcResponse): IO[McpError, Unit]
+  def notify(notification: JsonRpcNotification): IO[McpError, Unit]
+
+// ---------------------------------------------------------------------------
+// McpServer
+// ---------------------------------------------------------------------------
+
+trait McpServer:
+  def start: IO[McpError, Unit]
+  def stop: UIO[Unit]
+  def addTool(tool: Tool): UIO[Unit]
+  def removeTool(name: String): UIO[Unit]
+
+object McpServer:
+  def make(registry: ToolRegistry, transport: McpTransport): UIO[McpServer] =
+    for
+      stopPromise <- Promise.make[Nothing, Unit]
+    yield new McpServerLive(registry, transport, stopPromise)
+
+  val layer: ZLayer[ToolRegistry & McpTransport, Nothing, McpServer] =
+    ZLayer.fromZIO(
+      for
+        registry  <- ZIO.service[ToolRegistry]
+        transport <- ZIO.service[McpTransport]
+        server    <- make(registry, transport)
+      yield server
+    )
+
+// ---------------------------------------------------------------------------
+// McpServerLive
+// ---------------------------------------------------------------------------
+
+private class McpServerLive(
+  registry: ToolRegistry,
+  transport: McpTransport,
+  stopPromise: Promise[Nothing, Unit],
+) extends McpServer:
+
+  override def start: IO[McpError, Unit] =
+    val drain = transport.receive.mapZIO(handleRequest).runDrain
+    drain.race(stopPromise.await.as(()))
+
+  override def stop: UIO[Unit] = stopPromise.succeed(()).unit
+
+  override def addTool(tool: Tool): UIO[Unit] =
+    registry.register(tool).ignoreLogged *>
+      transport.notify(McpNotifications.toolsListChanged).ignore
+
+  override def removeTool(name: String): UIO[Unit] =
+    transport.notify(McpNotifications.toolsListChanged).ignore
+
+  private def handleRequest(req: JsonRpcRequest): IO[McpError, Unit] =
+    val respondId = req.id.getOrElse(RequestId.Num(0L))
+    req.method match
+      case "initialize" =>
+        val resp = JsonRpcResponse.success(
+          respondId,
+          McpInitializeResponse(
+            protocolVersion = "2024-11-05",
+            capabilities = ServerCapabilities(tools = Some(ToolsCapability())),
+            serverInfo = ServerInfo("llm4zio-gateway", "1.0"),
+          ).toJson.fromJson[Json].toOption.get,
+        )
+        transport.send(resp) <* transport.notify(McpNotifications.initialized)
+
+      case "tools/list" =>
+        registry.list.flatMap { tools =>
+          val resp = JsonRpcResponse.success(
+            respondId,
+            McpToolsListResponse(tools.map(McpToolInfo.fromTool)).toJson.fromJson[Json].toOption.get,
+          )
+          transport.send(resp)
+        }.mapError(e => McpError.TransportError(e.toString))
+
+      case "tools/call" =>
+        val callResult = for
+          params <- ZIO
+                      .fromOption(req.params)
+                      .orElseFail(McpError.ProtocolError("Missing params for tools/call"))
+          callReq <- ZIO
+                       .fromEither(params.as[McpToolCallRequest])
+                       .mapError(e => McpError.ProtocolError(s"Invalid tools/call params: $e"))
+          tool    <- registry
+                       .get(callReq.name)
+                       .mapError(e => McpError.ProtocolError(e.toString))
+          result  <- tool
+                       .execute(callReq.arguments)
+                       .mapError(e => McpError.ToolExecutionError(e.message))
+          content  = List(McpContent.Text(result.toJson))
+          resp     = JsonRpcResponse.success(
+                       respondId,
+                       McpToolCallResponse(content = content, isError = false)
+                         .toJson.fromJson[Json].toOption.get,
+                     )
+          _       <- transport.send(resp)
+        yield ()
+
+        callResult.catchAll {
+          case McpError.ProtocolError(msg) =>
+            transport.send(
+              JsonRpcResponse.error(respondId, JsonRpcError.invalidParams(msg))
+            )
+          case McpError.ToolExecutionError(msg) =>
+            val errorContent = List(McpContent.Text(s"Tool execution failed: $msg"))
+            transport.send(
+              JsonRpcResponse.success(
+                respondId,
+                McpToolCallResponse(content = errorContent, isError = true)
+                  .toJson.fromJson[Json].toOption.get,
+              )
+            )
+          case e =>
+            transport.send(
+              JsonRpcResponse.error(respondId, JsonRpcError.internalError(e.toString))
+            )
+        }
+
+      case "ping" =>
+        transport.send(JsonRpcResponse.success(respondId, Json.Obj()))
+
+      case unknown =>
+        transport.send(
+          JsonRpcResponse.error(respondId, JsonRpcError.methodNotFound(unknown))
+        )

--- a/llm4zio/src/main/scala/llm4zio/mcp/transport/SseTransport.scala
+++ b/llm4zio/src/main/scala/llm4zio/mcp/transport/SseTransport.scala
@@ -1,0 +1,112 @@
+package llm4zio.mcp.transport
+
+import java.util.UUID
+
+import zio.*
+import zio.stream.*
+
+import llm4zio.mcp.jsonrpc.*
+import llm4zio.mcp.server.{ McpError, McpTransport }
+
+/** Per-session outbound queue entry: notification or response. */
+type SessionOutbound = Either[JsonRpcNotification, JsonRpcResponse]
+
+/** Registry of active SSE sessions, each with a bounded outbound queue. */
+class SseSessionRegistry(state: Ref[Map[String, Queue[SessionOutbound]]]):
+
+  def create: UIO[String] =
+    for
+      id    <- ZIO.succeed(UUID.randomUUID().toString)
+      queue <- Queue.bounded[SessionOutbound](128)
+      _     <- state.update(_ + (id -> queue))
+    yield id
+
+  def close(id: String): UIO[Unit] =
+    state.modify(m => (m.get(id), m - id)).flatMap {
+      case Some(q) => q.shutdown
+      case None    => ZIO.unit
+    }
+
+  def exists(id: String): UIO[Boolean] =
+    state.get.map(_.contains(id))
+
+  def enqueue(id: String, msg: SessionOutbound): UIO[Unit] =
+    state.get.flatMap(m => ZIO.foreachDiscard(m.get(id))(_.offer(msg).unit))
+
+  /** Broadcast a message to all active sessions. */
+  def broadcast(msg: SessionOutbound): UIO[Unit] =
+    state.get.flatMap(m => ZIO.foreachDiscard(m.values)(_.offer(msg).unit))
+
+  /** Non-blocking poll of the next item in a session queue (for testing). */
+  def take(id: String): UIO[Option[SessionOutbound]] =
+    state.get.flatMap { m =>
+      m.get(id) match
+        case Some(q) => q.poll
+        case None    => ZIO.succeed(None)
+    }
+
+  /** Infinite stream of outbound messages for a session (used for SSE). */
+  def stream(id: String): ZStream[Any, Nothing, SessionOutbound] =
+    ZStream.unwrap(
+      state.get.map { m =>
+        m.get(id) match
+          case Some(q) => ZStream.fromQueue(q)
+          case None    => ZStream.empty
+      }
+    )
+
+object SseSessionRegistry:
+  def make: UIO[SseSessionRegistry] =
+    Ref.make(Map.empty[String, Queue[SessionOutbound]]).map(new SseSessionRegistry(_))
+
+// ---------------------------------------------------------------------------
+// SseTransport
+// ---------------------------------------------------------------------------
+
+/** MCP transport over HTTP SSE.
+  *
+  * - Client connects via `GET /mcp/sse?sessionId=<id>` and receives a stream of SSE events.
+  * - Client sends requests via `POST /mcp?sessionId=<id>` with JSON-RPC body.
+  *
+  * The gateway layer is responsible for mounting the HTTP routes and pushing
+  * incoming requests into this transport's inbound queue via `accept()`.
+  * Responses are sent per-session via `sendToSession()`. Notifications are broadcast.
+  */
+class SseTransport(
+  val sessions: SseSessionRegistry,
+  val apiKey: Option[String],
+  inboundQ: Queue[JsonRpcRequest],
+) extends McpTransport:
+
+  override def receive: ZStream[Any, McpError, JsonRpcRequest] =
+    ZStream.fromQueue(inboundQ)
+
+  override def send(response: JsonRpcResponse): IO[McpError, Unit] =
+    ZIO.unit // Per-session routing done via sendToSession
+
+  override def notify(notification: JsonRpcNotification): IO[McpError, Unit] =
+    sessions.broadcast(Left(notification))
+
+  /** Called by the HTTP route handler to enqueue a response to a specific session. */
+  def sendToSession(sessionId: String, response: JsonRpcResponse): UIO[Unit] =
+    sessions.enqueue(sessionId, Right(response))
+
+  /** Called by the HTTP route handler to push an inbound request. */
+  def accept(request: JsonRpcRequest): UIO[Unit] =
+    inboundQ.offer(request).unit
+
+  /** True when the request carries a valid API key (or no key is required). */
+  def validateKey(providedKey: Option[String]): Boolean =
+    apiKey match
+      case None         => true
+      case Some(secret) => providedKey.contains(secret)
+
+object SseTransport:
+  def make(apiKey: Option[String]): UIO[SseTransport] =
+    for
+      sessions <- SseSessionRegistry.make
+      inboundQ <- Queue.unbounded[JsonRpcRequest]
+    yield new SseTransport(sessions, apiKey, inboundQ)
+
+  val live: ZLayer[Any, Nothing, McpTransport] =
+    ZLayer.fromZIO(make(apiKey = None))

--- a/llm4zio/src/main/scala/llm4zio/mcp/transport/StdioTransport.scala
+++ b/llm4zio/src/main/scala/llm4zio/mcp/transport/StdioTransport.scala
@@ -1,0 +1,52 @@
+package llm4zio.mcp.transport
+
+import java.io.{ InputStream, OutputStream }
+
+import zio.*
+import zio.json.*
+import zio.stream.*
+
+import llm4zio.mcp.jsonrpc.*
+import llm4zio.mcp.server.{ McpError, McpTransport }
+
+/** MCP transport over stdin/stdout — newline-delimited JSON-RPC framing.
+  * All logging goes to stderr to avoid corrupting the protocol on stdout.
+  */
+class StdioTransport(in: InputStream, out: OutputStream) extends McpTransport:
+
+  override def receive: ZStream[Any, McpError, JsonRpcRequest] =
+    ZStream
+      .fromInputStream(in)
+      .mapError(e => McpError.TransportError(e.getMessage))
+      .via((ZPipeline.utf8Decode >>> ZPipeline.splitLines).mapError(e => McpError.TransportError(e.getMessage)))
+      .filter(_.trim.nonEmpty)
+      .mapZIO { line =>
+        ZIO
+          .fromEither(line.fromJson[JsonRpcRequest])
+          .mapError(e => McpError.ProtocolError(s"Failed to parse JSON-RPC request: $e"))
+      }
+
+  override def send(response: JsonRpcResponse): IO[McpError, Unit] =
+    writeJson(response.toJson)
+
+  override def notify(notification: JsonRpcNotification): IO[McpError, Unit] =
+    writeJson(notification.toJson)
+
+  private def writeJson(json: String): IO[McpError, Unit] =
+    ZIO
+      .attempt {
+        val bytes = (json + "\n").getBytes("UTF-8")
+        out.synchronized {
+          out.write(bytes)
+          out.flush()
+        }
+      }
+      .mapError(e => McpError.TransportError(s"Write failed: ${e.getMessage}"))
+
+object StdioTransport:
+  def fromStreams(in: InputStream, out: OutputStream): StdioTransport =
+    new StdioTransport(in, out)
+
+  /** Live layer using System.in / System.out. */
+  val live: ULayer[McpTransport] =
+    ZLayer.succeed(new StdioTransport(java.lang.System.in, java.lang.System.out))

--- a/llm4zio/src/test/scala/llm4zio/mcp/jsonrpc/JsonRpcSpec.scala
+++ b/llm4zio/src/test/scala/llm4zio/mcp/jsonrpc/JsonRpcSpec.scala
@@ -1,0 +1,102 @@
+package llm4zio.mcp.jsonrpc
+
+import zio.*
+import zio.json.*
+import zio.test.*
+import zio.test.Assertion.*
+
+object JsonRpcSpec extends ZIOSpecDefault:
+  def spec = suite("JsonRpc")(
+    suite("RequestId")(
+      test("encodes and decodes String id") {
+        val id   = RequestId.Str("abc-123")
+        val json = id.toJson
+        assertTrue(json.fromJson[RequestId].contains(RequestId.Str("abc-123")))
+      },
+      test("encodes and decodes Long id") {
+        val id   = RequestId.Num(42L)
+        val json = id.toJson
+        assertTrue(json.fromJson[RequestId].contains(RequestId.Num(42L)))
+      },
+    ),
+    suite("JsonRpcRequest")(
+      test("decodes request with string id") {
+        val json = """{"jsonrpc":"2.0","id":"1","method":"tools/list","params":null}"""
+        assertTrue(
+          json.fromJson[JsonRpcRequest].map(r =>
+            r.id.contains(RequestId.Str("1")) && r.method == "tools/list"
+          ).contains(true)
+        )
+      },
+      test("decodes notification without id") {
+        val json = """{"jsonrpc":"2.0","method":"notifications/initialized"}"""
+        assertTrue(
+          json.fromJson[JsonRpcRequest].map(r => r.id.isEmpty).contains(true)
+        )
+      },
+      test("encodes request to valid JSON") {
+        val req  = JsonRpcRequest(id = Some(RequestId.Num(1L)), method = "tools/list", params = None)
+        val json = req.toJson
+        assertTrue(json.contains("\"jsonrpc\":\"2.0\""), json.contains("\"method\":\"tools/list\""))
+      },
+    ),
+    suite("JsonRpcResponse")(
+      test("encodes success response") {
+        val resp = JsonRpcResponse.success(RequestId.Num(1L), """{"ok":true}""".fromJson[zio.json.ast.Json].toOption.get)
+        val json = resp.toJson
+        assertTrue(json.contains("\"result\""), !json.contains("\"error\""))
+      },
+      test("encodes error response") {
+        val resp = JsonRpcResponse.error(RequestId.Num(1L), JsonRpcError.methodNotFound("tools/unknown"))
+        val json = resp.toJson
+        assertTrue(json.contains("\"error\""), !json.contains("\"result\""))
+      },
+      test("decodes success response") {
+        val json = """{"jsonrpc":"2.0","id":1,"result":{"ok":true}}"""
+        assertTrue(json.fromJson[JsonRpcResponse].isRight)
+      },
+    ),
+    suite("JsonRpcError standard codes")(
+      test("parse error is -32700") {
+        assertTrue(JsonRpcError.parseError("bad json").code == -32700)
+      },
+      test("invalid request is -32600") {
+        assertTrue(JsonRpcError.invalidRequest("missing method").code == -32600)
+      },
+      test("method not found is -32601") {
+        assertTrue(JsonRpcError.methodNotFound("foo").code == -32601)
+      },
+      test("invalid params is -32602") {
+        assertTrue(JsonRpcError.invalidParams("missing name").code == -32602)
+      },
+      test("internal error is -32603") {
+        assertTrue(JsonRpcError.internalError("crash").code == -32603)
+      },
+    ),
+    suite("JsonRpcNotification")(
+      test("encodes notification without id") {
+        val n    = JsonRpcNotification(method = "notifications/initialized", params = None)
+        val json = n.toJson
+        assertTrue(json.contains("\"jsonrpc\":\"2.0\""), !json.contains("\"id\""))
+      },
+    ),
+    suite("JsonRpcHandler")(
+      test("routes method to handler and returns response") {
+        val handler = JsonRpcHandler.of {
+          case req if req.method == "ping" =>
+            ZIO.succeed(JsonRpcResponse.success(req.id.getOrElse(RequestId.Num(0L)), zio.json.ast.Json.Obj()))
+        }
+        val req = JsonRpcRequest(id = Some(RequestId.Num(1L)), method = "ping", params = None)
+        for
+          resp <- handler.handle(req)
+        yield assertTrue(resp.error.isEmpty)
+      },
+      test("returns method not found for unknown method") {
+        val handler = JsonRpcHandler.empty
+        val req     = JsonRpcRequest(id = Some(RequestId.Num(1L)), method = "unknown", params = None)
+        for
+          resp <- handler.handle(req)
+        yield assertTrue(resp.error.exists(_.code == -32601))
+      },
+    ),
+  )

--- a/llm4zio/src/test/scala/llm4zio/mcp/protocol/McpProtocolSpec.scala
+++ b/llm4zio/src/test/scala/llm4zio/mcp/protocol/McpProtocolSpec.scala
@@ -1,0 +1,75 @@
+package llm4zio.mcp.protocol
+
+import zio.*
+import zio.json.*
+import zio.json.ast.Json
+import zio.test.*
+import zio.test.Assertion.*
+
+import llm4zio.tools.{ Tool, ToolExecutionError }
+
+object McpProtocolSpec extends ZIOSpecDefault:
+  def spec = suite("McpProtocol")(
+    suite("McpInitializeRequest")(
+      test("decodes client capabilities") {
+        val json =
+          """{"protocolVersion":"2024-11-05","capabilities":{"roots":{"listChanged":true}},"clientInfo":{"name":"claude-code","version":"1.0"}}"""
+        assertTrue(json.fromJson[McpInitializeRequest].isRight)
+      },
+    ),
+    suite("McpInitializeResponse")(
+      test("encodes server capabilities with tools support") {
+        val resp = McpInitializeResponse(
+          protocolVersion = "2024-11-05",
+          capabilities = ServerCapabilities(tools = Some(ToolsCapability())),
+          serverInfo = ServerInfo("llm4zio-gateway", "1.0"),
+        )
+        val json = resp.toJson
+        assertTrue(json.contains("\"tools\""), json.contains("\"llm4zio-gateway\""))
+      },
+    ),
+    suite("McpToolsListResponse")(
+      test("encodes tool list with schema") {
+        val schema  = Json.Obj("type" -> Json.Str("object"), "properties" -> Json.Obj())
+        val tools   = List(McpToolInfo(name = "ping", description = "health check", inputSchema = schema))
+        val resp    = McpToolsListResponse(tools)
+        val encoded = resp.toJson
+        assertTrue(encoded.contains("\"ping\""), encoded.contains("\"health check\""))
+      },
+      test("McpToolInfo.fromTool converts Tool to McpToolInfo") {
+        val schema = Json.Obj("type" -> Json.Str("object"))
+        val tool   = Tool(name = "my_tool", description = "does stuff", parameters = schema, execute = _ => ZIO.fail(ToolExecutionError.ExecutionFailed("test")))
+        val info   = McpToolInfo.fromTool(tool)
+        assertTrue(info.name == "my_tool", info.description == "does stuff", info.inputSchema == schema)
+      },
+    ),
+    suite("McpToolCallRequest / McpToolCallResponse")(
+      test("decodes tool call request") {
+        val json = """{"name":"ping","arguments":{}}"""
+        assertTrue(json.fromJson[McpToolCallRequest].map(_.name).contains("ping"))
+      },
+      test("McpToolCallRequest.toToolCall converts to ToolCall") {
+        val req  = McpToolCallRequest(name = "run_agent", arguments = Json.Obj("prompt" -> Json.Str("hello")))
+        val call = req.toToolCall
+        assertTrue(call.name == "run_agent")
+      },
+      test("encodes text content response") {
+        val resp = McpToolCallResponse(content = List(McpContent.Text("result")), isError = false)
+        assertTrue(resp.toJson.contains("\"result\""))
+      },
+    ),
+    suite("McpContent")(
+      test("TextContent encodes with type field") {
+        val c = McpContent.Text("hello")
+        assertTrue(c.toJson.contains("\"text\""), c.toJson.contains("\"hello\""))
+      },
+    ),
+    suite("McpNotifications")(
+      test("initialized notification has correct method") {
+        assertTrue(McpNotifications.initialized.method == "notifications/initialized")
+      },
+      test("tools list changed notification has correct method") {
+        assertTrue(McpNotifications.toolsListChanged.method == "notifications/tools/list_changed")
+      },
+    ),
+  )

--- a/llm4zio/src/test/scala/llm4zio/mcp/server/McpServerSpec.scala
+++ b/llm4zio/src/test/scala/llm4zio/mcp/server/McpServerSpec.scala
@@ -1,0 +1,197 @@
+package llm4zio.mcp.server
+
+import zio.*
+import zio.json.*
+import zio.json.ast.Json
+import zio.stream.*
+import zio.test.*
+import zio.test.Assertion.*
+
+import llm4zio.mcp.jsonrpc.*
+import llm4zio.mcp.protocol.*
+import llm4zio.tools.{ Tool, ToolExecutionError, ToolRegistry }
+
+object McpServerSpec extends ZIOSpecDefault:
+
+  /** In-memory transport for testing: push requests in, collect responses out. */
+  def makeTestTransport: UIO[(InMemoryTransport, McpTransport)] =
+    for
+      inQ  <- Queue.unbounded[JsonRpcRequest]
+      outQ <- Queue.unbounded[Either[JsonRpcNotification, JsonRpcResponse]]
+    yield
+      val transport = new InMemoryTransport(inQ, outQ)
+      (transport, transport)
+
+  def spec = suite("McpServer")(
+    suite("initialize")(
+      test("responds with server capabilities including tools") {
+        for
+          (transport, mcpTransport) <- makeTestTransport
+          registry                  <- ToolRegistry.make
+          server                    <- McpServer.make(registry, mcpTransport)
+          _                         <- server.start.fork
+          req                        = JsonRpcRequest(
+                                         id = Some(RequestId.Num(1L)),
+                                         method = "initialize",
+                                         params = Some(
+                                           McpInitializeRequest(
+                                             protocolVersion = "2024-11-05",
+                                             clientInfo = ClientInfo("test", "1.0"),
+                                           ).toJson.fromJson[Json].toOption.get
+                                         ),
+                                       )
+          _                         <- transport.push(req)
+          resp                      <- transport.nextResponse
+        yield assertTrue(
+          resp.error.isEmpty,
+          resp.result.isDefined,
+        )
+      },
+    ),
+    suite("tools/list")(
+      test("returns empty list when no tools registered") {
+        for
+          (transport, mcpTransport) <- makeTestTransport
+          registry                  <- ToolRegistry.make
+          server                    <- McpServer.make(registry, mcpTransport)
+          _                         <- server.start.fork
+          req                        = JsonRpcRequest(id = Some(RequestId.Num(1L)), method = "tools/list")
+          _                         <- transport.push(req)
+          resp                      <- transport.nextResponse
+          result                    <- ZIO.fromEither(resp.result.get.as[McpToolsListResponse])
+        yield assertTrue(result.tools.isEmpty)
+      },
+      test("returns registered tools") {
+        for
+          (transport, mcpTransport) <- makeTestTransport
+          registry                  <- ToolRegistry.make
+          _                         <- registry.register(
+                                         Tool(
+                                           name = "ping",
+                                           description = "health check",
+                                           parameters = Json.Obj(),
+                                           execute = _ => ZIO.succeed(Json.Obj()),
+                                         )
+                                       )
+          server                    <- McpServer.make(registry, mcpTransport)
+          _                         <- server.start.fork
+          req                        = JsonRpcRequest(id = Some(RequestId.Num(1L)), method = "tools/list")
+          _                         <- transport.push(req)
+          resp                      <- transport.nextResponse
+          result                    <- ZIO.fromEither(resp.result.get.as[McpToolsListResponse])
+        yield assertTrue(result.tools.exists(_.name == "ping"))
+      },
+    ),
+    suite("tools/call")(
+      test("executes registered tool and returns text content") {
+        for
+          (transport, mcpTransport) <- makeTestTransport
+          registry                  <- ToolRegistry.make
+          _                         <- registry.register(
+                                         Tool(
+                                           name = "echo",
+                                           description = "echoes input",
+                                           parameters = Json.Obj(
+                                             "type"       -> Json.Str("object"),
+                                             "properties" -> Json.Obj("msg" -> Json.Obj("type" -> Json.Str("string"))),
+                                           ),
+                                           execute = args =>
+                                             ZIO.succeed(Json.Obj("echoed" -> args)),
+                                         )
+                                       )
+          server                    <- McpServer.make(registry, mcpTransport)
+          _                         <- server.start.fork
+          callParams                 = McpToolCallRequest(
+                                         name = "echo",
+                                         arguments = Json.Obj("msg" -> Json.Str("hello")),
+                                       ).toJson.fromJson[Json].toOption.get
+          req                        = JsonRpcRequest(
+                                         id = Some(RequestId.Num(1L)),
+                                         method = "tools/call",
+                                         params = Some(callParams),
+                                       )
+          _                         <- transport.push(req)
+          resp                      <- transport.nextResponse
+          result                    <- ZIO.fromEither(resp.result.get.as[McpToolCallResponse])
+        yield assertTrue(!result.isError, result.content.nonEmpty)
+      },
+      test("returns error content for unknown tool") {
+        for
+          (transport, mcpTransport) <- makeTestTransport
+          registry                  <- ToolRegistry.make
+          server                    <- McpServer.make(registry, mcpTransport)
+          _                         <- server.start.fork
+          callParams                 = McpToolCallRequest(name = "unknown", arguments = Json.Obj())
+                                         .toJson.fromJson[Json].toOption.get
+          req                        = JsonRpcRequest(
+                                         id = Some(RequestId.Num(1L)),
+                                         method = "tools/call",
+                                         params = Some(callParams),
+                                       )
+          _                         <- transport.push(req)
+          resp                      <- transport.nextResponse
+        yield assertTrue(resp.error.exists(_.code == -32602))
+      },
+    ),
+    suite("unknown method")(
+      test("returns method not found error") {
+        for
+          (transport, mcpTransport) <- makeTestTransport
+          registry                  <- ToolRegistry.make
+          server                    <- McpServer.make(registry, mcpTransport)
+          _                         <- server.start.fork
+          req                        = JsonRpcRequest(id = Some(RequestId.Num(1L)), method = "nonexistent")
+          _                         <- transport.push(req)
+          resp                      <- transport.nextResponse
+        yield assertTrue(resp.error.exists(_.code == -32601))
+      },
+    ),
+    suite("addTool")(
+      test("registers tool and emits tools/list_changed notification") {
+        for
+          (transport, mcpTransport) <- makeTestTransport
+          registry                  <- ToolRegistry.make
+          server                    <- McpServer.make(registry, mcpTransport)
+          _                         <- server.start.fork
+          _                         <- server.addTool(
+                                         Tool(
+                                           name = "new_tool",
+                                           description = "added at runtime",
+                                           parameters = Json.Obj(),
+                                           execute = _ => ZIO.succeed(Json.Obj()),
+                                         )
+                                       )
+          notification              <- transport.nextNotification
+        yield assertTrue(notification.method == "notifications/tools/list_changed")
+      },
+    ),
+  )
+
+/** Test double: in-memory McpTransport. */
+class InMemoryTransport(
+  inQ: Queue[JsonRpcRequest],
+  outQ: Queue[Either[JsonRpcNotification, JsonRpcResponse]],
+) extends McpTransport:
+
+  def push(req: JsonRpcRequest): UIO[Unit] = inQ.offer(req).unit
+
+  def nextResponse: UIO[JsonRpcResponse] =
+    outQ.take.flatMap {
+      case Right(resp) => ZIO.succeed(resp)
+      case Left(_)     => nextResponse // skip notifications
+    }
+
+  def nextNotification: UIO[JsonRpcNotification] =
+    outQ.take.flatMap {
+      case Left(n) => ZIO.succeed(n)
+      case Right(_) => nextNotification // skip responses
+    }
+
+  override def receive: ZStream[Any, McpError, JsonRpcRequest] =
+    ZStream.fromQueue(inQ)
+
+  override def send(response: JsonRpcResponse): IO[McpError, Unit] =
+    outQ.offer(Right(response)).unit
+
+  override def notify(notification: JsonRpcNotification): IO[McpError, Unit] =
+    outQ.offer(Left(notification)).unit

--- a/llm4zio/src/test/scala/llm4zio/mcp/transport/SseTransportSpec.scala
+++ b/llm4zio/src/test/scala/llm4zio/mcp/transport/SseTransportSpec.scala
@@ -1,0 +1,79 @@
+package llm4zio.mcp.transport
+
+import zio.*
+import zio.json.*
+import zio.json.ast.Json
+import zio.test.*
+
+import llm4zio.mcp.jsonrpc.*
+
+object SseTransportSpec extends ZIOSpecDefault:
+  def spec = suite("SseTransport")(
+    suite("session management")(
+      test("creates a new session and returns a session id") {
+        for
+          sessions <- SseSessionRegistry.make
+          id       <- sessions.create
+        yield assertTrue(id.nonEmpty)
+      },
+      test("different sessions get different ids") {
+        for
+          sessions <- SseSessionRegistry.make
+          id1      <- sessions.create
+          id2      <- sessions.create
+        yield assertTrue(id1 != id2)
+      },
+      test("closed session is removed from registry") {
+        for
+          sessions <- SseSessionRegistry.make
+          id       <- sessions.create
+          _        <- sessions.close(id)
+          exists   <- sessions.exists(id)
+        yield assertTrue(!exists)
+      },
+    ),
+    suite("send")(
+      test("enqueues response to the correct session queue") {
+        for
+          transport <- SseTransport.make(apiKey = None)
+          id        <- transport.sessions.create
+          resp       = JsonRpcResponse.success(RequestId.Num(1L), Json.Obj())
+          _         <- transport.sendToSession(id, resp)
+          outbound  <- transport.sessions.take(id)
+        yield assertTrue(outbound.contains(Right(resp)))
+      },
+    ),
+    suite("notify")(
+      test("broadcasts notification to all active sessions") {
+        for
+          transport <- SseTransport.make(apiKey = None)
+          id1       <- transport.sessions.create
+          id2       <- transport.sessions.create
+          notif      = JsonRpcNotification(method = "notifications/tools/list_changed")
+          _         <- transport.notify(notif)
+          out1      <- transport.sessions.take(id1)
+          out2      <- transport.sessions.take(id2)
+        yield assertTrue(
+          out1.contains(Left(notif)),
+          out2.contains(Left(notif)),
+        )
+      },
+    ),
+    suite("API key validation")(
+      test("accepts request when no API key is configured") {
+        for
+          transport <- SseTransport.make(apiKey = None)
+        yield assertTrue(transport.validateKey(None))
+      },
+      test("rejects request when key is configured but not provided") {
+        for
+          transport <- SseTransport.make(apiKey = Some("secret"))
+        yield assertTrue(!transport.validateKey(None))
+      },
+      test("accepts request when correct key is provided") {
+        for
+          transport <- SseTransport.make(apiKey = Some("secret"))
+        yield assertTrue(transport.validateKey(Some("secret")))
+      },
+    ),
+  )

--- a/llm4zio/src/test/scala/llm4zio/mcp/transport/StdioTransportSpec.scala
+++ b/llm4zio/src/test/scala/llm4zio/mcp/transport/StdioTransportSpec.scala
@@ -1,0 +1,75 @@
+package llm4zio.mcp.transport
+
+import java.io.{ ByteArrayInputStream, ByteArrayOutputStream }
+
+import zio.*
+import zio.json.*
+import zio.test.*
+import zio.test.Assertion.*
+
+import llm4zio.mcp.jsonrpc.*
+import llm4zio.mcp.server.McpError
+
+object StdioTransportSpec extends ZIOSpecDefault:
+  def spec = suite("StdioTransport")(
+    suite("receive")(
+      test("reads newline-delimited JSON-RPC requests from input stream") {
+        val req1 = JsonRpcRequest(id = Some(RequestId.Num(1L)), method = "tools/list")
+        val req2 = JsonRpcRequest(id = Some(RequestId.Num(2L)), method = "ping")
+        val input = (req1.toJson + "\n" + req2.toJson + "\n").getBytes("UTF-8")
+        val in    = new ByteArrayInputStream(input)
+        val out   = new ByteArrayOutputStream()
+
+        val transport = StdioTransport.fromStreams(in, out)
+        for
+          requests <- transport.receive.take(2).runCollect
+        yield assertTrue(
+          requests(0).method == "tools/list",
+          requests(1).method == "ping",
+        )
+      },
+      test("skips blank lines in input") {
+        val req   = JsonRpcRequest(id = Some(RequestId.Num(1L)), method = "ping")
+        val input = ("\n\n" + req.toJson + "\n").getBytes("UTF-8")
+        val in    = new ByteArrayInputStream(input)
+        val out   = new ByteArrayOutputStream()
+
+        val transport = StdioTransport.fromStreams(in, out)
+        for
+          requests <- transport.receive.take(1).runCollect
+        yield assertTrue(requests(0).method == "ping")
+      },
+      test("terminates stream on EOF") {
+        val in        = new ByteArrayInputStream(Array.empty)
+        val out       = new ByteArrayOutputStream()
+        val transport = StdioTransport.fromStreams(in, out)
+        for
+          count <- transport.receive.runCount
+        yield assertTrue(count == 0L)
+      },
+    ),
+    suite("send")(
+      test("writes response as newline-terminated JSON to output stream") {
+        val in        = new ByteArrayInputStream(Array.empty)
+        val out       = new ByteArrayOutputStream()
+        val transport = StdioTransport.fromStreams(in, out)
+        val resp      = JsonRpcResponse.success(RequestId.Num(1L), zio.json.ast.Json.Obj())
+        for
+          _      <- transport.send(resp)
+          written = out.toString("UTF-8")
+        yield assertTrue(written.endsWith("\n"), written.fromJson[JsonRpcResponse].isRight)
+      },
+    ),
+    suite("notify")(
+      test("writes notification as newline-terminated JSON to output stream") {
+        val in        = new ByteArrayInputStream(Array.empty)
+        val out       = new ByteArrayOutputStream()
+        val transport = StdioTransport.fromStreams(in, out)
+        val notif     = JsonRpcNotification(method = "notifications/initialized")
+        for
+          _      <- transport.notify(notif)
+          written = out.toString("UTF-8")
+        yield assertTrue(written.endsWith("\n"), written.contains("notifications/initialized"))
+      },
+    ),
+  )


### PR DESCRIPTION
Add ZIO-native MCP (Model Context Protocol) server implementation:

- mcp/jsonrpc: JSON-RPC 2.0 types (RequestId, request, response, error, notification, handler) with ZIO JSON codecs. RequestId handles String/Number
  union via custom codec.

- mcp/protocol: MCP message types (initialize, tools/list, tools/call, notifications). McpToolInfo.fromTool bridges existing Tool → MCP schema.
  McpContent ADT with Text/Image/Resource variants.

- mcp/server: McpServer trait + McpServerLive wires ToolRegistry to MCP protocol. McpTransport abstraction for pluggable transports. McpError ADT.
  Handles initialize, tools/list, tools/call, ping, and unknown methods.

- mcp/transport/StdioTransport: newline-delimited JSON-RPC over stdin/stdout.
  Logs to stderr only. Live layer uses java.lang.System.in/out.

- mcp/transport/SseTransport: per-session outbound queues via SseSessionRegistry. Broadcast notifications to all sessions. API key validation. Gateway layer mounts HTTP routes separately.

All 180 library tests pass (35 new MCP tests + 145 existing).

Closes #390, #391, #392, #393, #394

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>