### PR TITLE
feat: Implement MCP gateway wiring — issue #385

### DIFF
--- a/src/main/scala/app/ApplicationDI.scala
+++ b/src/main/scala/app/ApplicationDI.scala
@@ -264,6 +264,7 @@ object ApplicationDI:
       AppHealthController.live,
       GatewayTelegramController.live,
       ConversationWebSocketController.live,
+      mcp.McpService.live,
       WebServer.live,
     )
 

--- a/src/main/scala/app/boundary/WebServer.scala
+++ b/src/main/scala/app/boundary/WebServer.scala
@@ -30,6 +30,7 @@ import taskrun.boundary.{
   ReportsController as TaskRunReportsController,
   TasksController as TaskRunTasksController,
 }
+import mcp.McpService
 import workspace.boundary.WorkspacesController
 import workspace.control.{ GitService, WorkspaceRunService }
 import workspace.entity.WorkspaceRepository
@@ -39,7 +40,7 @@ trait WebServer:
 object WebServer:
 
   val live: ZLayer[
-    TaskRunDashboardController & TaskRunTasksController & TaskRunReportsController & TaskRunGraphController & SettingsBoundaryController & ConfigBoundaryController & ConfigAgentsController & AppAgentMonitorController & ConversationChatController & IssuesIssueController & ConfigWorkflowsController & GatewayTelegramController & ActivityController & MemoryBoundaryController & GatewayChannelController & AppHealthController & TaskRunLogsController & ConversationWebSocketController & WorkspaceRepository & WorkspaceRunService & GitService & AgentRegistry & IssueRepository,
+    TaskRunDashboardController & TaskRunTasksController & TaskRunReportsController & TaskRunGraphController & SettingsBoundaryController & ConfigBoundaryController & ConfigAgentsController & AppAgentMonitorController & ConversationChatController & IssuesIssueController & ConfigWorkflowsController & GatewayTelegramController & ActivityController & MemoryBoundaryController & GatewayChannelController & AppHealthController & TaskRunLogsController & ConversationWebSocketController & WorkspaceRepository & WorkspaceRunService & GitService & AgentRegistry & IssueRepository & McpService,
     Nothing,
     WebServer,
   ] = ZLayer {
@@ -67,10 +68,11 @@ object WebServer:
       gitService  <- ZIO.service[GitService]
       agentReg    <- ZIO.service[AgentRegistry]
       issueRepo   <- ZIO.service[IssueRepository]
+      mcpSvc      <- ZIO.service[McpService]
       staticRoutes = Routes.serveResources(Path.empty / "static")
     yield new WebServer {
       override val routes: Routes[Any, Response] =
-        dashboard.routes ++ tasks.routes ++ reports.routes ++ graph.routes ++ settings.routes ++ config.routes ++ agents.routes ++ monitor.routes ++ chat.routes ++ issues.routes ++ workflows.routes ++ telegram.routes ++ activity.routes ++ memory.routes ++ channels.routes ++ health.routes ++ logs.routes ++ websocket.routes ++ WorkspacesController.routes(
+        dashboard.routes ++ tasks.routes ++ reports.routes ++ graph.routes ++ settings.routes ++ config.routes ++ agents.routes ++ monitor.routes ++ chat.routes ++ issues.routes ++ workflows.routes ++ telegram.routes ++ activity.routes ++ memory.routes ++ channels.routes ++ health.routes ++ logs.routes ++ websocket.routes ++ mcpSvc.controller.routes ++ WorkspacesController.routes(
           wsRepo,
           wsRunSvc,
           agentReg,

--- a/src/main/scala/mcp/GatewayMcpTools.scala
+++ b/src/main/scala/mcp/GatewayMcpTools.scala
@@ -1,0 +1,275 @@
+package mcp
+
+import java.time.Instant
+
+import zio.*
+import zio.json.*
+import zio.json.ast.Json
+
+import agent.entity.AgentRepository
+import issues.entity.{ IssueEvent, IssueRepository }
+import llm4zio.tools.{ Tool, ToolExecutionError }
+import memory.entity.{ MemoryFilter, MemoryRepository, UserId }
+import shared.ids.Ids.IssueId
+import workspace.control.WorkspaceRunService
+import workspace.entity.WorkspaceRepository
+
+/** The 7 gateway tools exposed over MCP.
+  *
+  * Each tool is a pure `Tool` value: name + JSON schema + execute function.
+  * All repository/service dependencies are injected at construction time.
+  */
+final class GatewayMcpTools(
+  issueRepo: IssueRepository,
+  agentRepo: AgentRepository,
+  wsRepo: WorkspaceRepository,
+  runService: WorkspaceRunService,
+  memoryRepo: MemoryRepository,
+):
+
+  // ── assign_issue ──────────────────────────────────────────────────────────
+
+  private val assignIssueTool: Tool = Tool(
+    name        = "assign_issue",
+    description = "Create a new issue in the gateway issue tracker",
+    parameters  = Json.Obj(
+      "type"       -> Json.Str("object"),
+      "properties" -> Json.Obj(
+        "title"       -> Json.Obj("type" -> Json.Str("string")),
+        "description" -> Json.Obj("type" -> Json.Str("string")),
+        "priority"    -> Json.Obj("type" -> Json.Str("string")),
+      ),
+      "required"   -> Json.Arr(Chunk(Json.Str("title"), Json.Str("description"))),
+    ),
+    execute = args =>
+      for
+        title       <- fieldStr(args, "title")
+        description <- fieldStr(args, "description")
+        priority     = fieldStrOpt(args, "priority").getOrElse("medium")
+        issueId      = IssueId(java.util.UUID.randomUUID().toString)
+        event        = IssueEvent.Created(
+                         issueId = issueId,
+                         title = title,
+                         description = description,
+                         issueType = "task",
+                         priority = priority,
+                         occurredAt = Instant.now(),
+                       )
+        _           <- issueRepo
+                         .append(event)
+                         .mapError(e => ToolExecutionError.ExecutionFailed(e.toString))
+      yield Json.Obj("issueId" -> Json.Str(issueId.value)),
+  )
+
+  // ── run_agent ─────────────────────────────────────────────────────────────
+
+  private val runAgentTool: Tool = Tool(
+    name        = "run_agent",
+    description = "Start an agent run on a workspace for a given issue",
+    parameters  = Json.Obj(
+      "type"       -> Json.Str("object"),
+      "properties" -> Json.Obj(
+        "workspaceId" -> Json.Obj("type" -> Json.Str("string")),
+        "issueRef"    -> Json.Obj("type" -> Json.Str("string")),
+        "prompt"      -> Json.Obj("type" -> Json.Str("string")),
+        "agentName"   -> Json.Obj("type" -> Json.Str("string")),
+      ),
+      "required"   -> Json.Arr(
+        Chunk(Json.Str("workspaceId"), Json.Str("issueRef"), Json.Str("prompt"), Json.Str("agentName"))
+      ),
+    ),
+    execute = args =>
+      for
+        workspaceId <- fieldStr(args, "workspaceId")
+        issueRef    <- fieldStr(args, "issueRef")
+        prompt      <- fieldStr(args, "prompt")
+        agentName   <- fieldStr(args, "agentName")
+        run         <- runService
+                         .assign(workspaceId, workspace.control.AssignRunRequest(issueRef, prompt, agentName))
+                         .mapError(e => ToolExecutionError.ExecutionFailed(e.toString))
+      yield Json.Obj("runId" -> Json.Str(run.id), "status" -> Json.Str(run.status.toString)),
+  )
+
+  // ── get_run_status ────────────────────────────────────────────────────────
+
+  private val getRunStatusTool: Tool = Tool(
+    name        = "get_run_status",
+    description = "Get the status of an agent run by its run ID",
+    parameters  = Json.Obj(
+      "type"       -> Json.Str("object"),
+      "properties" -> Json.Obj(
+        "runId" -> Json.Obj("type" -> Json.Str("string")),
+      ),
+      "required"   -> Json.Arr(Chunk(Json.Str("runId"))),
+    ),
+    execute = args =>
+      for
+        runId <- fieldStr(args, "runId")
+        opt   <- wsRepo
+                   .getRun(runId)
+                   .mapError(e => ToolExecutionError.ExecutionFailed(e.toString))
+      yield opt match
+        case None      => Json.Obj("status" -> Json.Str("not_found"), "runId" -> Json.Str(runId))
+        case Some(run) =>
+          Json.Obj(
+            "runId"       -> Json.Str(run.id),
+            "status"      -> Json.Str(run.status.toString),
+            "workspaceId" -> Json.Str(run.workspaceId),
+            "agentName"   -> Json.Str(run.agentName),
+          ),
+  )
+
+  // ── list_agents ───────────────────────────────────────────────────────────
+
+  private val listAgentsTool: Tool = Tool(
+    name        = "list_agents",
+    description = "List all registered agents in this gateway",
+    parameters  = Json.Obj(
+      "type"       -> Json.Str("object"),
+      "properties" -> Json.Obj(),
+      "required"   -> Json.Arr(Chunk.empty),
+    ),
+    execute = _ =>
+      agentRepo
+        .list()
+        .mapError(e => ToolExecutionError.ExecutionFailed(e.toString))
+        .map { agents =>
+          Json.Arr(
+            Chunk.fromIterable(
+              agents.map(a =>
+                Json.Obj(
+                  "id"           -> Json.Str(a.id.value),
+                  "name"         -> Json.Str(a.name),
+                  "description"  -> Json.Str(a.description),
+                  "capabilities" -> Json.Arr(Chunk.fromIterable(a.capabilities.map(Json.Str(_)))),
+                )
+              )
+            )
+          )
+        },
+  )
+
+  // ── list_workspaces ───────────────────────────────────────────────────────
+
+  private val listWorkspacesTool: Tool = Tool(
+    name        = "list_workspaces",
+    description = "List all configured workspaces in this gateway",
+    parameters  = Json.Obj(
+      "type"       -> Json.Str("object"),
+      "properties" -> Json.Obj(),
+      "required"   -> Json.Arr(Chunk.empty),
+    ),
+    execute = _ =>
+      wsRepo.list
+        .mapError(e => ToolExecutionError.ExecutionFailed(e.toString))
+        .map { workspaces =>
+          Json.Arr(
+            Chunk.fromIterable(
+              workspaces.map(ws =>
+                Json.Obj(
+                  "id"        -> Json.Str(ws.id),
+                  "name"      -> Json.Str(ws.name),
+                  "localPath" -> Json.Str(ws.localPath),
+                  "enabled"   -> Json.Bool(ws.enabled),
+                )
+              )
+            )
+          )
+        },
+  )
+
+  // ── search_conversations ──────────────────────────────────────────────────
+
+  private val searchConversationsTool: Tool = Tool(
+    name        = "search_conversations",
+    description = "Semantic search over conversation memory",
+    parameters  = Json.Obj(
+      "type"       -> Json.Str("object"),
+      "properties" -> Json.Obj(
+        "query" -> Json.Obj("type" -> Json.Str("string")),
+        "limit" -> Json.Obj("type" -> Json.Str("integer")),
+      ),
+      "required"   -> Json.Arr(Chunk(Json.Str("query"))),
+    ),
+    execute = args =>
+      for
+        query   <- fieldStr(args, "query")
+        limit    = fieldIntOpt(args, "limit").getOrElse(10)
+        results <- memoryRepo
+                     .searchRelevant(UserId("mcp"), query, limit, MemoryFilter())
+                     .mapError(e => ToolExecutionError.ExecutionFailed(e.getMessage))
+      yield Json.Arr(
+        Chunk.fromIterable(
+          results.map(r =>
+            Json.Obj(
+              "text"  -> Json.Str(r.entry.text),
+              "score" -> Json.Num(BigDecimal(r.score.toDouble)),
+            )
+          )
+        )
+      ),
+  )
+
+  // ── get_metrics ───────────────────────────────────────────────────────────
+
+  private val getMetricsTool: Tool = Tool(
+    name        = "get_metrics",
+    description = "Get aggregate gateway metrics (agent count, workspace count, active runs)",
+    parameters  = Json.Obj(
+      "type"       -> Json.Str("object"),
+      "properties" -> Json.Obj(),
+      "required"   -> Json.Arr(Chunk.empty),
+    ),
+    execute = _ =>
+      for
+        agents     <- agentRepo.list().mapError(e => ToolExecutionError.ExecutionFailed(e.toString))
+        workspaces <- wsRepo.list.mapError(e => ToolExecutionError.ExecutionFailed(e.toString))
+        runs       <- ZIO
+                        .foreach(workspaces)(ws =>
+                          wsRepo
+                            .listRuns(ws.id)
+                            .mapError(e => ToolExecutionError.ExecutionFailed(e.toString))
+                        )
+                        .map(_.flatten)
+      yield Json.Obj(
+        "agents"      -> Json.Num(BigDecimal(agents.size)),
+        "workspaces"  -> Json.Num(BigDecimal(workspaces.size)),
+        "activeRuns"  -> Json.Num(BigDecimal(runs.count(r => isActive(r.status)))),
+        "totalRuns"   -> Json.Num(BigDecimal(runs.size)),
+      ),
+  )
+
+  // ── helpers ───────────────────────────────────────────────────────────────
+
+  private def fieldStr(args: Json, key: String): IO[ToolExecutionError, String] =
+    args match
+      case Json.Obj(fields) =>
+        fields.toMap.get(key) match
+          case Some(Json.Str(v)) => ZIO.succeed(v)
+          case _                 => ZIO.fail(ToolExecutionError.InvalidParameters(s"Missing required string field: $key"))
+      case _                =>
+        ZIO.fail(ToolExecutionError.InvalidParameters("Arguments must be a JSON object"))
+
+  private def fieldStrOpt(args: Json, key: String): Option[String] =
+    args match
+      case Json.Obj(fields) => fields.toMap.get(key).collect { case Json.Str(v) => v }
+      case _                => None
+
+  private def fieldIntOpt(args: Json, key: String): Option[Int] =
+    args match
+      case Json.Obj(fields) => fields.toMap.get(key).collect { case Json.Num(v) => v.intValue() }
+      case _                => None
+
+  private def isActive(status: workspace.entity.RunStatus): Boolean =
+    status == workspace.entity.RunStatus.Pending ||
+      status.isInstanceOf[workspace.entity.RunStatus.Running]
+
+  val all: List[Tool] = List(
+    assignIssueTool,
+    runAgentTool,
+    getRunStatusTool,
+    listAgentsTool,
+    listWorkspacesTool,
+    searchConversationsTool,
+    getMetricsTool,
+  )

--- a/src/main/scala/mcp/McpController.scala
+++ b/src/main/scala/mcp/McpController.scala
@@ -1,0 +1,68 @@
+package mcp
+
+import zio.*
+import zio.http.*
+import zio.json.*
+import zio.stream.ZStream
+
+import llm4zio.mcp.jsonrpc.JsonRpcRequest
+import llm4zio.mcp.transport.SseTransport
+
+/** HTTP routes for the MCP SSE transport.
+  *
+  * - `GET  /mcp/sse`            — open SSE stream; creates a session, sends outbound messages
+  * - `POST /mcp?sessionId=<id>` — receive a JSON-RPC request from the client
+  *
+  * Authentication: if an API key is configured, the client must supply it via the `X-Api-Key` header.
+  */
+final class McpController(transport: SseTransport):
+
+  val routes: Routes[Any, Response] = Routes(
+    Method.GET / "mcp" / "sse" -> handler { (req: Request) => sseHandler(req) },
+    Method.POST / "mcp"        -> handler { (req: Request) => postHandler(req) },
+  )
+
+  // ── POST /mcp ─────────────────────────────────────────────────────────────
+
+  private def postHandler(req: Request): UIO[Response] =
+    val providedKey = req.rawHeader("X-Api-Key")
+    if !transport.validateKey(providedKey) then
+      ZIO.succeed(Response.status(Status.Unauthorized))
+    else
+      req.queryParam("sessionId") match
+        case None            => ZIO.succeed(Response.status(Status.BadRequest))
+        case Some(sessionId) =>
+          transport.sessions.exists(sessionId).flatMap {
+            case false => ZIO.succeed(Response.status(Status.NotFound))
+            case true  =>
+              req.body.asString.orDie.flatMap { body =>
+                body.fromJson[JsonRpcRequest] match
+                  case Left(_)    => ZIO.succeed(Response.status(Status.BadRequest))
+                  case Right(rpc) => transport.accept(rpc).as(Response.status(Status.Accepted))
+              }
+          }
+
+  // ── GET /mcp/sse ──────────────────────────────────────────────────────────
+
+  private def sseHandler(req: Request): UIO[Response] =
+    val providedKey = req.rawHeader("X-Api-Key")
+    if !transport.validateKey(providedKey) then
+      ZIO.succeed(Response.status(Status.Unauthorized))
+    else
+      transport.sessions.create.map { sessionId =>
+        val stream: ZStream[Any, Nothing, String] = transport.sessions
+          .stream(sessionId)
+          .map {
+            case Left(notif) => s"event: message\ndata: ${notif.toJson}\n\n"
+            case Right(resp) => s"event: message\ndata: ${resp.toJson}\n\n"
+          }
+        Response(
+          status = Status.Ok,
+          headers = Headers(
+            Header.ContentType(MediaType.text.`event-stream`),
+            Header.CacheControl.NoCache,
+            Header.Custom("Connection", "keep-alive"),
+          ),
+          body = Body.fromCharSequenceStreamChunked(stream),
+        )
+      }

--- a/src/main/scala/mcp/McpService.scala
+++ b/src/main/scala/mcp/McpService.scala
@@ -1,0 +1,68 @@
+package mcp
+
+import zio.*
+
+import agent.entity.AgentRepository
+import issues.entity.IssueRepository
+import llm4zio.mcp.server.{ McpError, McpServer }
+import llm4zio.mcp.transport.SseTransport
+import llm4zio.tools.ToolRegistry
+import memory.entity.MemoryRepository
+import workspace.control.WorkspaceRunService
+import workspace.entity.WorkspaceRepository
+
+/** Holds the running MCP server (SSE transport) and its controller.
+  *
+  * Starts the MCP message-loop as a background fiber on construction.
+  * The fiber is interrupted when the ZLayer scope is closed.
+  */
+final class McpService(
+  val transport: SseTransport,
+  val controller: McpController,
+  private val serverFiber: Fiber[McpError, Unit],
+):
+  def interrupt: UIO[Unit] = serverFiber.interrupt.unit
+
+object McpService:
+
+  def make(
+    apiKey: Option[String],
+    issueRepo: IssueRepository,
+    agentRepo: AgentRepository,
+    wsRepo: WorkspaceRepository,
+    runService: WorkspaceRunService,
+    memoryRepo: MemoryRepository,
+  ): ZIO[Scope, Nothing, McpService] =
+    for
+      transport  <- SseTransport.make(apiKey)
+      registry   <- ToolRegistry.make
+      tools       = GatewayMcpTools(issueRepo, agentRepo, wsRepo, runService, memoryRepo)
+      _          <- registry.registerAll(tools.all).mapError(e => new RuntimeException(e.toString)).orDie
+      server     <- McpServer.make(registry, transport)
+      fiber      <- server.start.forkScoped
+      controller  = McpController(transport)
+    yield McpService(transport, controller, fiber)
+
+  /** ZLayer for wiring into ApplicationDI. */
+  val live: ZLayer[
+    IssueRepository & AgentRepository & WorkspaceRepository & WorkspaceRunService & MemoryRepository,
+    Nothing,
+    McpService,
+  ] =
+    ZLayer.scoped {
+      for
+        issueRepo  <- ZIO.service[IssueRepository]
+        agentRepo  <- ZIO.service[AgentRepository]
+        wsRepo     <- ZIO.service[WorkspaceRepository]
+        runService <- ZIO.service[WorkspaceRunService]
+        memoryRepo <- ZIO.service[MemoryRepository]
+        svc        <- make(
+                        apiKey = None, // can be configured via GatewayConfig.mcp.apiKey later
+                        issueRepo,
+                        agentRepo,
+                        wsRepo,
+                        runService,
+                        memoryRepo,
+                      )
+      yield svc
+    }

--- a/src/test/scala/mcp/GatewayMcpToolsSpec.scala
+++ b/src/test/scala/mcp/GatewayMcpToolsSpec.scala
@@ -1,0 +1,204 @@
+package mcp
+
+import zio.*
+import zio.json.*
+import zio.json.ast.Json
+import zio.test.*
+
+import agent.entity.AgentRepository
+import issues.entity.{ AgentIssue, IssueEvent, IssueFilter, IssueRepository }
+import llm4zio.tools.ToolRegistry
+import memory.entity.MemoryRepository
+import shared.errors.PersistenceError
+import shared.ids.Ids.{ AgentId, IssueId }
+import workspace.control.{ AssignRunRequest, WorkspaceRunService }
+import workspace.entity.{ WorkspaceError, WorkspaceRepository, WorkspaceRun }
+
+object GatewayMcpToolsSpec extends ZIOSpecDefault:
+
+  // ── Stubs ─────────────────────────────────────────────────────────────────
+
+  private val stubIssueRepo: IssueRepository = new IssueRepository:
+    override def append(event: IssueEvent): IO[PersistenceError, Unit] = ZIO.unit
+    override def get(id: IssueId): IO[PersistenceError, AgentIssue]   =
+      ZIO.fail(PersistenceError.NotFound("issue", id.value))
+    override def list(filter: IssueFilter): IO[PersistenceError, List[AgentIssue]] = ZIO.succeed(Nil)
+    override def delete(id: IssueId): IO[PersistenceError, Unit]      = ZIO.unit
+
+  private val stubAgentRepo: AgentRepository = new AgentRepository:
+    import agent.entity.*
+    private val testAgent = Agent(
+      id = AgentId("a1"),
+      name = "test-agent",
+      description = "A test agent",
+      cliTool = "claude-code",
+      capabilities = List("scala"),
+      defaultModel = None,
+      systemPrompt = None,
+      maxConcurrentRuns = 2,
+      envVars = Map.empty,
+      timeout = java.time.Duration.ofMinutes(30),
+      enabled = true,
+      createdAt = java.time.Instant.EPOCH,
+      updatedAt = java.time.Instant.EPOCH,
+    )
+    override def append(event: AgentEvent): IO[PersistenceError, Unit]            = ZIO.unit
+    override def get(id: AgentId): IO[PersistenceError, Agent]                    =
+      ZIO.fail(PersistenceError.NotFound("agent", id.value))
+    override def list(includeDeleted: Boolean): IO[PersistenceError, List[Agent]] =
+      ZIO.succeed(List(testAgent))
+    override def findByName(name: String): IO[PersistenceError, Option[Agent]]    =
+      list().map(_.find(_.name == name))
+
+  private val stubWorkspaceRepo: WorkspaceRepository = new WorkspaceRepository:
+    import workspace.entity.*
+    private val testWorkspace = Workspace(
+      id = "ws1",
+      name = "main-repo",
+      localPath = "/repos/main",
+      defaultAgent = None,
+      description = None,
+      enabled = true,
+      runMode = RunMode.Host,
+      cliTool = "claude-code",
+      createdAt = java.time.Instant.EPOCH,
+      updatedAt = java.time.Instant.EPOCH,
+    )
+    override def append(event: WorkspaceEvent): IO[PersistenceError, Unit]               = ZIO.unit
+    override def list: IO[PersistenceError, List[Workspace]]                             = ZIO.succeed(List(testWorkspace))
+    override def get(id: String): IO[PersistenceError, Option[Workspace]]                = list.map(_.find(_.id == id))
+    override def delete(id: String): IO[PersistenceError, Unit]                          = ZIO.unit
+    override def appendRun(event: WorkspaceRunEvent): IO[PersistenceError, Unit]         = ZIO.unit
+    override def listRuns(workspaceId: String): IO[PersistenceError, List[WorkspaceRun]] = ZIO.succeed(Nil)
+    override def getRun(id: String): IO[PersistenceError, Option[WorkspaceRun]]          = ZIO.succeed(None)
+
+  private val stubRunService: WorkspaceRunService = new WorkspaceRunService:
+    override def assign(workspaceId: String, req: AssignRunRequest): IO[WorkspaceError, WorkspaceRun] =
+      ZIO.fail(WorkspaceError.NotFound(workspaceId))
+    override def continueRun(runId: String, followUpPrompt: String, agentNameOverride: Option[String]): IO[WorkspaceError, WorkspaceRun] =
+      ZIO.fail(WorkspaceError.NotFound(runId))
+    override def cancelRun(runId: String): IO[WorkspaceError, Unit] =
+      ZIO.fail(WorkspaceError.NotFound(runId))
+
+  private val stubMemoryRepo: MemoryRepository = new MemoryRepository:
+    import memory.entity.*
+    override def save(entry: MemoryEntry): IO[Throwable, Unit] = ZIO.unit
+    override def searchRelevant(userId: UserId, query: String, limit: Int, filter: MemoryFilter): IO[Throwable, List[ScoredMemory]] =
+      ZIO.succeed(Nil)
+    override def listForUser(userId: UserId, filter: MemoryFilter, page: Int, pageSize: Int): IO[Throwable, List[MemoryEntry]] =
+      ZIO.succeed(Nil)
+    override def deleteById(userId: UserId, id: memory.entity.MemoryId): IO[Throwable, Unit] = ZIO.unit
+    override def deleteBySession(sessionId: memory.entity.SessionId): IO[Throwable, Unit] = ZIO.unit
+
+  // ── Tests ─────────────────────────────────────────────────────────────────
+
+  def spec = suite("GatewayMcpTools")(
+    suite("tool registration")(
+      test("registers all 7 gateway tools") {
+        for
+          registry <- ToolRegistry.make
+          tools     = GatewayMcpTools(stubIssueRepo, stubAgentRepo, stubWorkspaceRepo, stubRunService, stubMemoryRepo)
+          _        <- registry.registerAll(tools.all)
+          listed   <- registry.list
+          names     = listed.map(_.name).toSet
+        yield assertTrue(
+          names.contains("assign_issue"),
+          names.contains("run_agent"),
+          names.contains("get_run_status"),
+          names.contains("list_agents"),
+          names.contains("list_workspaces"),
+          names.contains("search_conversations"),
+          names.contains("get_metrics"),
+        )
+      },
+    ),
+    suite("list_agents")(
+      test("returns registered agents as JSON array") {
+        for
+          registry <- ToolRegistry.make
+          tools     = GatewayMcpTools(stubIssueRepo, stubAgentRepo, stubWorkspaceRepo, stubRunService, stubMemoryRepo)
+          _        <- registry.registerAll(tools.all)
+          result   <- registry.execute(llm4zio.core.ToolCall(id = "1", name = "list_agents", arguments = "{}"))
+          json      = result.result.toOption.get
+        yield assertTrue(json.toJson.contains("test-agent"))
+      },
+    ),
+    suite("list_workspaces")(
+      test("returns workspaces as JSON array") {
+        for
+          registry <- ToolRegistry.make
+          tools     = GatewayMcpTools(stubIssueRepo, stubAgentRepo, stubWorkspaceRepo, stubRunService, stubMemoryRepo)
+          _        <- registry.registerAll(tools.all)
+          result   <- registry.execute(llm4zio.core.ToolCall(id = "2", name = "list_workspaces", arguments = "{}"))
+          json      = result.result.toOption.get
+        yield assertTrue(json.toJson.contains("main-repo"))
+      },
+    ),
+    suite("assign_issue")(
+      test("creates issue event and returns issue id") {
+        var appended: Option[IssueEvent] = None
+        val capturingRepo                = new IssueRepository:
+          override def append(event: IssueEvent): IO[PersistenceError, Unit] =
+            ZIO.succeed { appended = Some(event) }
+          override def get(id: IssueId): IO[PersistenceError, AgentIssue]   =
+            ZIO.fail(PersistenceError.NotFound("issue", id.value))
+          override def list(filter: IssueFilter): IO[PersistenceError, List[AgentIssue]] = ZIO.succeed(Nil)
+          override def delete(id: IssueId): IO[PersistenceError, Unit]                   = ZIO.unit
+
+        for
+          registry <- ToolRegistry.make
+          tools     = GatewayMcpTools(capturingRepo, stubAgentRepo, stubWorkspaceRepo, stubRunService, stubMemoryRepo)
+          _        <- registry.registerAll(tools.all)
+          args      = Json.Obj(
+                        "title"       -> Json.Str("Fix bug"),
+                        "description" -> Json.Str("Reproduce and fix the crash"),
+                        "priority"    -> Json.Str("high"),
+                      )
+          result   <- registry.execute(llm4zio.core.ToolCall(id = "3", name = "assign_issue", arguments = args.toJson))
+          json      = result.result.toOption.get
+        yield assertTrue(
+          appended.isDefined,
+          appended.get.isInstanceOf[IssueEvent.Created],
+          json.toJson.contains("issueId"),
+        )
+      },
+    ),
+    suite("get_run_status")(
+      test("returns not_found when run does not exist") {
+        for
+          registry <- ToolRegistry.make
+          tools     = GatewayMcpTools(stubIssueRepo, stubAgentRepo, stubWorkspaceRepo, stubRunService, stubMemoryRepo)
+          _        <- registry.registerAll(tools.all)
+          args      = Json.Obj("runId" -> Json.Str("unknown-run"))
+          result   <- registry.execute(llm4zio.core.ToolCall(id = "4", name = "get_run_status", arguments = args.toJson))
+          json      = result.result.toOption.get
+        yield assertTrue(json.toJson.contains("not_found"))
+      },
+    ),
+    suite("search_conversations")(
+      test("returns empty results from stub memory repository") {
+        for
+          registry <- ToolRegistry.make
+          tools     = GatewayMcpTools(stubIssueRepo, stubAgentRepo, stubWorkspaceRepo, stubRunService, stubMemoryRepo)
+          _        <- registry.registerAll(tools.all)
+          args      = Json.Obj("query" -> Json.Str("test query"))
+          result   <- registry.execute(llm4zio.core.ToolCall(id = "5", name = "search_conversations", arguments = args.toJson))
+          json      = result.result.toOption.get
+        yield assertTrue(json.isInstanceOf[Json.Arr])
+      },
+    ),
+    suite("get_metrics")(
+      test("returns gateway metrics JSON") {
+        for
+          registry <- ToolRegistry.make
+          tools     = GatewayMcpTools(stubIssueRepo, stubAgentRepo, stubWorkspaceRepo, stubRunService, stubMemoryRepo)
+          _        <- registry.registerAll(tools.all)
+          result   <- registry.execute(llm4zio.core.ToolCall(id = "6", name = "get_metrics", arguments = "{}"))
+          json      = result.result.toOption.get
+        yield assertTrue(
+          json.toJson.contains("agents"),
+          json.toJson.contains("workspaces"),
+        )
+      },
+    ),
+  )

--- a/src/test/scala/mcp/McpControllerSpec.scala
+++ b/src/test/scala/mcp/McpControllerSpec.scala
@@ -1,0 +1,81 @@
+package mcp
+
+import zio.*
+import zio.http.*
+import zio.json.*
+import zio.json.ast.Json
+import zio.test.*
+
+import llm4zio.mcp.jsonrpc.{ JsonRpcRequest, RequestId }
+import llm4zio.mcp.transport.SseTransport
+
+object McpControllerSpec extends ZIOSpecDefault:
+
+  def spec = suite("McpController")(
+    suite("POST /mcp")(
+      test("returns 401 when API key is required but not provided") {
+        for
+          transport  <- SseTransport.make(apiKey = Some("secret"))
+          registry    = transport.sessions
+          controller  = McpController(transport)
+          request     = Request.post(URL.decode("/mcp?sessionId=s1").toOption.get, Body.fromString("{}"))
+          response   <- controller.routes.runZIO(request)
+        yield assertTrue(response.status == Status.Unauthorized)
+      },
+      test("returns 400 when sessionId is missing") {
+        for
+          transport  <- SseTransport.make(apiKey = None)
+          controller  = McpController(transport)
+          body        = JsonRpcRequest(id = Some(RequestId.Num(1L)), method = "ping").toJson
+          request     = Request.post(URL.decode("/mcp").toOption.get, Body.fromString(body))
+          response   <- controller.routes.runZIO(request)
+        yield assertTrue(response.status == Status.BadRequest)
+      },
+      test("returns 404 when session does not exist") {
+        for
+          transport  <- SseTransport.make(apiKey = None)
+          controller  = McpController(transport)
+          body        = JsonRpcRequest(id = Some(RequestId.Num(1L)), method = "ping").toJson
+          request     = Request.post(
+                          URL.decode("/mcp?sessionId=nonexistent").toOption.get,
+                          Body.fromString(body),
+                        )
+          response   <- controller.routes.runZIO(request)
+        yield assertTrue(response.status == Status.NotFound)
+      },
+      test("accepts request for existing session and returns 202") {
+        for
+          transport  <- SseTransport.make(apiKey = None)
+          sessionId  <- transport.sessions.create
+          controller  = McpController(transport)
+          body        = JsonRpcRequest(id = Some(RequestId.Num(1L)), method = "ping").toJson
+          request     = Request.post(
+                          URL.decode(s"/mcp?sessionId=$sessionId").toOption.get,
+                          Body.fromString(body),
+                        )
+          response   <- controller.routes.runZIO(request)
+        yield assertTrue(response.status == Status.Accepted)
+      },
+    ),
+    suite("GET /mcp/sse")(
+      test("returns 401 when API key is required but not provided") {
+        for
+          transport  <- SseTransport.make(apiKey = Some("secret"))
+          controller  = McpController(transport)
+          request     = Request.get(URL.decode("/mcp/sse").toOption.get)
+          response   <- controller.routes.runZIO(request)
+        yield assertTrue(response.status == Status.Unauthorized)
+      },
+      test("returns 200 with text/event-stream content type for valid request") {
+        for
+          transport  <- SseTransport.make(apiKey = None)
+          controller  = McpController(transport)
+          request     = Request.get(URL.decode("/mcp/sse").toOption.get)
+          response   <- controller.routes.runZIO(request)
+        yield assertTrue(
+          response.status == Status.Ok,
+          response.headers.get(Header.ContentType).exists(_.mediaType == MediaType.text.`event-stream`),
+        )
+      },
+    ),
+  )


### PR DESCRIPTION
- GatewayMcpTools: 7 tools (assign_issue, run_agent, get_run_status,
  list_agents, list_workspaces, search_conversations, get_metrics)
- McpController: SSE HTTP routes (GET /mcp/sse, POST /mcp) with
  API key validation, session management, and streaming
- McpService: ZLayer holding SseTransport + McpServer fiber,
  registers all gateway tools and starts the MCP message-loop
- Wire McpService.live into ApplicationDI.webServerLayer and
  McpController routes into WebServer.live
- 13 new tests (GatewayMcpToolsSpec + McpControllerSpec), all pass alongside 629 existing gateway tests and 180 library tests

Closes #385

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>