### PR TITLE
fix(gemini): classify quota exhaustion from CLI stderr into typed UsageLimitError

### DIFF
--- a/docs/legacy-modernization.md
+++ b/docs/legacy-modernization.md
@@ -114,6 +114,26 @@ each script, or set `LLM4ZIO_CODER=claude|codex|gemini|pi` to run a whole flow o
 one provider. Cross-provider judging (e.g. Claude judging Gemini's extraction) is
 one config swap.
 
+llm4zio passes the configured model to the CLI (`gemini -m <model>`), but the CLI
+can still route or fall back to a different model (its own settings, `auto`
+routing, tier fallbacks); the run logs a WARN when the session's serving model
+differs from the requested one — that's the first thing to check when a flash-pinned
+flow is unexpectedly burning pro quota.
+
+### Provider quota exhaustion
+
+When gemini exhausts a model's quota mid-flow it often reports the reason
+(`TerminalQuotaError: … Your quota will reset after 21h1m53s`) only on the CLI's
+stderr while stdout carries a catch-all error or nothing. llm4zio classifies that
+stderr diagnostic into a typed usage-limit error with the concrete reset time, so
+the flow **fails fast with the reason instead of burning its retry budget**. Two
+ways out:
+
+- `LLM4ZIO_USAGE_WAIT=24h` (or `on`) — sleep until the reported reset, then
+  auto-resume the flow (extract is resumable: the committed draft pack is reused).
+- Point the seats at a model with remaining quota (e.g. swap the `ProModel` val
+  to `gemini-2.5-flash`) and rerun.
+
 ## Token & cost traceability
 
 Every flow run appends one structured record to an append-only ledger —

--- a/examples/modernize-extract.sc
+++ b/examples/modernize-extract.sc
@@ -33,6 +33,10 @@
   *
   * Seats (all-gemini defaults; LLM4ZIO_CODER=claude|codex|gemini|pi swaps the whole flow):
   * analyst + reasoning + judge on the Pro model — extraction quality is the product here.
+  *
+  * Quota: if gemini exhausts the model's quota the flow fails fast with the reset time
+  * (set LLM4ZIO_USAGE_WAIT=24h to wait it out and auto-resume, or point ProModel at a model
+  * with remaining quota). A WARN is logged if the CLI serves a different model than requested.
   */
 
 import java.nio.charset.StandardCharsets

--- a/modules/llm4zio-core/src/main/scala/llm4zio/providers/GeminiCliProvider.scala
+++ b/modules/llm4zio-core/src/main/scala/llm4zio/providers/GeminiCliProvider.scala
@@ -66,6 +66,9 @@ object GeminiCliExecutionContext:
 
 object GeminiCliExecutor:
 
+  /** Cap on captured (non-noise) stderr lines per process — enough for gemini's error report + stack trace. */
+  private val stderrCaptureLimit = 200
+
   private[providers] def validateExitCode(
     exitCode: Int,
     stderr: String,
@@ -80,8 +83,89 @@ object GeminiCliExecutor:
         ZIO.logWarning(s"Gemini CLI turn limit exceeded (exit 53): $stderr") *>
           ZIO.fail(LlmError.TurnLimitError(turnLimit))
       case _  =>
+        // Classify before falling back to a generic ProviderError: a quota-driven death (gemini prints the reason —
+        // with its reset time — to stderr) must surface as the typed usage-limit error, not a retriable-looking blob.
         ZIO.logError(s"Gemini CLI exited with code $exitCode: $stderr") *>
-          ZIO.fail(LlmError.ProviderError(s"Gemini CLI exited with code $exitCode: $stderr", None))
+          Clock.instant.flatMap { now =>
+            ZIO.fail(
+              UsageLimits
+                .classify("gemini", stderr, now, ZoneId.systemDefault)
+                .getOrElse(LlmError.ProviderError(s"Gemini CLI exited with code $exitCode: $stderr", None))
+            )
+          }
+
+  /** The first captured stderr line carrying a quota/usage-limit signal. Gemini prints the real reason for a dead turn
+    * — e.g. `TerminalQuotaError: You have exhausted your capacity on this model. Your quota will reset after 21h1m53s.`
+    * — to stderr only, while stdout gets a catch-all error event or nothing at all; this line is what lets
+    * [[UsageLimits.classify]] type the failure (with a concrete reset time) instead of burning retries.
+    */
+  private[providers] def quotaDiagnostic(stderr: Chunk[String]): Option[String] =
+    stderr.find(UsageLimits.isGeminiQuota).map(_.trim)
+
+  /** Fold the stderr quota diagnostic (when one exists) into a fatal stream event's message, so downstream
+    * classification sees gemini's real reason instead of the stdout catch-all. Events whose message already carries a
+    * quota signal pass through unchanged; non-fatal events pass through unchanged.
+    */
+  private[providers] def withStderrDiagnostic(
+    event: GeminiCliStreamEvent,
+    stderr: Chunk[String],
+  ): GeminiCliStreamEvent =
+    quotaDiagnostic(stderr) match
+      case None       => event
+      case Some(diag) =>
+        def merged(base: Option[String]): Option[String] =
+          base.map(_.trim).filter(_.nonEmpty) match
+            case Some(m) if UsageLimits.isGeminiQuota(m) => Some(m)
+            case Some(m)                                 => Some(s"$m — $diag")
+            case None                                    => Some(diag)
+        event match
+          case GeminiCliStreamEvent.Error(message, code, errorType)                                 =>
+            GeminiCliStreamEvent.Error(merged(message), code, errorType)
+          case GeminiCliStreamEvent.Result(status, errorMessage, stats) if status.contains("error") =>
+            GeminiCliStreamEvent.Result(status, merged(errorMessage), stats)
+          case other                                                                                => other
+
+  /** Exit-time validation for the stream path, over the captured stderr. Two shapes beyond [[validateExitCode]]:
+    *   - quota exhaustion with a nonzero exit → the typed usage-limit error, not a generic ProviderError;
+    *   - quota exhaustion with exit 0 and NO assistant text → gemini died of quota but "succeeded": without this the
+    *     empty stream surfaces downstream as a retriable "empty response" and burns the whole flaky-retry + auto-resume
+    *     budget against a wall that will not move for hours.
+    * Exits 42/53 keep their specific meanings (rejected input / turn limit) regardless of stderr.
+    */
+  private[providers] def validateStreamExit(
+    exitCode: Int,
+    stderr: Chunk[String],
+    sawAssistantText: Boolean,
+    turnLimit: Option[Int],
+  ): IO[LlmError, Unit] =
+    def classifiedQuota(diag: String): IO[LlmError, Nothing] =
+      Clock.instant.flatMap { now =>
+        val err = UsageLimits
+          .classify("gemini", diag, now, ZoneId.systemDefault)
+          .getOrElse(LlmError.UsageLimitError(resetAt = None, provider = "gemini", message = diag))
+        ZIO.logWarning(s"Gemini CLI quota exhausted (from stderr): $diag") *> ZIO.fail(err)
+      }
+    val stderrText                                           = stderr.mkString("\n").trim
+    exitCode match
+      case 0       =>
+        quotaDiagnostic(stderr) match
+          case Some(diag) if !sawAssistantText => classifiedQuota(diag)
+          case _                               => ZIO.unit
+      case 42 | 53 =>
+        validateExitCode(
+          exitCode,
+          if stderrText.nonEmpty then stderrText else s"Gemini stream process exited with code $exitCode",
+          turnLimit,
+        )
+      case _       =>
+        quotaDiagnostic(stderr) match
+          case Some(diag) => classifiedQuota(diag)
+          case None       =>
+            validateExitCode(
+              exitCode,
+              if stderrText.nonEmpty then stderrText else s"Gemini stream process exited with code $exitCode",
+              turnLimit,
+            )
 
   /** Environment variables injected into every spawned gemini process.
     *
@@ -188,38 +272,58 @@ object GeminiCliExecutor:
       ): ZStream[Any, LlmError, GeminiCliStreamEvent] =
         ZStream.unwrapScoped {
           for
-            _       <- ZIO.logDebug(
-                         s"Starting Gemini stream: ${geminiArgv(config, executionContext, "stream-json").mkString(" ")}"
-                       )
-            process <- geminiCmd(prompt, config, executionContext, "stream-json").run.mapError(startError)
-            // Drain stderr: benign chatter at debug, anything else at WARN (so a stderr-only failure isn't lost).
-            // Killing the child first on teardown (finalizer below, registered last ⇒ runs first) closes this stream
-            // so the drain fiber can never wedge scope shutdown.
-            _       <- process.stderr.linesStream
-                         .foreach(line =>
-                           val shown = line.take(500) + (if line.length > 500 then "..." else "")
-                           if GeminiCliProvider.isKnownStderrNoise(line) then ZIO.logDebug(s"Gemini stderr: $shown")
-                           else ZIO.logWarning(s"Gemini stderr: $shown")
-                         )
-                         .ignore
-                         .forkScoped
-            _       <- ZIO.addFinalizer(process.killForcibly.ignore)
+            _          <- ZIO.logDebug(
+                            s"Starting Gemini stream: ${geminiArgv(config, executionContext, "stream-json").mkString(" ")}"
+                          )
+            process    <- geminiCmd(prompt, config, executionContext, "stream-json").run.mapError(startError)
+            stderrRef  <- Ref.make(Chunk.empty[String])
+            sawText    <- Ref.make(false)
+            // Drain stderr: benign chatter at debug, anything else at WARN — and captured (bounded), because gemini
+            // prints the real reason for a dead turn (e.g. TerminalQuotaError with the quota reset time) to stderr
+            // only, while stdout carries a catch-all error or nothing. Killing the child first on teardown
+            // (finalizer below, registered last ⇒ runs first) closes this stream so the drain fiber can never wedge
+            // scope shutdown.
+            errDrain   <- process.stderr.linesStream
+                            .foreach { line =>
+                              val shown = line.take(500) + (if line.length > 500 then "..." else "")
+                              if GeminiCliProvider.isKnownStderrNoise(line) then ZIO.logDebug(s"Gemini stderr: $shown")
+                              else
+                                ZIO.logWarning(s"Gemini stderr: $shown") *>
+                                  stderrRef.update(c =>
+                                    if c.size < GeminiCliExecutor.stderrCaptureLimit then c :+ line else c
+                                  )
+                            }
+                            .ignore
+                            .forkScoped
+            _          <- ZIO.addFinalizer(process.killForcibly.ignore)
+            // Fatal events and the exit check consult stderr for the quota diagnostic; the write races the stdout
+            // pipe, so give the drain a moment to reach EOF (gemini exits right after a fatal error) before reading.
+            awaitStderr = errDrain.join.timeout(2.seconds).ignore
           yield process.stdout.linesStream
             .mapError(e => LlmError.ProviderError(s"Failed to read gemini stream output: ${e.getMessage}", Some(e)))
             .tap(line =>
               ZIO.logDebug(s"Gemini stream output: ${line.take(500)}${if line.length > 500 then "..." else ""}")
             )
-            .map(GeminiCliProvider.parseStreamEvent) ++
+            .map(GeminiCliProvider.parseStreamEvent)
+            .mapZIO {
+              case msg @ GeminiCliStreamEvent.Message(role, content, _)
+                   if role.exists(_.equalsIgnoreCase("assistant")) && content.exists(_.trim.nonEmpty) =>
+                sawText.set(true).as(msg)
+              case err: GeminiCliStreamEvent.Error                                             =>
+                awaitStderr *> stderrRef.get.map(GeminiCliExecutor.withStderrDiagnostic(err, _))
+              case res @ GeminiCliStreamEvent.Result(status, _, _) if status.contains("error") =>
+                awaitStderr *> stderrRef.get.map(GeminiCliExecutor.withStderrDiagnostic(res, _))
+              case other                                                                       => ZIO.succeed(other)
+            } ++
             ZStream.fromZIO(
-              process.exitCode
-                .mapError(e => LlmError.ProviderError(s"Process wait failed: ${e.getMessage}", Some(e)))
-                .flatMap(exit =>
-                  GeminiCliExecutor.validateExitCode(
-                    exit.code,
-                    s"Gemini stream process exited with code ${exit.code}",
-                    executionContext.turnLimit,
-                  )
-                )
+              for
+                exit    <- process.exitCode
+                             .mapError(e => LlmError.ProviderError(s"Process wait failed: ${e.getMessage}", Some(e)))
+                _       <- awaitStderr // process is gone; let the capture reach EOF before reading
+                stderr  <- stderrRef.get
+                hadText <- sawText.get
+                _       <- GeminiCliExecutor.validateStreamExit(exit.code, stderr, hadText, executionContext.turnLimit)
+              yield ()
             ).drain
         }
     }
@@ -353,6 +457,12 @@ object GeminiCliProvider:
     val l = line.trim
     l.isEmpty ||
     l.contains("256-color support not detected") ||
+    l.contains("color support detected") || // "Warning: Limited color support detected (TERM=...)"
+    l.contains("support not detected") ||   // "True color (24-bit) support not detected..."
+    l.contains("tmux") ||                   // the ~/.tmux.conf suggestion lines that follow
+    l.startsWith("set -g ") ||              // tmux.conf snippet continuation
+    l.startsWith("set -ga ") ||
+    l.startsWith("Ripgrep is not available") ||
     l.startsWith("YOLO mode is enabled") ||
     l.startsWith("Shell cwd was reset to") ||
     l.startsWith("Loaded cached") ||
@@ -433,11 +543,20 @@ object GeminiCliProvider:
                 case GeminiCliStreamEvent.LogLine(line)                                                   =>
                   ZIO.logTrace(s"Gemini stream non-JSON output: ${line.trim}")
                 case GeminiCliStreamEvent.Init(model, sessionId)                                          =>
+                  // A session serving a different model than the one we passed with -m (CLI routing / fallback /
+                  // user settings) is exactly the "I asked for flash, why is it burning pro quota?" surprise —
+                  // surface it at WARN instead of burying it at debug.
                   ZIO.logDebug(
                     s"Gemini stream initialized${model.fold("")(m =>
                         s" with model=$m"
                       )}${sessionId.fold("")(id => s", session=$id")}"
-                  )
+                  ) *>
+                    ZIO.foreachDiscard(model.filter(m => !m.equalsIgnoreCase(config.model)))(m =>
+                      ZIO.logWarning(
+                        s"Gemini CLI is serving model '$m' but '${config.model}' was requested — " +
+                          "the CLI routed or fell back (check `gemini` settings and model quota)"
+                      )
+                    )
                 case GeminiCliStreamEvent.Message(role, _, delta)                                         =>
                   ZIO.logDebug(s"Gemini stream message event role=${role.getOrElse("unknown")}, delta=$delta")
                 case GeminiCliStreamEvent.ToolUse(toolName, toolId, _)                                    =>

--- a/modules/llm4zio-core/src/main/scala/llm4zio/providers/UsageLimits.scala
+++ b/modules/llm4zio-core/src/main/scala/llm4zio/providers/UsageLimits.scala
@@ -13,9 +13,14 @@ import llm4zio.core.LlmError
   */
 object UsageLimits:
 
-  private val codexAt   = """(?i)try again at\s+(\d{1,2}:\d{2}\s*[AP]M)""".r.unanchored
-  private val claudeAt  = """(?i)usage limit.*?(?:resets?|try again) at\s+(\d{1,2}(?::\d{2})?\s*[ap]m)""".r.unanchored
-  private val geminiSec = """(?i)reset after\s+(\d+)\s*s""".r.unanchored
+  private val codexAt         = """(?i)try again at\s+(\d{1,2}:\d{2}\s*[AP]M)""".r.unanchored
+  private val claudeAt        = """(?i)usage limit.*?(?:resets?|try again) at\s+(\d{1,2}(?::\d{2})?\s*[ap]m)""".r.unanchored
+  // Gemini reset durations are composite: "reset after 2s", "reset after 45m", "reset after 21h1m53s".
+  private val geminiReset     = """(?i)reset after\s+((?:\d+(?:ms|[dhms]))+)""".r.unanchored
+  private val resetComponent  = """(\d+)(ms|[dhms])""".r
+  // Below this a reset is a rate blip worth riding out in-place (RateLimitError → TransientRetry's backoff);
+  // above it it's a quota window that only a wait-until-reset layer (or a human) can handle (UsageLimitError).
+  private val shortResetLimit = Duration.fromSeconds(120)
 
   def classify(provider: String, text: String, now: Instant, zone: ZoneId): Option[LlmError] =
     provider match
@@ -24,21 +29,37 @@ object UsageLimits:
         wallClock(text, claudeAt, now, zone).map(at => LlmError.UsageLimitError(Some(at), provider, text))
       case "gemini" =>
         text match
-          // Most specific first: an explicit "reset after Ns" yields a concrete wait duration.
-          case geminiSec(secs)          => Some(LlmError.RateLimitError(Some(Duration.fromSeconds(secs.toLong))))
+          // Most specific first: an explicit "reset after <duration>" yields a concrete wait.
+          case geminiReset(spec)        =>
+            val d = resetDuration(spec)
+            if d.compareTo(shortResetLimit) <= 0 then Some(LlmError.RateLimitError(Some(d)))
+            else Some(LlmError.UsageLimitError(resetAt = Some(now.plus(d)), provider = "gemini", message = text))
           case _ if isGeminiQuota(text) =>
             // Capacity/quota exhaustion without a duration: resetAt = None so wait-layers fall back to pollInterval.
             Some(LlmError.UsageLimitError(resetAt = None, provider = "gemini", message = text))
           case _                        => None
       case _        => None
 
+  private def resetDuration(spec: String): Duration =
+    resetComponent.findAllMatchIn(spec).foldLeft(Duration.Zero) { (acc, m) =>
+      val n      = m.group(1).toLong
+      val millis = m.group(2).toLowerCase(Locale.US) match
+        case "d" => n * 86400_000
+        case "h" => n * 3600_000
+        case "m" => n * 60_000
+        case "s" => n * 1000
+        case _   => n // "ms"
+      acc.plus(Duration.fromMillis(millis))
+    }
+
   /** Case-insensitive substring check for gemini quota/capacity exhaustion signals. The ambiguous catch-all ("an
     * unknown error occurred") deliberately matches none of these so it stays an (unclassified) transient error.
+    * `private[providers]` so the gemini executor can spot the quota diagnostics the CLI prints only to stderr.
     */
   private val geminiQuotaSignals =
     List("exhausted your capacity", "quota", "resource_exhausted", "rate_limit", "rate limit", "429")
 
-  private def isGeminiQuota(text: String): Boolean =
+  private[providers] def isGeminiQuota(text: String): Boolean =
     val lower = text.toLowerCase(Locale.US)
     geminiQuotaSignals.exists(lower.contains)
 

--- a/modules/llm4zio-core/src/test/scala/llm4zio/providers/GeminiCliProviderSpec.scala
+++ b/modules/llm4zio-core/src/test/scala/llm4zio/providers/GeminiCliProviderSpec.scala
@@ -500,6 +500,198 @@ object GeminiCliProviderSpec extends ZIOSpecDefault:
         !GeminiCliProvider.isKnownStderrNoise("Error: connection refused"),
       )
     },
+    test("isKnownStderrNoise filters terminal-cosmetics and ripgrep chatter (real gemini 0.45 stderr)") {
+      assertTrue(
+        GeminiCliProvider.isKnownStderrNoise(
+          "Warning: Limited color support detected (TERM=screen). Some visual elements may not render correctly."
+        ),
+        GeminiCliProvider.isKnownStderrNoise("in tmux, add to ~/.tmux.conf:"),
+        GeminiCliProvider.isKnownStderrNoise("""      set -g default-terminal "tmux-256color""""),
+        GeminiCliProvider.isKnownStderrNoise("""      set -ga terminal-overrides ",*256col*:Tc""""),
+        GeminiCliProvider.isKnownStderrNoise(
+          "Warning: True color (24-bit) support not detected. Using a terminal with true color enabled..."
+        ),
+        GeminiCliProvider.isKnownStderrNoise("Ripgrep is not available. Falling back to GrepTool."),
+        // the quota diagnostic must NEVER be classified as noise — it is the only place the real reason appears
+        !GeminiCliProvider.isKnownStderrNoise(
+          "Error when talking to Gemini API Full report available at: /tmp/x.json TerminalQuotaError: " +
+            "You have exhausted your capacity on this model. Your quota will reset after 21h1m53s."
+        ),
+      )
+    },
+    suite("stderr quota diagnostics")(
+      {
+        val quotaLine  =
+          "Error when talking to Gemini API Full report available at: /tmp/gemini-client-error.json " +
+            "TerminalQuotaError: You have exhausted your capacity on this model. Your quota will reset after 21h1m53s."
+        val stackLines = Chunk(
+          "    at classifyGoogleError (file:///root/.nvm/versions/node/v24.15.0/lib/node_modules/...js:297639:18)",
+          "    at retryWithBackoff (file:///root/.nvm/versions/node/v24.15.0/lib/node_modules/...js:298310:31)",
+        )
+        Seq(
+          test("quotaDiagnostic finds the TerminalQuotaError line among stack-trace noise") {
+            assertTrue(
+              GeminiCliExecutor.quotaDiagnostic(stackLines.prepended(quotaLine)) == Some(quotaLine),
+              GeminiCliExecutor.quotaDiagnostic(stackLines).isEmpty,
+              GeminiCliExecutor.quotaDiagnostic(Chunk.empty).isEmpty,
+            )
+          },
+          test("withStderrDiagnostic folds the quota reason into the stdout catch-all error event") {
+            val catchAll = GeminiCliStreamEvent.Error(
+              message = Some("[API Error: An unknown error occurred.]"),
+              code = None,
+              errorType = None,
+            )
+            GeminiCliExecutor.withStderrDiagnostic(catchAll, stackLines.prepended(quotaLine)) match
+              case GeminiCliStreamEvent.Error(Some(msg), _, _) =>
+                assertTrue(
+                  msg.contains("An unknown error occurred"),
+                  msg.contains("exhausted your capacity"),
+                  msg.contains("reset after 21h1m53s"),
+                )
+              case _                                           => assertTrue(false)
+          },
+          test("withStderrDiagnostic folds the quota reason into an error result event") {
+            val errResult = GeminiCliStreamEvent.Result(status = Some("error"), errorMessage = None, stats = None)
+            GeminiCliExecutor.withStderrDiagnostic(errResult, Chunk(quotaLine)) match
+              case GeminiCliStreamEvent.Result(_, Some(msg), _) => assertTrue(msg.contains("exhausted your capacity"))
+              case _                                            => assertTrue(false)
+          },
+          test("withStderrDiagnostic leaves events alone when stderr carries no quota signal") {
+            val catchAll = GeminiCliStreamEvent.Error(Some("[API Error: An unknown error occurred.]"), None, None)
+            assertTrue(GeminiCliExecutor.withStderrDiagnostic(catchAll, stackLines) == catchAll)
+          },
+          test("withStderrDiagnostic does not double up an already quota-flavoured message") {
+            val quotaErr =
+              GeminiCliStreamEvent.Error(Some("You have exhausted your capacity on this model."), None, None)
+            assertTrue(GeminiCliExecutor.withStderrDiagnostic(quotaErr, Chunk(quotaLine)) == quotaErr)
+          },
+          test(
+            "validateStreamExit: exit 0 with quota stderr and NO assistant text fails with UsageLimitError + resetAt"
+          ) {
+            for
+              result <- GeminiCliExecutor
+                          .validateStreamExit(0, Chunk(quotaLine), sawAssistantText = false, turnLimit = None)
+                          .exit
+            yield assertTrue(
+              result.causeOption.flatMap(_.failureOption).exists {
+                case LlmError.UsageLimitError(resetAt, "gemini", msg) =>
+                  resetAt.isDefined && msg.contains("exhausted your capacity")
+                case _                                                => false
+              }
+            )
+          },
+          test("validateStreamExit: exit 0 with quota stderr but assistant text seen succeeds (fallback worked)") {
+            for
+              result <- GeminiCliExecutor
+                          .validateStreamExit(0, Chunk(quotaLine), sawAssistantText = true, turnLimit = None)
+                          .exit
+            yield assertTrue(result == Exit.succeed(()))
+          },
+          test("validateStreamExit: clean exit 0 without quota stderr succeeds") {
+            for
+              result <-
+                GeminiCliExecutor.validateStreamExit(0, stackLines, sawAssistantText = false, turnLimit = None).exit
+            yield assertTrue(result == Exit.succeed(()))
+          },
+          test("validateStreamExit: nonzero exit with quota stderr fails with the typed usage-limit error") {
+            for
+              result <- GeminiCliExecutor
+                          .validateStreamExit(1, Chunk(quotaLine), sawAssistantText = false, turnLimit = None)
+                          .exit
+            yield assertTrue(
+              result.causeOption.flatMap(_.failureOption).exists {
+                case _: LlmError.UsageLimitError => true
+                case _                           => false
+              }
+            )
+          },
+          test("validateStreamExit: nonzero exit without quota stderr surfaces the captured stderr in the error") {
+            for
+              result <-
+                GeminiCliExecutor
+                  .validateStreamExit(1, Chunk("something exploded"), sawAssistantText = false, turnLimit = None)
+                  .exit
+            yield assertTrue(
+              result.causeOption.flatMap(_.failureOption).exists {
+                case LlmError.ProviderError(msg, _) => msg.contains("something exploded")
+                case _                              => false
+              }
+            )
+          },
+          test("validateStreamExit: exit 53 keeps its turn-limit meaning even with quota-looking stderr") {
+            for
+              result <- GeminiCliExecutor
+                          .validateStreamExit(53, Chunk(quotaLine), sawAssistantText = false, turnLimit = Some(3))
+                          .exit
+            yield assertTrue(
+              result.causeOption.flatMap(_.failureOption).contains(LlmError.TurnLimitError(Some(3)))
+            )
+          },
+        )
+      }*
+    ),
+    test("executeStream classifies a quota error event with a long reset into UsageLimitError with resetAt") {
+      val config   = LlmConfig(provider = LlmProvider.GeminiCli, model = "gemini-2.5-pro")
+      val executor = new MockGeminiCliExecutor(
+        streamEvents = List(
+          GeminiCliStreamEvent.Error(
+            message = Some(
+              "[API Error: An unknown error occurred.] — TerminalQuotaError: You have exhausted your capacity " +
+                "on this model. Your quota will reset after 21h1m53s."
+            ),
+            code = None,
+            errorType = None,
+          )
+        )
+      )
+      val provider = GeminiCliProvider.make(config, executor)
+      for
+        result <- provider.executeStream("hi").runCollect.exit
+      yield assertTrue(
+        result.causeOption.exists(_.failures.exists {
+          case LlmError.UsageLimitError(resetAt, "gemini", _) => resetAt.isDefined
+          case _                                              => false
+        })
+      )
+    },
+    test("executeStream warns when the CLI serves a different model than requested") {
+      val config   = LlmConfig(provider = LlmProvider.GeminiCli, model = "gemini-2.5-flash")
+      val executor = new MockGeminiCliExecutor(
+        streamEvents = List(
+          GeminiCliStreamEvent.Init(model = Some("gemini-2.5-pro"), sessionId = Some("s1")),
+          GeminiCliStreamEvent.Message(role = Some("assistant"), content = Some("hi"), delta = true),
+          GeminiCliStreamEvent.Result(status = Some("success"), errorMessage = None, stats = None),
+        )
+      )
+      val provider = GeminiCliProvider.make(config, executor)
+      (for
+        _    <- provider.executeStream("hi").runDrain
+        logs <- ZTestLogger.logOutput
+      yield assertTrue(
+        logs.exists(e =>
+          e.logLevel == LogLevel.Warning &&
+          e.message().contains("serving model 'gemini-2.5-pro'") &&
+          e.message().contains("gemini-2.5-flash")
+        )
+      )).provideLayer(ZTestLogger.default)
+    },
+    test("executeStream does not warn when the served model matches the requested one") {
+      val config   = LlmConfig(provider = LlmProvider.GeminiCli, model = "gemini-2.5-flash")
+      val executor = new MockGeminiCliExecutor(
+        streamEvents = List(
+          GeminiCliStreamEvent.Init(model = Some("gemini-2.5-flash"), sessionId = Some("s1")),
+          GeminiCliStreamEvent.Result(status = Some("success"), errorMessage = None, stats = None),
+        )
+      )
+      val provider = GeminiCliProvider.make(config, executor)
+      (for
+        _    <- provider.executeStream("hi").runDrain
+        logs <- ZTestLogger.logOutput
+      yield assertTrue(
+        !logs.exists(e => e.logLevel == LogLevel.Warning && e.message().contains("serving model"))
+      )).provideLayer(ZTestLogger.default)
+    },
     test("a JSON-looking but unparseable stream line is logged at WARN, not lost at trace") {
       val config   = LlmConfig(provider = LlmProvider.GeminiCli, model = "gemini-2.5-pro")
       val executor = new MockGeminiCliExecutor(

--- a/modules/llm4zio-core/src/test/scala/llm4zio/providers/UsageLimitsSpec.scala
+++ b/modules/llm4zio-core/src/test/scala/llm4zio/providers/UsageLimitsSpec.scala
@@ -31,6 +31,35 @@ object UsageLimitsSpec extends ZIOSpecDefault:
         case Some(LlmError.RateLimitError(Some(d))) => assertTrue(d == zio.Duration.fromSeconds(2))
         case _                                      => assertTrue(false)
     },
+    test("gemini composite 'reset after 21h1m53s' → UsageLimitError with a concrete resetAt") {
+      // The real TerminalQuotaError line gemini prints to stderr when a model's daily quota is exhausted.
+      val text =
+        "Error when talking to Gemini API Full report available at: /tmp/gemini-client-error.json " +
+          "TerminalQuotaError: You have exhausted your capacity on this model. Your quota will reset after 21h1m53s."
+      UsageLimits.classify("gemini", text, now, zone) match
+        case Some(LlmError.UsageLimitError(Some(at), "gemini", msg)) =>
+          assertTrue(at == now.plusSeconds(21L * 3600 + 60 + 53), msg == text)
+        case _                                                       => assertTrue(false)
+    },
+    test("gemini 'reset after 45m' → UsageLimitError (beyond the short-reset window)") {
+      val text = "You have exhausted your capacity on this model. Your quota will reset after 45m."
+      UsageLimits.classify("gemini", text, now, zone) match
+        case Some(LlmError.UsageLimitError(Some(at), "gemini", _)) =>
+          assertTrue(at == now.plusSeconds(45L * 60))
+        case _                                                     => assertTrue(false)
+    },
+    test("gemini 'reset after 90s' stays a short RateLimitError") {
+      val text = "Your quota will reset after 90s."
+      UsageLimits.classify("gemini", text, now, zone) match
+        case Some(LlmError.RateLimitError(Some(d))) => assertTrue(d == zio.Duration.fromSeconds(90))
+        case _                                      => assertTrue(false)
+    },
+    test("gemini 'reset after 500ms' is not misread as 500 minutes") {
+      val text = "Your quota will reset after 500ms."
+      UsageLimits.classify("gemini", text, now, zone) match
+        case Some(LlmError.RateLimitError(Some(d))) => assertTrue(d == zio.Duration.fromMillis(500))
+        case _                                      => assertTrue(false)
+    },
     test("gemini 'exhausted your capacity' (no reset) → UsageLimitError, resetAt None") {
       val text = "You have exhausted your capacity on this model."
       UsageLimits.classify("gemini", text, now, zone) match

--- a/modules/llm4zio-flow/src/main/scala/llm4zio/flow/TransientRetry.scala
+++ b/modules/llm4zio-flow/src/main/scala/llm4zio/flow/TransientRetry.scala
@@ -41,7 +41,8 @@ final class TransientRetry(
         case e if TransientRetry.isFlakyStream(e) && fN < flakyRetries =>
           notice(s"flaky $what (fresh retry)", fN, flakyRetries, e) *> ZIO.sleep(flakyDelay) *> loop(tN, fN + 1)
         case e if TransientRetry.isTransient(e) && tN < maxRetries     =>
-          notice(s"transient error ($what)", tN, maxRetries, e) *> ZIO.sleep(backoff(tN)) *> loop(tN + 1, fN)
+          notice(s"transient error ($what)", tN, maxRetries, e) *>
+            ZIO.sleep(TransientRetry.transientDelay(e, backoff(tN))) *> loop(tN + 1, fN)
       }
     loop(0, 0)
 
@@ -52,7 +53,10 @@ final class TransientRetry(
           ZStream.fromZIO(notice(s"flaky $what (fresh retry)", fN, flakyRetries, e) *> ZIO.sleep(flakyDelay)).drain ++
             loop(tN, fN + 1)
         case e if TransientRetry.isTransient(e) && tN < maxRetries     =>
-          ZStream.fromZIO(notice(s"transient error ($what)", tN, maxRetries, e) *> ZIO.sleep(backoff(tN))).drain ++
+          ZStream.fromZIO(
+            notice(s"transient error ($what)", tN, maxRetries, e) *>
+              ZIO.sleep(TransientRetry.transientDelay(e, backoff(tN)))
+          ).drain ++
             loop(tN + 1, fN)
       }
     loop(0, 0)
@@ -78,6 +82,22 @@ final class TransientRetry(
   override def isAvailable: UIO[Boolean] = underlying.isAvailable
 
 object TransientRetry:
+
+  /** Longest provider-named `retryAfter` honored before a transient retry. Longer waits are usage-cap territory —
+    * classified as [[LlmError.UsageLimitError]] and handled by the wait layers — so the cap only guards against a
+    * pathological header stalling the flow.
+    */
+  private val maxHonoredRetryAfter: Duration = 2.minutes
+
+  /** The wait before a transient retry: the exponential backoff, unless the provider named a longer `retryAfter` (e.g.
+    * gemini "quota will reset after 45s") — sleeping 1s+2s+4s against a 45s window burns the whole retry budget on
+    * failures that were never going to succeed.
+    */
+  def transientDelay(e: LlmError, backoff: Duration): Duration = e match
+    case LlmError.RateLimitError(Some(retryAfter)) =>
+      val honored = if retryAfter.compareTo(maxHonoredRetryAfter) > 0 then maxHonoredRetryAfter else retryAfter
+      if honored.compareTo(backoff) > 0 then honored else backoff
+    case _                                         => backoff
 
   /** Flaky-stream class: gemini intermittently closes the stream with no candidates or a half-formed function call.
     * Non-deterministic; a fresh process (which a retried stream spawns) almost always succeeds, so this gets its own,

--- a/modules/llm4zio-flow/src/test/scala/llm4zio/flow/TransientRetrySpec.scala
+++ b/modules/llm4zio-flow/src/test/scala/llm4zio/flow/TransientRetrySpec.scala
@@ -67,6 +67,40 @@ object TransientRetrySpec extends ZIOSpecDefault:
         )
       },
     ),
+    suite("transientDelay")(
+      test("honors a provider-named retryAfter longer than the backoff (gemini 'reset after 45s')") {
+        assertTrue(
+          TransientRetry.transientDelay(LlmError.RateLimitError(Some(45.seconds)), 1.second) == 45.seconds
+        )
+      },
+      test("keeps the backoff when it is already longer than retryAfter") {
+        assertTrue(TransientRetry.transientDelay(LlmError.RateLimitError(Some(1.second)), 4.seconds) == 4.seconds)
+      },
+      test("caps a pathological retryAfter at two minutes") {
+        assertTrue(TransientRetry.transientDelay(LlmError.RateLimitError(Some(21.hours)), 1.second) == 2.minutes)
+      },
+      test("non-rate-limit transients use the plain backoff") {
+        assertTrue(
+          TransientRetry.transientDelay(LlmError.ProviderError("connection reset", None), 3.seconds) == 3.seconds,
+          TransientRetry.transientDelay(LlmError.RateLimitError(None), 3.seconds) == 3.seconds,
+        )
+      },
+    ),
+    test("a usage-limit failure fails straight through — no transient or flaky retries, no notices") {
+      // A quota-exhausted provider (e.g. gemini "quota will reset after 21h") cannot be retried back to life;
+      // the typed UsageLimitError must reach the wait layers (LLM4ZIO_USAGE_WAIT) or the user immediately.
+      for
+        events          <- FlowEvents.collecting
+        given FlowEvents = events
+        attempts        <- Ref.make(0)
+        cap              = LlmError.UsageLimitError(None, "gemini", "You have exhausted your capacity on this model.")
+        svc              = FlakyService(attempts, failTimes = 99, cap)
+        retry            = TransientRetry(svc, maxRetries = 3, baseDelay = Duration.Zero)
+        result          <- retry.executeStream("hi").runCollect.exit
+        tries           <- attempts.get
+        infos           <- events.recorded
+      yield assertTrue(result.isFailure, tries == 1, infos.isEmpty)
+    },
     test("retries a transient stream failure then succeeds, emitting a visible retry notice each time") {
       for
         events          <- FlowEvents.collecting

--- a/modules/llm4zio-runner/src/main/scala/llm4zio/runner/Llm4zio.scala
+++ b/modules/llm4zio-runner/src/main/scala/llm4zio/runner/Llm4zio.scala
@@ -28,14 +28,18 @@ object Llm4zio:
       .map(_.message)
       .orElse(cause.dieOption.map(_.getMessage))
       .getOrElse(if cause.isInterrupted then "interrupted" else "unknown error")
-    base + geminiCatchAllHint(base)
+    base + failureHint(base)
 
-  // gemini repeatedly returns a generic catch-all ("an unknown error occurred") for what is usually
-  // quota/rate-limit exhaustion. classify() leaves it unclassified (a transient ProviderError), so the
-  // typed error stays unchanged — here, purely presentationally, we append an actionable hint.
-  private def geminiCatchAllHint(message: String): String =
+  // Purely presentational, appended to the ✖ banner (the typed error stays unchanged):
+  //   - a classified quota/usage-limit failure gets the two actionable ways out (wait, or switch model);
+  //   - gemini's generic catch-all ("an unknown error occurred") — usually quota/rate-limit exhaustion the CLI
+  //     didn't attribute — gets the same pointer, hedged.
+  private def failureHint(message: String): String =
     val lower = message.toLowerCase
-    if lower.contains("an unknown error occurred") then
+    if lower.contains("exhausted your capacity") || lower.contains("usage limit") || lower.contains("quota") then
+      " — provider quota/usage limit exhausted. Set LLM4ZIO_USAGE_WAIT (e.g. 24h) to wait out the reset and " +
+        "resume, or point the flow at a model with remaining quota."
+    else if lower.contains("an unknown error occurred") then
       " — gemini repeatedly returned its catch-all error; this is often quota/rate-limit exhaustion." +
         " Check your gemini quota, or set LLM4ZIO_USAGE_WAIT to wait and resume."
     else ""

--- a/modules/llm4zio-runner/src/test/scala/llm4zio/runner/BannerSpec.scala
+++ b/modules/llm4zio-runner/src/test/scala/llm4zio/runner/BannerSpec.scala
@@ -30,4 +30,17 @@ object BannerSpec extends ZIOSpecDefault:
       val msg = Llm4zio.failMessage(Cause.fail(FlowError.Llm("something else broke", None)))
       assertTrue(!msg.toLowerCase.contains("quota"), !msg.contains("LLM4ZIO_USAGE_WAIT"))
     },
+    test("failMessage appends the wait-or-switch hint for a classified quota exhaustion") {
+      val msg = Llm4zio.failMessage(
+        Cause.fail(FlowError.Llm(
+          "You have exhausted your capacity on this model. Your quota will reset after 21h1m53s.",
+          None,
+        ))
+      )
+      assertTrue(
+        msg.contains("exhausted your capacity"),
+        msg.contains("LLM4ZIO_USAGE_WAIT"),
+        msg.contains("remaining quota"),
+      )
+    },
   )


### PR DESCRIPTION
Gemini CLI reports quota exhaustion (TerminalQuotaError: "You have exhausted
your capacity on this model. Your quota will reset after 21h1m53s.", 429
QUOTA_EXHAUSTED) only on stderr, while stdout carries the catch-all
"[API Error: An unknown error occurred.]" or nothing at all. llm4zio logged
the stderr at WARN and dropped it, so the flow burned the transient budget
(3x), the flaky "empty response" budget (6x), and auto-resume re-entries
against a wall that would not move for ~21 hours — with no visible reason.

- GeminiCliExecutor.runGeminiProcessStream now captures non-noise stderr
  (bounded), folds the quota diagnostic into fatal Error/error-Result events
  (withStderrDiagnostic), and validates the exit over the captured stderr
  (validateStreamExit): a quota-driven death — even an exit-0 empty stream —
  fails with the typed LlmError.UsageLimitError instead of a retriable blob.
  Nonzero exits also surface the real stderr text instead of a generic code.
- UsageLimits.classify parses composite gemini reset durations (21h1m53s,
  45m, 500ms): short resets stay RateLimitError, longer ones become
  UsageLimitError with a concrete resetAt, so LLM4ZIO_USAGE_WAIT sleeps until
  the actual reset. TransientRetry does not retry UsageLimitError, and now
  honors a provider-named retryAfter (capped at 2m) over its backoff.
- Model visibility: the stream init event's serving model is compared against
  the requested one and a WARN is logged on mismatch — makes "I pinned flash
  but pro quota is burning" diagnosable (the -m flag was and is passed
  through; routing/fallback happens inside the CLI).
- UX: the ✖ banner appends a wait-or-switch-model hint for quota failures;
  gemini's tmux/color/ripgrep stderr chatter is filtered to debug.
- Docs: quota-exhaustion section in docs/legacy-modernization.md and a note
  in modernize-extract.sc's header.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Q8N4SebEKTx6AG2fQvBMcN