### PR TITLE
ci: bump actions to Node 24-native majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,6 @@ on:
 permissions:
   contents: write
 
-# Opt the JS-based actions into Node 24 ahead of the Node 20 removal (GitHub
-# Actions deprecation, 2025). Avoids the deprecation warnings on checkout/
-# setup-java/import-gpg without pinning specific action major versions.
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   test:
     name: Test
@@ -29,12 +23,12 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '21'
@@ -58,12 +52,12 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '21'
@@ -73,7 +67,7 @@ jobs:
         uses: sbt/setup-sbt@v1
 
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v6
+        uses: crazy-max/ghaction-import-gpg@v7
         with:
           gpg_private_key: ${{ secrets.PGP_SECRET }}
           passphrase: ${{ secrets.PGP_PASSPHRASE }}


### PR DESCRIPTION
Every CI run annotates "Node.js 20 is deprecated" for `actions/checkout@v4`, `actions/setup-java@v4`, and `crazy-max/ghaction-import-gpg@v6`. The existing `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env forced them onto Node 24, but GitHub still flags the forcing itself.

- `actions/checkout` v4 → v5 (the Node 24 release; deliberately not v6/v7 to avoid unrelated major-version behavior changes)
- `actions/setup-java` v4 → v5
- `crazy-max/ghaction-import-gpg` v6 → v7
- drop the now-moot `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env and its stale comment

`ncipollo/release-action@v1` was not flagged and stays. Note the publish job's import-gpg bump only exercises on the next `v*` tag; this PR's run verifies checkout/setup-java in the test job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)