### PR TITLE
Merge AgentsView and AgentRegistryView into unified page

### DIFF
--- a/src/main/scala/config/boundary/AgentsController.scala
+++ b/src/main/scala/config/boundary/AgentsController.scala
@@ -15,7 +15,7 @@ import agent.entity.api.*
 import agent.entity.{ Agent as RegistryAgent, AgentEvent, AgentRepository }
 import db.{ ConfigRepository, CustomAgentRow, PersistenceError }
 import llm4zio.core.{ LlmError, LlmService }
-import orchestration.control.AgentRegistry
+import orchestration.control.{ AgentRegistry, OrchestratorControlPlane }
 import shared.ids.Ids.AgentId
 import shared.web.{ ErrorHandlingMiddleware, HtmlViews }
 import workspace.entity.{ RunStatus, WorkspaceRepository, WorkspaceRun }
@@ -28,7 +28,8 @@ object AgentsController:
   def routes: ZIO[AgentsController, Nothing, Routes[Any, Response]] =
     ZIO.serviceWith[AgentsController](_.routes)
 
-  val live: ZLayer[ConfigRepository & LlmService & AgentRepository & WorkspaceRepository, Nothing, AgentsController] =
+  val live
+    : ZLayer[ConfigRepository & LlmService & AgentRepository & WorkspaceRepository & OrchestratorControlPlane, Nothing, AgentsController] =
     ZLayer.fromFunction(AgentsControllerLive.apply)
 
 final case class AgentsControllerLive(
@@ -36,6 +37,7 @@ final case class AgentsControllerLive(
   llmService: LlmService,
   agentRepository: AgentRepository,
   workspaceRepository: WorkspaceRepository,
+  controlPlane: OrchestratorControlPlane,
 ) extends AgentsController:
 
   private val aiSettingKeys: List[String] = List(
@@ -214,43 +216,98 @@ final case class AgentsControllerLive(
         yield Response.json(toRunHistory(workspaceRuns).toJson)
       }
     },
-    Method.GET / "agents" / "registry"                                   -> handler { (req: Request) =>
+    Method.GET / "agents" / "registry" / "new"                           -> handler { (_: Request) =>
+      ZIO.succeed(redirectPermanent("/agents/new"))
+    },
+    Method.GET / "agents" / "registry" / string("id")                    -> handler { (id: String, _: Request) =>
+      ZIO.succeed(redirectPermanent(s"/agents/$id"))
+    },
+    Method.GET / "agents" / "registry"                                   -> handler { (_: Request) =>
+      ZIO.succeed(redirectPermanent("/agents"))
+    },
+    Method.GET / "agents"                                                -> handler { (req: Request) =>
       ErrorHandlingMiddleware.fromPersistence {
         for
-          _      <- ensureRegistryMigrated
-          agents <- agentRepository.list().mapError(mapAgentRepoError)
-          flash   = req.queryParam("flash").map(urlDecode).filter(_.nonEmpty)
-        yield html(HtmlViews.agentRegistryListPage(agents, flash))
+          _              <- ensureRegistryMigrated
+          registryAgents <- agentRepository.list().mapError(mapAgentRepoError)
+          customAgents   <- repository.listCustomAgents
+          bindings       <- repository.listAgentChannelBindings
+          workspaceRuns  <- loadAllWorkspaceRuns
+          now            <- Clock.instant
+          flash           = req.queryParam("flash").map(urlDecode).filter(_.nonEmpty)
+          cards           = buildAgentCards(
+                              registryAgents = registryAgents,
+                              customAgents = customAgents,
+                              bindings = bindings,
+                              runs = workspaceRuns,
+                              now = now,
+                            )
+        yield html(HtmlViews.agentsPage(cards, flash))
       }
     },
-    Method.GET / "agents" / "registry" / "new"                           -> handler { (_: Request) =>
+    Method.GET / "agents" / "new"                                        -> handler { (_: Request) =>
       ZIO.succeed(
         html(
-          HtmlViews.agentRegistryFormPage(
-            title = "Create Agent",
-            action = "/agents/registry",
-            values = Map("enabled" -> "true", "timeout" -> "PT30M", "maxConcurrentRuns" -> "1"),
+          HtmlViews.newAgentPage(
+            values = Map(
+              "agentSource"       -> "custom",
+              "enabled"           -> "true",
+              "timeout"           -> "PT30M",
+              "maxConcurrentRuns" -> "1",
+              "cliTool"           -> "gemini",
+            )
           )
         )
       )
     },
-    Method.POST / "agents" / "registry"                                  -> handler { (req: Request) =>
+    Method.POST / "agents"                                               -> handler { (req: Request) =>
       ErrorHandlingMiddleware.fromPersistence {
         for
-          _      <- ensureRegistryMigrated
-          form   <- parseForm(req)
-          upsert <- upsertFromForm(form)
-          dup    <- agentRepository.findByName(upsert.name).mapError(mapAgentRepoError)
-          _      <- ZIO
-                      .fail(PersistenceError.QueryFailed("agent_create", s"Agent '${upsert.name}' already exists"))
-                      .when(dup.isDefined)
-          now    <- Clock.instant
-          agent  <- buildAgentFromUpsert(AgentId.generate, upsert, now, now)
-          _      <- agentRepository.append(AgentEvent.Created(agent, now)).mapError(mapAgentRepoError)
-        yield redirectToAgentRegistry(s"Agent '${agent.name}' created.")
+          _          <- ensureRegistryMigrated
+          form       <- parseForm(req)
+          source      = form.get("agentSource").map(_.trim.toLowerCase).getOrElse("custom")
+          now        <- Clock.instant
+          _          <- source match
+                          case "registry" =>
+                            for
+                              upsert <- upsertFromForm(form)
+                              dup    <- agentRepository.findByName(upsert.name).mapError(mapAgentRepoError)
+                              _      <- ZIO
+                                          .fail(
+                                            PersistenceError.QueryFailed(
+                                              "agent_create",
+                                              s"Agent '${upsert.name}' already exists",
+                                            )
+                                          )
+                                          .when(dup.isDefined)
+                              agent  <- buildAgentFromUpsert(AgentId.generate, upsert, now, now)
+                              _      <- agentRepository.append(AgentEvent.Created(agent, now)).mapError(mapAgentRepoError)
+                            yield ()
+                          case _          =>
+                            for
+                              name         <- required(form, "name")
+                              displayName  <- required(form, "displayName")
+                              systemPrompt <- required(form, "systemPrompt")
+                              _            <- validateAgentNameFormat(name, "createCustomAgent")
+                              _            <- repository.createCustomAgent(
+                                                CustomAgentRow(
+                                                  name = name,
+                                                  displayName = displayName,
+                                                  description = optional(form, "description"),
+                                                  systemPrompt = systemPrompt,
+                                                  tags = optional(form, "tags"),
+                                                  enabled = true,
+                                                  createdAt = now,
+                                                  updatedAt = now,
+                                                )
+                                              )
+                            yield ()
+          displayName =
+            form.get("displayName").map(_.trim).filter(_.nonEmpty).getOrElse(form.getOrElse("name", "agent"))
+        yield redirectToAgents(s"Agent '$displayName' created.")
       }
     },
-    Method.GET / "agents" / "registry" / string("id")                    -> handler { (id: String, req: Request) =>
+    Method.GET / "agents" / string("id")                                 -> handler { (id: String, req: Request) =>
       ErrorHandlingMiddleware.fromPersistence {
         for
           _             <- ensureRegistryMigrated
@@ -261,36 +318,103 @@ final case class AgentsControllerLive(
           runs           = toRunHistory(workspaceRuns)
           history        = computeHistory(workspaceRuns, 30, now)
           flash          = req.queryParam("flash").map(urlDecode).filter(_.nonEmpty)
-        yield html(HtmlViews.agentRegistryDetailPage(agent, metrics.summary, runs, metrics.activeRuns, history, flash))
+        yield html(HtmlViews.agentDetailPage(agent, metrics.summary, runs, metrics.activeRuns, history, flash))
       }
     },
-    Method.GET / "agents" / "registry" / string("id") / "edit"           -> handler { (id: String, _: Request) =>
+    Method.GET / "agents" / string("slug") / "edit"                      -> handler { (slug: String, req: Request) =>
       ErrorHandlingMiddleware.fromPersistence {
         for
-          _     <- ensureRegistryMigrated
-          agent <- agentRepository.get(AgentId(id)).mapError(mapAgentRepoError)
-          values = valuesFromAgent(agent)
-        yield html(HtmlViews.agentRegistryFormPage("Edit Agent", s"/agents/registry/$id/edit", values))
+          _             <- ensureRegistryMigrated
+          registryAgent <- findRegistryAgentById(slug)
+          response      <- registryAgent match
+                             case Some(agent) =>
+                               val values = valuesFromAgent(agent)
+                               ZIO.succeed(
+                                 html(HtmlViews.agentRegistryFormPage(
+                                   "Edit Agent",
+                                   s"/agents/${agent.id.value}/edit",
+                                   values,
+                                 ))
+                               )
+                             case None        =>
+                               for
+                                 agent <- repository
+                                            .getCustomAgentByName(slug)
+                                            .someOrFail(
+                                              PersistenceError.QueryFailed("custom_agents", s"Unknown custom agent: $slug")
+                                            )
+                                 flash  = req.queryParam("flash").map(urlDecode).filter(_.nonEmpty)
+                               yield html(
+                                 HtmlViews.editCustomAgentPage(
+                                   name = agent.name,
+                                   values = customAgentFormValues(agent),
+                                   flash = flash,
+                                 )
+                               )
+        yield response
       }
     },
-    Method.POST / "agents" / "registry" / string("id") / "edit"          -> handler { (id: String, req: Request) =>
+    Method.POST / "agents" / string("slug") / "edit"                     -> handler { (slug: String, req: Request) =>
       ErrorHandlingMiddleware.fromPersistence {
         for
-          _        <- ensureRegistryMigrated
-          existing <- agentRepository.get(AgentId(id)).mapError(mapAgentRepoError)
-          form     <- parseForm(req)
-          upsert   <- upsertFromForm(form)
-          byName   <- agentRepository.findByName(upsert.name).mapError(mapAgentRepoError)
-          _        <- ZIO
-                        .fail(PersistenceError.QueryFailed("agent_update", s"Agent '${upsert.name}' already exists"))
-                        .when(byName.exists(_.id != existing.id))
-          now      <- Clock.instant
-          updated  <- buildAgentFromUpsert(existing.id, upsert, now, existing.createdAt)
-          _        <- agentRepository.append(AgentEvent.Updated(updated, now)).mapError(mapAgentRepoError)
-        yield redirectToAgentRegistry(s"Agent '${updated.name}' updated.")
+          _             <- ensureRegistryMigrated
+          registryAgent <- findRegistryAgentById(slug)
+          _             <- registryAgent match
+                             case Some(existing) =>
+                               for
+                                 form    <- parseForm(req)
+                                 upsert  <- upsertFromForm(form)
+                                 byName  <- agentRepository.findByName(upsert.name).mapError(mapAgentRepoError)
+                                 _       <- ZIO
+                                              .fail(
+                                                PersistenceError.QueryFailed(
+                                                  "agent_update",
+                                                  s"Agent '${upsert.name}' already exists",
+                                                )
+                                              )
+                                              .when(byName.exists(_.id != existing.id))
+                                 now     <- Clock.instant
+                                 updated <- buildAgentFromUpsert(existing.id, upsert, now, existing.createdAt)
+                                 _       <- agentRepository.append(AgentEvent.Updated(updated, now)).mapError(mapAgentRepoError)
+                               yield ()
+                             case None           =>
+                               for
+                                 existing <- repository
+                                               .getCustomAgentByName(slug)
+                                               .someOrFail(
+                                                 PersistenceError.QueryFailed(
+                                                   "custom_agents",
+                                                   s"Unknown custom agent: $slug",
+                                                 )
+                                               )
+                                 form     <- parseForm(req)
+                                 now      <- Clock.instant
+                                 newName  <- required(form, "name")
+                                 _        <- validateAgentNameFormat(newName, "updateCustomAgent")
+                                 updated  <- ZIO.succeed(
+                                               existing.copy(
+                                                 name = newName,
+                                                 displayName = form
+                                                   .get("displayName")
+                                                   .map(_.trim)
+                                                   .filter(_.nonEmpty)
+                                                   .getOrElse(existing.displayName),
+                                                 description = optional(form, "description"),
+                                                 systemPrompt = form
+                                                   .get("systemPrompt")
+                                                   .map(_.trim)
+                                                   .filter(_.nonEmpty)
+                                                   .getOrElse(existing.systemPrompt),
+                                                 tags = optional(form, "tags"),
+                                                 updatedAt = now,
+                                               )
+                                             )
+                                 _        <- repository.updateCustomAgent(updated)
+                               yield ()
+        yield redirectToAgents("Agent updated.")
       }
     },
-    Method.POST / "agents" / "registry" / string("id") / "disable"       -> handler { (id: String, _: Request) =>
+    Method.POST / "agents" / string("id") / "disable"                    -> handler { (id: String, _: Request) =>
       ErrorHandlingMiddleware.fromPersistence {
         for
           _        <- ensureRegistryMigrated
@@ -298,90 +422,39 @@ final case class AgentsControllerLive(
           now      <- Clock.instant
           _        <-
             if existing.enabled then
-              agentRepository.append(AgentEvent.Disabled(existing.id, Some("Disabled from UI"), now)).mapError(
-                mapAgentRepoError
-              )
+              agentRepository
+                .append(AgentEvent.Disabled(existing.id, Some("Disabled from UI"), now))
+                .mapError(mapAgentRepoError)
             else
               agentRepository.append(AgentEvent.Enabled(existing.id, now)).mapError(mapAgentRepoError)
-        yield redirectToAgentRegistry("Agent status updated.")
+        yield redirectToAgent("Agent status updated.", id)
       }
     },
-    Method.GET / "agents"                                                -> handler { (req: Request) =>
-      ZIO.succeed(
-        Response(
-          status = Status.Found,
-          headers = Headers(Header.Location(URL.decode("/agents/registry").getOrElse(URL.root))),
-        )
-      )
-    },
-    Method.GET / "agents" / "new"                                        -> handler { (_: Request) =>
-      ZIO.succeed(html(HtmlViews.newCustomAgentPage()))
-    },
-    Method.POST / "agents"                                               -> handler { (req: Request) =>
+    Method.POST / "agents" / string("id") / "pause"                      -> handler { (id: String, _: Request) =>
       ErrorHandlingMiddleware.fromPersistence {
         for
-          form         <- parseForm(req)
-          now          <- Clock.instant
-          name         <- required(form, "name")
-          displayName  <- required(form, "displayName")
-          systemPrompt <- required(form, "systemPrompt")
-          _            <- validateAgentNameFormat(name, "createCustomAgent")
-          _            <- repository.createCustomAgent(
-                            CustomAgentRow(
-                              name = name,
-                              displayName = displayName,
-                              description = optional(form, "description"),
-                              systemPrompt = systemPrompt,
-                              tags = optional(form, "tags"),
-                              enabled = true,
-                              createdAt = now,
-                              updatedAt = now,
-                            )
-                          )
-        yield redirectToAgents(s"Custom agent '$displayName' created.")
+          _     <- ensureRegistryMigrated
+          agent <- agentRepository.get(AgentId(id)).mapError(mapAgentRepoError)
+          _     <- controlPlane.pauseAgentExecution(agent.name).mapError(mapControlPlaneError)
+        yield redirectToAgents(s"Paused ${agent.name}.")
       }
     },
-    Method.GET / "agents" / string("name") / "edit"                      -> handler { (name: String, req: Request) =>
+    Method.POST / "agents" / string("id") / "resume"                     -> handler { (id: String, _: Request) =>
       ErrorHandlingMiddleware.fromPersistence {
         for
-          agent <- repository
-                     .getCustomAgentByName(name)
-                     .someOrFail(PersistenceError.QueryFailed("custom_agents", s"Unknown custom agent: $name"))
-          flash  = req.queryParam("flash").map(urlDecode).filter(_.nonEmpty)
-        yield html(
-          HtmlViews.editCustomAgentPage(
-            name = agent.name,
-            values = customAgentFormValues(agent),
-            flash = flash,
-          )
-        )
+          _     <- ensureRegistryMigrated
+          agent <- agentRepository.get(AgentId(id)).mapError(mapAgentRepoError)
+          _     <- controlPlane.resumeAgentExecution(agent.name).mapError(mapControlPlaneError)
+        yield redirectToAgents(s"Resumed ${agent.name}.")
       }
     },
-    Method.POST / "agents" / string("name") / "edit"                     -> handler { (name: String, req: Request) =>
+    Method.POST / "agents" / string("id") / "abort"                      -> handler { (id: String, _: Request) =>
       ErrorHandlingMiddleware.fromPersistence {
         for
-          existing <- repository
-                        .getCustomAgentByName(name)
-                        .someOrFail(PersistenceError.QueryFailed("custom_agents", s"Unknown custom agent: $name"))
-          form     <- parseForm(req)
-          now      <- Clock.instant
-          // Name is immutable in edit form, but we still parse and validate it.
-          newName  <- required(form, "name")
-          _        <- validateAgentNameFormat(newName, "updateCustomAgent")
-          updated  <- ZIO.succeed(
-                        existing.copy(
-                          name = newName,
-                          displayName =
-                            form.get("displayName").map(_.trim).filter(_.nonEmpty).getOrElse(existing.displayName),
-                          description = optional(form, "description"),
-                          systemPrompt =
-                            form.get("systemPrompt").map(_.trim).filter(_.nonEmpty).getOrElse(existing.systemPrompt),
-                          tags = optional(form, "tags"),
-                          updatedAt = now,
-                        )
-                      )
-          _        <- repository.updateCustomAgent(updated)
-        yield redirectToAgents(s"Custom agent '${updated.displayName}' updated.")
+          _     <- ensureRegistryMigrated
+          agent <- agentRepository.get(AgentId(id)).mapError(mapAgentRepoError)
+          _     <- controlPlane.abortAgentExecution(agent.name).mapError(mapControlPlaneError)
+        yield redirectToAgents(s"Aborted ${agent.name}.")
       }
     },
     Method.POST / "agents" / string("name") / "delete"                   -> handler { (name: String, _: Request) =>
@@ -528,10 +601,16 @@ final case class AgentsControllerLive(
       headers = Headers(Header.Custom("Location", s"/agents?flash=${urlEncode(flash)}")),
     )
 
-  private def redirectToAgentRegistry(flash: String): Response =
+  private def redirectToAgent(flash: String, id: String): Response =
     Response(
       status = Status.SeeOther,
-      headers = Headers(Header.Custom("Location", s"/agents/registry?flash=${urlEncode(flash)}")),
+      headers = Headers(Header.Custom("Location", s"/agents/$id?flash=${urlEncode(flash)}")),
+    )
+
+  private def redirectPermanent(path: String): Response =
+    Response(
+      status = Status.MovedPermanently,
+      headers = Headers(Header.Location(URL.decode(path).getOrElse(URL.root))),
     )
 
   private def mapAgentRepoError(error: shared.errors.PersistenceError): PersistenceError =
@@ -544,6 +623,9 @@ final case class AgentsControllerLive(
         PersistenceError.QueryFailed(entity, cause)
       case shared.errors.PersistenceError.StoreUnavailable(msg)              =>
         PersistenceError.QueryFailed("store", msg)
+
+  private def mapControlPlaneError(error: shared.errors.ControlPlaneError): PersistenceError =
+    PersistenceError.QueryFailed("agent_control", error.toString)
 
   private def ensureRegistryMigrated: IO[PersistenceError, Unit] =
     for
@@ -613,15 +695,58 @@ final case class AgentsControllerLive(
       .filter(_.nonEmpty)
       .distinct
 
-  private def loadWorkspaceRuns(agent: RegistryAgent): IO[PersistenceError, List[WorkspaceRun]] =
+  private def findRegistryAgentById(id: String): IO[PersistenceError, Option[RegistryAgent]] =
+    agentRepository
+      .get(AgentId(id))
+      .map(Some(_))
+      .catchAll {
+        case shared.errors.PersistenceError.NotFound(_, _) => ZIO.none
+        case other                                         => ZIO.fail(mapAgentRepoError(other))
+      }
+
+  private def loadAllWorkspaceRuns: IO[PersistenceError, List[WorkspaceRun]] =
     for
       workspaces <- workspaceRepository.list.mapError(mapAgentRepoError)
       allRuns    <-
         ZIO.foreach(workspaces)(ws => workspaceRepository.listRuns(ws.id).mapError(mapAgentRepoError)).map(_.flatten)
-      runs        = allRuns
-                      .filter(_.agentName.equalsIgnoreCase(agent.name))
-                      .sortBy(_.updatedAt)(Ordering[Instant].reverse)
+    yield allRuns
+
+  private def loadWorkspaceRuns(agent: RegistryAgent): IO[PersistenceError, List[WorkspaceRun]] =
+    for
+      allRuns <- loadAllWorkspaceRuns
+      runs     = allRuns
+                   .filter(_.agentName.equalsIgnoreCase(agent.name))
+                   .sortBy(_.updatedAt)(Ordering[Instant].reverse)
     yield runs
+
+  private def buildAgentCards(
+    registryAgents: List[RegistryAgent],
+    customAgents: List[CustomAgentRow],
+    bindings: List[AgentChannelBinding],
+    runs: List[WorkspaceRun],
+    now: Instant,
+  ): List[shared.web.AgentsView.AgentCard] =
+    val infoByNameLower = (registryAgents.map(toAgentInfo) ++ AgentRegistry.allAgents(customAgents))
+      .groupBy(_.name.trim.toLowerCase)
+      .view
+      .mapValues(_.head)
+      .toMap
+    val registryByName  = registryAgents.groupBy(_.name.trim.toLowerCase).view.mapValues(_.head).toMap
+    val names           = (infoByNameLower.keySet ++ registryByName.keySet).toList.sorted
+    names.map { nameLower =>
+      val info             = infoByNameLower.getOrElse(nameLower, toAgentInfo(registryByName(nameLower)))
+      val registryAgent    = registryByName.get(nameLower)
+      val agentRuns        = runs.filter(_.agentName.equalsIgnoreCase(info.name))
+      val metrics          = computeMetrics(agentRuns, now)
+      val bindingsForAgent = bindings.filter(_.agentId.value.equalsIgnoreCase(info.name))
+      shared.web.AgentsView.AgentCard(
+        info = info,
+        registryAgent = registryAgent,
+        metrics = metrics.summary,
+        activeRuns = metrics.activeRuns,
+        bindings = bindingsForAgent,
+      )
+    }
 
   private def toRunHistory(runs: List[WorkspaceRun]): List[AgentRunHistoryItem] =
     runs.map(run =>

--- a/src/main/scala/shared/web/AgentsView.scala
+++ b/src/main/scala/shared/web/AgentsView.scala
@@ -1,15 +1,23 @@
 package shared.web
 
+import zio.json.*
+
 import _root_.config.entity.{ AgentChannelBinding, AgentInfo, AgentType }
+import agent.entity.Agent
+import agent.entity.api.{ AgentActiveRun, AgentMetricsHistoryPoint, AgentMetricsSummary, AgentRunHistoryItem }
 import scalatags.Text.all.*
 
 object AgentsView:
 
-  def list(
-    agents: List[AgentInfo],
-    bindingsByAgent: Map[String, List[AgentChannelBinding]],
-    flash: Option[String] = None,
-  ): String =
+  final case class AgentCard(
+    info: AgentInfo,
+    registryAgent: Option[Agent],
+    metrics: AgentMetricsSummary,
+    activeRuns: List[AgentActiveRun],
+    bindings: List[AgentChannelBinding],
+  )
+
+  def list(cards: List[AgentCard], flash: Option[String] = None): String =
     Layout.page("Agents", "/agents")(
       div(cls := "space-y-6")(
         div(cls := "rounded-xl border border-white/10 bg-slate-900/80 px-5 py-4")(
@@ -17,13 +25,13 @@ object AgentsView:
             div(
               h1(cls := "text-2xl font-bold text-white")("Agents"),
               p(cls := "mt-1 text-sm text-slate-300")(
-                "Built-in and custom migration agents"
+                "Built-in, custom config, and registry agents"
               ),
             ),
             a(
               href := "/agents/new",
               cls  := "rounded-md border border-emerald-400/30 bg-emerald-500/20 px-3 py-2 text-sm font-semibold text-emerald-200 hover:bg-emerald-500/30",
-            )("Create Custom Agent"),
+            )("Create Agent"),
           )
         ),
         flash.map { msg =>
@@ -31,28 +39,66 @@ object AgentsView:
             p(cls := "text-sm text-emerald-300")(msg)
           )
         },
-        div(cls := "grid grid-cols-1 gap-4 lg:grid-cols-2")(
-          agents.map(agent => agentCard(agent, bindingsByAgent.getOrElse(agent.name, Nil)))
-        ),
+        if cards.isEmpty then
+          div(cls := "rounded-xl border border-white/10 bg-slate-900/60 px-4 py-8 text-sm text-slate-400")(
+            "No agents configured yet."
+          )
+        else
+          div(cls := "grid grid-cols-1 gap-4 lg:grid-cols-2")(
+            cards.sortBy(_.info.displayName.toLowerCase).map(agentCard)
+          ),
       )
     )
 
-  private def agentCard(agent: AgentInfo, bindings: List[AgentChannelBinding]): Frag =
+  private def agentCard(card: AgentCard): Frag =
+    val agent   = card.info
+    val metrics = card.metrics
     div(cls := "rounded-xl border border-white/10 bg-slate-900/70 p-5")(
       div(cls := "flex items-start justify-between gap-3")(
         div(
           h2(cls := "text-lg font-semibold text-slate-100")(agent.displayName),
           p(cls := "mt-1 text-sm text-slate-300")(agent.description),
           p(cls := "mt-1 font-mono text-xs text-indigo-300")(s"@${effectiveHandle(agent)}"),
+          card.registryAgent.map(reg => p(cls := "mt-1 font-mono text-[11px] text-slate-500")(s"id: ${reg.id.value}")),
         ),
         div(cls := "flex flex-col items-end gap-2")(
           typeBadge(agent.agentType),
           aiBadge(agent.usesAI),
+          statusBadge(card.registryAgent),
         ),
       ),
-      div(cls := "mt-4 flex flex-wrap gap-2")(
-        agent.tags.map(tagBadge)
+      div(cls := "mt-4 grid grid-cols-2 gap-2 text-xs text-slate-300 md:grid-cols-3")(
+        metricCard("Runs", metrics.totalRuns.toString),
+        metricCard("Success", f"${metrics.successRate * 100}%.1f%%"),
+        metricCard("Avg", formatSeconds(metrics.averageDurationSeconds)),
       ),
+      if agent.tags.nonEmpty then
+        div(cls := "mt-4 flex flex-wrap gap-2")(
+          agent.tags.map(tagBadge)
+        )
+      else (),
+      if card.activeRuns.nonEmpty then
+        div(cls := "mt-4 rounded-lg border border-amber-400/20 bg-amber-500/10 p-3")(
+          p(cls := "text-xs font-semibold uppercase tracking-wide text-amber-200")("Active Runs"),
+          ul(cls := "mt-2 space-y-1 text-xs text-amber-100")(
+            card.activeRuns.take(3).map { run =>
+              li(
+                span(cls := "font-semibold")(run.runId),
+                span(cls := "ml-2")(run.status),
+                span(cls := "ml-2 text-amber-200/70")(run.issueRef),
+              )
+            }
+          ),
+          card.registryAgent match
+            case Some(registryAgent) =>
+              div(cls := "mt-3 flex flex-wrap gap-2")(
+                monitorActionButton(registryAgent.id.value, "pause", "Pause", "amber"),
+                monitorActionButton(registryAgent.id.value, "resume", "Resume", "emerald"),
+                monitorActionButton(registryAgent.id.value, "abort", "Abort", "rose"),
+              )
+            case None                => (),
+        )
+      else (),
       div(cls := "mt-4 flex flex-wrap gap-2")(
         if agent.usesAI then
           a(
@@ -60,6 +106,12 @@ object AgentsView:
             cls  := "inline-flex rounded-md border border-indigo-400/30 bg-indigo-500/20 px-3 py-1.5 text-sm font-semibold text-indigo-200 hover:bg-indigo-500/30",
           )("Configure AI")
         else (),
+        card.registryAgent.map { reg =>
+          a(
+            href := s"/agents/${reg.id.value}",
+            cls  := "inline-flex rounded-md border border-slate-400/30 bg-slate-600/20 px-3 py-1.5 text-sm font-semibold text-slate-200 hover:bg-slate-500/30",
+          )("Details")
+        },
         if agent.agentType == AgentType.Custom then
           List(
             a(
@@ -77,10 +129,10 @@ object AgentsView:
       ),
       div(cls := "mt-4 border-t border-white/10 pt-3")(
         p(cls := "mb-2 text-xs font-semibold uppercase tracking-wide text-slate-400")("Channel Bindings"),
-        if bindings.isEmpty then p(cls := "text-xs text-slate-500")("No bindings")
+        if card.bindings.isEmpty then p(cls := "text-xs text-slate-500")("No bindings")
         else
           ul(cls := "mb-2 space-y-1 text-xs text-slate-300")(
-            bindings.map { binding =>
+            card.bindings.map { binding =>
               val channel = binding.channelName.trim
               val account = binding.accountId.map(_.trim).filter(_.nonEmpty)
               val label   =
@@ -125,55 +177,342 @@ object AgentsView:
       ),
     )
 
-  private def effectiveHandle(agent: AgentInfo): String =
-    Option(agent.handle).map(_.trim).filter(_.nonEmpty).getOrElse(agent.name)
-
-  private def typeBadge(agentType: AgentType): Frag =
-    val badgeCls = agentType match
-      case AgentType.BuiltIn =>
-        "rounded-full border border-sky-400/30 bg-sky-500/20 px-2 py-0.5 text-xs font-semibold text-sky-200"
-      case AgentType.Custom  =>
-        "rounded-full border border-violet-400/30 bg-violet-500/20 px-2 py-0.5 text-xs font-semibold text-violet-200"
-    span(cls := badgeCls)(
-      agentType match
-        case AgentType.BuiltIn => "Built-in"
-        case AgentType.Custom  => "Custom"
+  private def monitorActionButton(agentId: String, actionName: String, label: String, palette: String): Frag =
+    val buttonCls = palette match
+      case "amber"   =>
+        "rounded-md border border-amber-400/30 bg-amber-500/20 px-3 py-1 text-xs font-semibold text-amber-100"
+      case "emerald" =>
+        "rounded-md border border-emerald-400/30 bg-emerald-500/20 px-3 py-1 text-xs font-semibold text-emerald-100"
+      case _         =>
+        "rounded-md border border-rose-400/30 bg-rose-500/20 px-3 py-1 text-xs font-semibold text-rose-100"
+    form(method := "post", action := s"/agents/$agentId/$actionName")(
+      button(`type` := "submit", cls := buttonCls)(label)
     )
 
-  private def aiBadge(usesAI: Boolean): Frag =
-    val badgeCls =
-      if usesAI then
-        "rounded-full border border-emerald-400/30 bg-emerald-500/20 px-2 py-0.5 text-xs font-semibold text-emerald-200"
-      else "rounded-full border border-slate-500/30 bg-slate-500/20 px-2 py-0.5 text-xs font-semibold text-slate-200"
-    span(cls := badgeCls)(
-      if usesAI then "Uses AI" else "No AI"
+  private def statusBadge(registryAgent: Option[Agent]): Frag =
+    registryAgent match
+      case Some(agent) if agent.enabled =>
+        span(
+          cls := "rounded-full border border-emerald-400/30 bg-emerald-500/20 px-2 py-0.5 text-xs font-semibold text-emerald-200"
+        )(
+          "Enabled"
+        )
+      case Some(_)                      =>
+        span(
+          cls := "rounded-full border border-slate-500/30 bg-slate-500/20 px-2 py-0.5 text-xs font-semibold text-slate-200"
+        )(
+          "Disabled"
+        )
+      case None                         =>
+        span(
+          cls := "rounded-full border border-slate-500/30 bg-slate-500/20 px-2 py-0.5 text-xs font-semibold text-slate-200"
+        )(
+          "Config Only"
+        )
+
+  private def metricCard(labelText: String, value: String): Frag =
+    div(cls := "rounded border border-white/10 bg-slate-800/70 px-2 py-2")(
+      p(cls := "text-[10px] uppercase tracking-wide text-slate-400")(labelText),
+      p(cls := "mt-1 text-sm font-semibold text-slate-100")(value),
     )
 
-  private def tagBadge(tag: String): Frag =
-    span(cls := s"rounded-full border px-2 py-0.5 text-xs font-semibold ${tagBadgeClass(tag)}")(tag)
-
-  private def tagBadgeClass(tag: String): String =
-    val palette = Vector(
-      "border-rose-400/30 bg-rose-500/20 text-rose-200",
-      "border-amber-400/30 bg-amber-500/20 text-amber-200",
-      "border-emerald-400/30 bg-emerald-500/20 text-emerald-200",
-      "border-cyan-400/30 bg-cyan-500/20 text-cyan-200",
-      "border-indigo-400/30 bg-indigo-500/20 text-indigo-200",
-      "border-fuchsia-400/30 bg-fuchsia-500/20 text-fuchsia-200",
+  def detail(
+    agent: Agent,
+    metrics: AgentMetricsSummary,
+    runs: List[AgentRunHistoryItem],
+    activeRuns: List[AgentActiveRun],
+    history: List[AgentMetricsHistoryPoint],
+    flash: Option[String] = None,
+  ): String =
+    Layout.page(s"Agent ${agent.name}", "/agents")(
+      div(cls := "space-y-4")(
+        a(
+          href := "/agents",
+          cls  := "text-sm font-medium text-indigo-300 hover:text-indigo-200",
+        )("Back to agents"),
+        flash.map(msg =>
+          div(cls := "rounded-md bg-emerald-500/10 border border-emerald-400/30 p-3 text-sm text-emerald-200")(msg)
+        ),
+        div(cls := "rounded-xl border border-white/10 bg-slate-900/70 p-5")(
+          h1(cls := "text-xl font-bold text-white")(agent.name),
+          p(cls := "mt-1 text-sm text-slate-300")(agent.description),
+          div(cls := "mt-3 flex flex-wrap gap-2 text-xs")(
+            span(cls := "rounded bg-indigo-500/20 px-2 py-1 text-indigo-200")(s"cli: ${agent.cliTool}"),
+            span(cls := "rounded bg-slate-700/40 px-2 py-1 text-slate-200")(s"timeout: ${agent.timeout}"),
+            span(
+              cls := "rounded bg-slate-700/40 px-2 py-1 text-slate-200"
+            )(s"maxConcurrentRuns: ${agent.maxConcurrentRuns}"),
+            agent.dockerMemoryLimit.map(limit =>
+              span(cls := "rounded bg-slate-700/40 px-2 py-1 text-slate-200")(s"docker memory: $limit")
+            ),
+            agent.dockerCpuLimit.map(limit =>
+              span(cls := "rounded bg-slate-700/40 px-2 py-1 text-slate-200")(s"docker cpus: $limit")
+            ),
+          ),
+          div(cls := "mt-3 text-xs text-slate-300")(
+            strong("Capabilities: "),
+            if agent.capabilities.isEmpty then "none" else agent.capabilities.mkString(", "),
+          ),
+          div(cls := "mt-4 flex gap-2")(
+            a(
+              href := s"/agents/${agent.id.value}/edit",
+              cls  := "rounded-md border border-indigo-300/30 px-3 py-1.5 text-xs font-semibold text-indigo-200 hover:bg-indigo-500/20",
+            )("Edit"),
+            tag("form")(method := "post", action := s"/agents/${agent.id.value}/disable")(
+              button(
+                `type` := "submit",
+                cls    := "rounded-md border border-amber-300/30 px-3 py-1.5 text-xs font-semibold text-amber-200 hover:bg-amber-500/20",
+              )(if agent.enabled then "Disable" else "Enable")
+            ),
+          ),
+        ),
+        div(cls := "rounded-xl border border-white/10 bg-slate-900/60 p-4")(
+          h2(cls := "text-sm font-semibold text-slate-100")("Metrics"),
+          div(cls := "mt-2 grid grid-cols-2 gap-2 text-xs text-slate-300 md:grid-cols-5")(
+            metricCard("Total", metrics.totalRuns.toString),
+            metricCard("Completed", metrics.completedRuns.toString),
+            metricCard("Failed", metrics.failedRuns.toString),
+            metricCard("Active", metrics.activeRuns.toString),
+            metricCard("Success", f"${metrics.successRate * 100}%.1f%%"),
+          ),
+          div(cls := "mt-2 grid grid-cols-1 gap-2 text-xs text-slate-300 md:grid-cols-4")(
+            metricCard("Runs (7d)", metrics.totalRuns7d.toString),
+            metricCard("Runs (30d)", metrics.totalRuns30d.toString),
+            metricCard("Avg Duration", formatSeconds(metrics.averageDurationSeconds)),
+            metricCard("Issues Resolved", metrics.issuesResolvedCount.toString),
+          ),
+        ),
+        div(
+          cls                                := "rounded-xl border border-white/10 bg-slate-900/60 p-4",
+          attr("data-agent-metrics-history") := "true",
+          attr("data-history-points")        := history.toJson,
+        )(
+          h2(cls := "text-sm font-semibold text-slate-100")("30d Trend"),
+          div(cls := "mt-3 grid grid-cols-1 gap-3 md:grid-cols-2")(
+            div(
+              p(cls := "text-xs text-slate-400")("Success Rate"),
+              div(cls := "mt-1 rounded border border-white/10 bg-slate-800/70 p-2")(
+                tag("svg")(
+                  cls                         := "w-full h-16 text-emerald-300",
+                  attr("viewBox")             := "0 0 100 40",
+                  attr("preserveAspectRatio") := "none",
+                  attr("data-sparkline")      := "success-rate",
+                )
+              ),
+            ),
+            div(
+              p(cls := "text-xs text-slate-400")("Run Count"),
+              div(cls := "mt-1 rounded border border-white/10 bg-slate-800/70 p-2")(
+                tag("svg")(
+                  cls                         := "w-full h-16 text-indigo-300",
+                  attr("viewBox")             := "0 0 100 40",
+                  attr("preserveAspectRatio") := "none",
+                  attr("data-sparkline")      := "run-count",
+                )
+              ),
+            ),
+          ),
+        ),
+        div(cls := "rounded-xl border border-white/10 bg-slate-900/60 p-4")(
+          h2(cls := "text-sm font-semibold text-slate-100")("Active Runs"),
+          if activeRuns.isEmpty then
+            p(cls := "mt-2 text-xs text-slate-400")("No active runs.")
+          else
+            div(cls := "mt-2 space-y-2")(
+              activeRuns.map { run =>
+                val target =
+                  if run.conversationId.trim.nonEmpty then s"/chat/${run.conversationId}"
+                  else s"/runs?agent=${agent.name}"
+                a(
+                  href := target,
+                  cls  := "block rounded border border-white/10 bg-slate-800/70 px-3 py-2 text-xs text-slate-300 hover:bg-slate-800",
+                )(
+                  span(cls := "font-semibold text-slate-100")(run.runId),
+                  span(cls := "ml-2")(s"workspace:${run.workspaceId}"),
+                  span(cls := "ml-2")(run.status),
+                  span(cls := "ml-2 text-slate-400")(run.issueRef),
+                )
+              }
+            ),
+        ),
+        div(cls := "rounded-xl border border-white/10 bg-slate-900/60 p-4")(
+          h2(cls := "text-sm font-semibold text-slate-100")("Run History"),
+          if runs.isEmpty then
+            p(cls := "mt-2 text-xs text-slate-400")("No runs found for this agent.")
+          else
+            div(cls := "mt-2 space-y-2")(
+              runs.map { run =>
+                div(cls := "rounded border border-white/10 bg-slate-800/70 px-3 py-2 text-xs text-slate-300")(
+                  span(cls := "font-semibold text-slate-100")(run.runId),
+                  span(cls := "ml-2")(s"workspace:${run.workspaceId}"),
+                  span(cls := "ml-2")(run.status),
+                  span(cls := "ml-2 text-slate-500")(run.updatedAt.toString),
+                )
+              }
+            ),
+        ),
+        JsResources.inlineModuleScript("/static/client/components/agent-metrics.js"),
+      )
     )
-    val idx     = math.abs(tag.toLowerCase.hashCode) % palette.size
-    palette(idx)
 
-  def newCustomAgentForm(
+  def newAgentForm(
     values: Map[String, String] = Map.empty,
     flash: Option[String] = None,
   ): String =
-    customAgentFormPage(
-      title = "Create Custom Agent",
-      formAction = "/agents",
-      values = values,
-      flash = flash,
-      editingName = None,
+    Layout.page("Create Agent", "/agents")(
+      div(cls := "mx-auto max-w-4xl space-y-5")(
+        a(href := "/agents", cls := "text-sm font-medium text-indigo-300 hover:text-indigo-200")("Back to agents"),
+        div(cls := "rounded-xl border border-white/10 bg-slate-900/80 px-5 py-4")(
+          h1(cls := "text-2xl font-bold text-white")("Create Agent"),
+          p(cls := "mt-1 text-sm text-slate-300")(
+            "Single flow for config-level custom agents and registry-backed agents."
+          ),
+        ),
+        flash.map { msg =>
+          div(cls := "rounded-md border border-amber-500/30 bg-amber-500/10 p-4")(
+            p(cls := "text-sm text-amber-200")(msg)
+          )
+        },
+        form(method := "post", action := "/agents", cls := "space-y-5")(
+          div(cls := "rounded-xl border border-white/10 bg-slate-900/70 p-5 space-y-4")(
+            div(
+              label(cls := "mb-2 block text-sm font-semibold text-slate-200", `for` := "agentSource")("Agent Type"),
+              select(
+                id   := "agentSource",
+                name := "agentSource",
+                cls  := "w-full rounded-lg border border-white/15 bg-slate-800/80 px-3 py-2 text-sm text-slate-100",
+              )(
+                option(
+                  value := "custom",
+                  if values.getOrElse("agentSource", "custom") == "custom" then selected := "selected" else (),
+                )("Custom Config Agent"),
+                option(
+                  value := "registry",
+                  if values.get("agentSource").contains("registry") then selected := "selected" else (),
+                )("Registry Agent"),
+              ),
+            ),
+            div(cls := "grid grid-cols-1 gap-4 md:grid-cols-2")(
+              textInputField(
+                fieldName = "name",
+                labelText = "Name",
+                value = values.getOrElse("name", ""),
+                placeholder = "e.g. billingRefactorAgent",
+                required = true,
+              ),
+              textInputField(
+                fieldName = "displayName",
+                labelText = "Display Name",
+                value = values.getOrElse("displayName", ""),
+                placeholder = "e.g. Billing Refactor Agent",
+                required = true,
+              ),
+              textInputField(
+                fieldName = "description",
+                labelText = "Description",
+                value = values.getOrElse("description", ""),
+                placeholder = "One-line purpose",
+                required = true,
+              ),
+              textInputField(
+                fieldName = "tags",
+                labelText = "Tags (comma separated)",
+                value = values.getOrElse("tags", ""),
+                placeholder = "analysis,refactor,billing",
+              ),
+            ),
+            div(
+              label(cls := "mb-2 block text-sm font-semibold text-slate-200", `for` := "systemPrompt")("System Prompt"),
+              textarea(
+                id          := "systemPrompt",
+                name        := "systemPrompt",
+                rows        := 10,
+                cls         := "w-full rounded-lg border border-white/15 bg-slate-800/80 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:border-indigo-400/40 focus:outline-none",
+                placeholder := "You are a specialized migration agent. Follow these rules...",
+                required,
+              )(values.getOrElse("systemPrompt", "")),
+            ),
+          ),
+          div(cls := "rounded-xl border border-white/10 bg-slate-900/70 p-5")(
+            h2(cls := "text-sm font-semibold uppercase tracking-wide text-slate-300")("Registry Fields"),
+            p(cls := "mt-1 text-xs text-slate-400")(
+              "Used only when Agent Type is Registry Agent."
+            ),
+            div(cls := "mt-3 grid grid-cols-1 gap-4 md:grid-cols-2")(
+              textInputField(
+                fieldName = "cliTool",
+                labelText = "CLI Tool",
+                value = values.getOrElse("cliTool", "gemini"),
+                placeholder = "gemini / claude / codex",
+              ),
+              textInputField(
+                fieldName = "capabilities",
+                labelText = "Capabilities",
+                value = values.getOrElse("capabilities", values.getOrElse("tags", "")),
+                placeholder = "analysis,review",
+              ),
+              textInputField(
+                fieldName = "defaultModel",
+                labelText = "Default Model",
+                value = values.getOrElse("defaultModel", ""),
+                placeholder = "optional",
+              ),
+              textInputField(
+                fieldName = "maxConcurrentRuns",
+                labelText = "Max Concurrent Runs",
+                value = values.getOrElse("maxConcurrentRuns", "1"),
+                placeholder = "1",
+              ),
+              textInputField(
+                fieldName = "timeout",
+                labelText = "Timeout (ISO-8601)",
+                value = values.getOrElse("timeout", "PT30M"),
+                placeholder = "PT30M",
+              ),
+              textInputField(
+                fieldName = "dockerMemoryLimit",
+                labelText = "Docker Memory Limit",
+                value = values.getOrElse("dockerMemoryLimit", ""),
+                placeholder = "optional, e.g. 2g",
+              ),
+              textInputField(
+                fieldName = "dockerCpuLimit",
+                labelText = "Docker CPU Limit",
+                value = values.getOrElse("dockerCpuLimit", ""),
+                placeholder = "optional, e.g. 1.5",
+              ),
+            ),
+            div(cls := "mt-4")(
+              label(cls := "mb-2 block text-sm font-semibold text-slate-200", `for` := "envVars")(
+                "Env Vars (KEY=VALUE per line)"
+              ),
+              textarea(
+                id   := "envVars",
+                name := "envVars",
+                rows := 5,
+                cls  := "w-full rounded-md border border-white/15 bg-slate-800/80 px-3 py-2 text-sm text-slate-100",
+              )(values.getOrElse("envVars", "")),
+            ),
+            div(cls := "mt-3")(
+              label(cls := "inline-flex items-center gap-2 text-sm text-slate-200")(
+                input(
+                  `type` := "checkbox",
+                  name   := "enabled",
+                  if values.getOrElse("enabled", "true") == "true" then checked else (),
+                ),
+                span("Enabled"),
+              )
+            ),
+          ),
+          div(cls := "flex items-center gap-3")(
+            button(
+              `type` := "submit",
+              cls    := "rounded-md bg-indigo-500 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-400",
+            )("Create Agent"),
+            a(href := "/agents", cls := "text-sm font-medium text-slate-300 hover:text-white")("Cancel"),
+          ),
+        ),
+      )
     )
 
   def editCustomAgentForm(
@@ -189,6 +528,65 @@ object AgentsView:
       editingName = Some(name),
     )
 
+  def registryForm(
+    title: String,
+    formAction: String,
+    values: Map[String, String],
+  ): String =
+    Layout.page(title, "/agents")(
+      div(cls := "max-w-3xl space-y-4")(
+        a(
+          href := "/agents",
+          cls  := "text-sm font-medium text-indigo-300 hover:text-indigo-200",
+        )("Back to agents"),
+        h1(cls := "text-2xl font-bold text-white")(title),
+        tag("form")(
+          method := "post",
+          action := formAction,
+          cls    := "space-y-4 rounded-xl border border-white/10 bg-slate-900/70 p-5",
+        )(
+          textField("name", "Name", values.getOrElse("name", "")),
+          textField("description", "Description", values.getOrElse("description", "")),
+          textField("cliTool", "CLI Tool", values.getOrElse("cliTool", "gemini")),
+          capabilityEditor(
+            fieldName = "capabilities",
+            labelText = "Capabilities",
+            valueText = values.getOrElse("capabilities", ""),
+          ),
+          textField("defaultModel", "Default Model", values.getOrElse("defaultModel", "")),
+          textAreaField("systemPrompt", "System Prompt", values.getOrElse("systemPrompt", "")),
+          textField("maxConcurrentRuns", "Max Concurrent Runs", values.getOrElse("maxConcurrentRuns", "1")),
+          textField("timeout", "Timeout ISO-8601 (e.g. PT30M)", values.getOrElse("timeout", "PT30M")),
+          textField(
+            "dockerMemoryLimit",
+            "Docker Memory Limit (optional, e.g. 2g)",
+            values.getOrElse("dockerMemoryLimit", ""),
+          ),
+          textField(
+            "dockerCpuLimit",
+            "Docker CPU Limit (optional, e.g. 1.5)",
+            values.getOrElse("dockerCpuLimit", ""),
+          ),
+          textAreaField("envVars", "Env Vars (KEY=VALUE per line)", values.getOrElse("envVars", "")),
+          div(
+            label(cls := "inline-flex items-center gap-2 text-sm text-slate-200")(
+              input(
+                `type` := "checkbox",
+                name   := "enabled",
+                if values.getOrElse("enabled", "true") == "true" then checked else (),
+              ),
+              span("Enabled"),
+            )
+          ),
+          button(
+            `type` := "submit",
+            cls    := "rounded-md bg-indigo-500 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-400",
+          )("Save"),
+        ),
+        JsResources.inlineModuleScript("/static/client/components/capability-tag-editor.js"),
+      )
+    )
+
   private def customAgentFormPage(
     title: String,
     formAction: String,
@@ -198,7 +596,7 @@ object AgentsView:
   ): String =
     Layout.page(title, "/agents")(
       div(cls := "mx-auto max-w-4xl space-y-5")(
-        a(href := "/agents", cls := "text-sm font-medium text-indigo-300 hover:text-indigo-200")("← Back to Agents"),
+        a(href := "/agents", cls := "text-sm font-medium text-indigo-300 hover:text-indigo-200")("Back to agents"),
         div(cls := "rounded-xl border border-white/10 bg-slate-900/80 px-5 py-4")(
           h1(cls := "text-2xl font-bold text-white")(title),
           p(cls := "mt-1 text-sm text-slate-300")(
@@ -300,7 +698,7 @@ object AgentsView:
           a(
             href := "/agents",
             cls  := "text-sm font-medium text-indigo-300 hover:text-indigo-200",
-          )("← Back to Agents")
+          )("Back to agents")
         ),
         div(cls := "rounded-xl border border-white/10 bg-slate-900/80 px-5 py-4")(
           h1(cls := "text-2xl font-bold text-white")(s"${agent.displayName} Configuration"),
@@ -435,5 +833,94 @@ object AgentsView:
         attr("placeholder") := global.getOrElse(key, ""),
         cls                 := s"$widthCls rounded-md border-0 bg-white/5 px-3 py-1.5 text-white ring-1 ring-inset ring-white/10 focus:ring-2 focus:ring-indigo-500 sm:text-sm/6",
         step.map(s => attr("step") := s),
+      ),
+    )
+
+  private def effectiveHandle(agent: AgentInfo): String =
+    Option(agent.handle).map(_.trim).filter(_.nonEmpty).getOrElse(agent.name)
+
+  private def typeBadge(agentType: AgentType): Frag =
+    val badgeCls = agentType match
+      case AgentType.BuiltIn =>
+        "rounded-full border border-sky-400/30 bg-sky-500/20 px-2 py-0.5 text-xs font-semibold text-sky-200"
+      case AgentType.Custom  =>
+        "rounded-full border border-violet-400/30 bg-violet-500/20 px-2 py-0.5 text-xs font-semibold text-violet-200"
+    span(cls := badgeCls)(
+      agentType match
+        case AgentType.BuiltIn => "Built-in"
+        case AgentType.Custom  => "Custom"
+    )
+
+  private def aiBadge(usesAI: Boolean): Frag =
+    val badgeCls =
+      if usesAI then
+        "rounded-full border border-emerald-400/30 bg-emerald-500/20 px-2 py-0.5 text-xs font-semibold text-emerald-200"
+      else "rounded-full border border-slate-500/30 bg-slate-500/20 px-2 py-0.5 text-xs font-semibold text-slate-200"
+    span(cls := badgeCls)(
+      if usesAI then "Uses AI" else "No AI"
+    )
+
+  private def tagBadge(tag: String): Frag =
+    span(cls := s"rounded-full border px-2 py-0.5 text-xs font-semibold ${tagBadgeClass(tag)}")(tag)
+
+  private def tagBadgeClass(tag: String): String =
+    val palette = Vector(
+      "border-rose-400/30 bg-rose-500/20 text-rose-200",
+      "border-amber-400/30 bg-amber-500/20 text-amber-200",
+      "border-emerald-400/30 bg-emerald-500/20 text-emerald-200",
+      "border-cyan-400/30 bg-cyan-500/20 text-cyan-200",
+      "border-indigo-400/30 bg-indigo-500/20 text-indigo-200",
+      "border-fuchsia-400/30 bg-fuchsia-500/20 text-fuchsia-200",
+    )
+    val idx     = math.abs(tag.toLowerCase.hashCode) % palette.size
+    palette(idx)
+
+  private def formatSeconds(seconds: Long): String =
+    if seconds <= 0 then "0s"
+    else if seconds < 60 then s"${seconds}s"
+    else
+      val minutes = seconds / 60
+      val rem     = seconds % 60
+      s"${minutes}m ${rem}s"
+
+  private def textField(nameValue: String, labelText: String, valueText: String): Frag =
+    div(
+      label(cls := "mb-1 block text-sm font-semibold text-slate-200", `for` := nameValue)(labelText),
+      input(
+        `type` := "text",
+        id     := nameValue,
+        name   := nameValue,
+        value  := valueText,
+        cls    := "w-full rounded-md border border-white/15 bg-slate-800/80 px-3 py-2 text-sm text-slate-100",
+      ),
+    )
+
+  private def textAreaField(nameValue: String, labelText: String, valueText: String): Frag =
+    div(
+      label(cls := "mb-1 block text-sm font-semibold text-slate-200", `for` := nameValue)(labelText),
+      textarea(
+        id   := nameValue,
+        name := nameValue,
+        rows := 5,
+        cls  := "w-full rounded-md border border-white/15 bg-slate-800/80 px-3 py-2 text-sm text-slate-100",
+      )(valueText),
+    )
+
+  private def capabilityEditor(fieldName: String, labelText: String, valueText: String): Frag =
+    div(
+      label(cls := "mb-1 block text-sm font-semibold text-slate-200", `for` := s"${fieldName}EditorInput")(labelText),
+      div(
+        cls                            := "rounded-md border border-white/15 bg-slate-800/80 px-3 py-2",
+        attr("data-capability-editor") := "true",
+      )(
+        input(`type`                    := "hidden", id                                               := fieldName, name := fieldName, value := valueText),
+        div(cls                         := "mb-2 flex flex-wrap gap-2", attr("data-capability-chips") := "true"),
+        input(
+          `type`                        := "text",
+          id                            := s"${fieldName}EditorInput",
+          cls                           := "w-full rounded border border-white/10 bg-slate-900/80 px-2 py-1.5 text-sm text-slate-100",
+          attr("data-capability-input") := "true",
+          attr("placeholder")           := "Type capability and press Enter",
+        ),
       ),
     )

--- a/src/main/scala/shared/web/DashboardView.scala
+++ b/src/main/scala/shared/web/DashboardView.scala
@@ -77,9 +77,9 @@ object DashboardView:
             p(cls := "text-xs text-gray-400 mt-1")("Runs, success rate, average duration, and active load by agent."),
           ),
           a(
-            href := "/agents/registry",
+            href := "/agents",
             cls  := "inline-flex items-center rounded-md bg-indigo-500/20 px-3 py-2 text-xs font-semibold text-indigo-100 ring-1 ring-indigo-300/30 hover:bg-indigo-500/30",
-          )("Open Registry"),
+          )("Open Agents"),
         ),
         div(
           id                                   := "dashboard-agent-metrics",

--- a/src/main/scala/shared/web/HtmlViews.scala
+++ b/src/main/scala/shared/web/HtmlViews.scala
@@ -1,10 +1,8 @@
 package shared.web
 
 import activity.entity.ActivityEvent
-import agent.entity.Agent
-import agent.entity.api.{ AgentActiveRun, AgentMetricsHistoryPoint, AgentMetricsSummary, AgentRunHistoryItem }
 import config.control.{ ModelRegistryResponse, ProviderProbeStatus }
-import config.entity.{ AgentChannelBinding, AgentInfo, WorkflowDefinition }
+import config.entity.{ AgentInfo, WorkflowDefinition }
 import conversation.entity.api.{ ChatConversation, ConversationEntry, ConversationSessionMeta }
 import db.{ TaskReportRow, TaskRunRow }
 import gateway.entity.ChatSession
@@ -104,18 +102,14 @@ object HtmlViews:
   def workflowDetail(workflow: WorkflowDefinition): String =
     WorkflowsView.detail(workflow)
 
-  def agentsPage(
-    agents: List[AgentInfo],
-    bindingsByAgent: Map[String, List[AgentChannelBinding]],
-    flash: Option[String] = None,
-  ): String =
-    AgentsView.list(agents, bindingsByAgent, flash)
+  def agentsPage(cards: List[AgentsView.AgentCard], flash: Option[String] = None): String =
+    AgentsView.list(cards, flash)
 
-  def newCustomAgentPage(
+  def newAgentPage(
     values: Map[String, String] = Map.empty,
     flash: Option[String] = None,
   ): String =
-    AgentsView.newCustomAgentForm(values, flash)
+    AgentsView.newAgentForm(values, flash)
 
   def editCustomAgentPage(
     name: String,
@@ -124,25 +118,22 @@ object HtmlViews:
   ): String =
     AgentsView.editCustomAgentForm(name, values, flash)
 
-  def agentRegistryListPage(agents: List[Agent], flash: Option[String] = None): String =
-    AgentRegistryView.list(agents, flash)
-
-  def agentRegistryDetailPage(
-    agent: Agent,
-    metrics: AgentMetricsSummary,
-    runs: List[AgentRunHistoryItem],
-    activeRuns: List[AgentActiveRun],
-    history: List[AgentMetricsHistoryPoint],
-    flash: Option[String] = None,
-  ): String =
-    AgentRegistryView.detail(agent, metrics, runs, activeRuns, history, flash)
-
   def agentRegistryFormPage(
     title: String,
     action: String,
     values: Map[String, String],
   ): String =
-    AgentRegistryView.form(title, action, values)
+    AgentsView.registryForm(title, action, values)
+
+  def agentDetailPage(
+    registryAgent: agent.entity.Agent,
+    metrics: agent.entity.api.AgentMetricsSummary,
+    runs: List[agent.entity.api.AgentRunHistoryItem],
+    activeRuns: List[agent.entity.api.AgentActiveRun],
+    history: List[agent.entity.api.AgentMetricsHistoryPoint],
+    flash: Option[String] = None,
+  ): String =
+    AgentsView.detail(registryAgent, metrics, runs, activeRuns, history, flash)
 
   def agentConfigPage(
     agent: AgentInfo,


### PR DESCRIPTION
Fixes #449 Add inline metrics panel to agent cards Fixes #450 Move agent pause/resume/abort controls to agent cards Fixes #451 Remove /agents/registry as separate route tree Fixes #452 Unify config-level and registry-level agent creation Fixes #453