### PR TITLE
Wave 2 — ace-kafka: event-stream equivalence with per-key ordering (v3.24.0)

### DIFF
--- a/docs/legacy-modernization.md
+++ b/docs/legacy-modernization.md
@@ -40,6 +40,7 @@ seeding (default `cobol-springboot`):
 | `jsp-nextjs` | J2EE servlets + JSP | client-only Next.js SPA (S3 static export) |
 | `jsp-bff-nextjs` | J2EE servlets + JSP | Spring Boot BFF + Next.js SPA monorepo |
 | `ace-integration` | IBM ACE msgflow + ESQL | Spring Boot integration service |
+| `ace-kafka` | IBM ACE msgflow + ESQL | Kafka Streams topology (per-key equivalence, TopologyTestDriver replay) |
 
 ## The pack: modernization knowledge as data
 

--- a/examples/fixtures/scaffolds/kafka-streams-service/README.md
+++ b/examples/fixtures/scaffolds/kafka-streams-service/README.md
@@ -1,0 +1,12 @@
+# meridian-streams-scaffold
+
+Bank-provided Kafka Streams / Java 21 scaffold: the empty target that the
+llm4zio legacy-modernization flows fill in with event-streaming replacements
+for ACE message flows. Build with `mvn verify` (TopologyTestDriver only — no
+broker anywhere in the test path).
+
+The topology is built by `Application.buildTopology()`, a pure factory that
+tests and the equivalence replay harness (`scripts/replay.sh` →
+`com.meridian.replay.ReplayHarness`) drive with TopologyTestDriver. Extracted
+specs go under `docs/specs/`; BDD `.feature` files are seeded into
+`src/test/resources/features/`.

--- a/examples/fixtures/scaffolds/kafka-streams-service/pom.xml
+++ b/examples/fixtures/scaffolds/kafka-streams-service/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>3.5.3</version>
+    <relativePath/>
+  </parent>
+
+  <groupId>com.meridian</groupId>
+  <artifactId>meridian-streams-scaffold</artifactId>
+  <version>0.1.0-SNAPSHOT</version>
+  <name>meridian-streams-scaffold</name>
+  <description>Bank-provided Kafka Streams scaffold for modernized integration flows</description>
+
+  <properties>
+    <java.version>21</java.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-streams</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-streams-test-utils</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/examples/fixtures/scaffolds/kafka-streams-service/scripts/replay.sh
+++ b/examples/fixtures/scaffolds/kafka-streams-service/scripts/replay.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# The pack's replay contract: one equivalence vector as JSON on stdin, a JSON array of
+# observations on stdout — nothing else on stdout, ever (build noise goes to stderr).
+# Delegates to the ReplayHarness the implementation provides (TopologyTestDriver-backed;
+# see the pack's implement prompt).
+set -e
+cd "$(dirname "$0")/.."
+[ -d target/classes ] || mvn -q -B -DskipTests compile >&2
+[ -f target/cp.txt ] || mvn -q -B dependency:build-classpath -Dmdep.outputFile=target/cp.txt >&2
+exec java -cp "target/classes:$(cat target/cp.txt)" com.meridian.replay.ReplayHarness

--- a/examples/fixtures/scaffolds/kafka-streams-service/src/main/java/com/meridian/scaffold/Application.java
+++ b/examples/fixtures/scaffolds/kafka-streams-service/src/main/java/com/meridian/scaffold/Application.java
@@ -1,0 +1,29 @@
+package com.meridian.scaffold;
+
+import java.util.Properties;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.Topology;
+
+/**
+ * The topology lives behind a pure factory so tests and the equivalence replay harness drive it
+ * with TopologyTestDriver — no broker in the test path. The modernization tasks replace the empty
+ * builder with the flow's real stages.
+ */
+public class Application {
+
+  public static Topology buildTopology() {
+    return new StreamsBuilder().build();
+  }
+
+  public static void main(String[] args) {
+    Properties props = new Properties();
+    props.put(StreamsConfig.APPLICATION_ID_CONFIG, "meridian-streams");
+    props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG,
+        System.getenv().getOrDefault("KAFKA_BOOTSTRAP", "localhost:9092"));
+    KafkaStreams streams = new KafkaStreams(buildTopology(), props);
+    Runtime.getRuntime().addShutdownHook(new Thread(streams::close));
+    streams.start();
+  }
+}

--- a/examples/fixtures/scaffolds/kafka-streams-service/src/test/java/com/meridian/scaffold/ApplicationTests.java
+++ b/examples/fixtures/scaffolds/kafka-streams-service/src/test/java/com/meridian/scaffold/ApplicationTests.java
@@ -1,0 +1,21 @@
+package com.meridian.scaffold;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.Properties;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.TopologyTestDriver;
+import org.junit.jupiter.api.Test;
+
+class ApplicationTests {
+
+  @Test
+  void topologyBuilds() {
+    Properties props = new Properties();
+    props.put(StreamsConfig.APPLICATION_ID_CONFIG, "meridian-streams-test");
+    props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "unused:9092");
+    try (TopologyTestDriver driver = new TopologyTestDriver(Application.buildTopology(), props)) {
+      assertNotNull(driver);
+    }
+  }
+}

--- a/examples/modernize-extract.sc
+++ b/examples/modernize-extract.sc
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla::llm4zio-runner:3.23.0"
+//> using dep "io.github.riccardomerolla::llm4zio-runner:3.24.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/examples/modernize-implement.sc
+++ b/examples/modernize-implement.sc
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla::llm4zio-runner:3.23.0"
+//> using dep "io.github.riccardomerolla::llm4zio-runner:3.24.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/examples/modernize-review.sc
+++ b/examples/modernize-review.sc
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla::llm4zio-runner:3.23.0"
+//> using dep "io.github.riccardomerolla::llm4zio-runner:3.24.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/examples/modernize-seed.sc
+++ b/examples/modernize-seed.sc
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla::llm4zio-runner:3.23.0"
+//> using dep "io.github.riccardomerolla::llm4zio-runner:3.24.0"
 //> using scala "3.8.3"
 //> using jvm 21
 
@@ -44,7 +44,7 @@ import llm4zio.flow.*
 import llm4zio.runner.*
 
 val ModDir         = "docs/modernization"
-val Llm4zioVersion = "3.23.0" // keep in step with the `using dep` header pin
+val Llm4zioVersion = "3.24.0" // keep in step with the `using dep` header pin
 
 def writeFile(path: Path, content: String): IO[FlowError, Unit] =
   ZIO

--- a/examples/modernize-verify.sc
+++ b/examples/modernize-verify.sc
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla::llm4zio-runner:3.23.0"
+//> using dep "io.github.riccardomerolla::llm4zio-runner:3.24.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/examples/packs/ace-kafka/lessons.md
+++ b/examples/packs/ace-kafka/lessons.md
@@ -1,0 +1,6 @@
+- ESQL routing ladders are business policy tables in disguise: extract them into the
+  spec AS TABLES and keep them as declarative data in the target service — once they
+  dissolve into nested ifs, nobody can verify them against the source again.
+- MQ failure terminals and reject queues are part of the contract: every failure
+  path in the msgflow needs a spec rule and a scenario, or it silently disappears in
+  the port.

--- a/examples/packs/ace-kafka/pack.md
+++ b/examples/packs/ace-kafka/pack.md
@@ -1,0 +1,36 @@
+# Pack: ace-kafka
+
+source: ace
+scaffold: ../../fixtures/scaffolds/kafka-streams-service
+sources: .*\.(msgflow|esql)
+programs: .*\.(msgflow|esql)
+specs-dir: docs/specs
+features-dir: src/test/resources/features
+replay: scripts/replay.sh
+
+## Gates
+
+- build: mvn -q -B test-compile
+- test: mvn -q -B test
+- verify: mvn -q -B verify
+
+## Judge
+
+- completeness (0..2): Every node in the message flow, every routing rule, validation, reject code, interface, message mapping, and threshold/flag in the msgflow/ESQL source is captured in the specs and BDD scenarios — re-expressed as event contracts (topics, keys, event payloads); the traceability matrix accounts for every flow node and ESQL module. Score 2 only if nothing material is missing.
+- faithfulness (0..2): Every statement is grounded in the source: reject codes, routing predicates, currency lists, thresholds, flag values, and field mappings match the ESQL exactly, and nothing is invented — renaming a queue to a topic is mapping, changing its meaning is invention. Score 2 only if fully source-grounded.
+- testability (0..2): Scenarios are concrete event-in/events-out examples — specific payloads, amounts, currencies, correlation keys, and the exact output topic or reject code expected; no vague language. Score 2 only if every scenario is directly encodable as a TopologyTestDriver test.
+
+## Equivalence
+
+- ordering: per-key
+- ignore: TIMESTAMP, TS, PROCESSED_AT
+
+## Coverage: flow-node
+
+files: .*\.msgflow
+unit: <translation xmi:type="utility:ConstantString" string="([^"]+)"/>
+
+## Coverage: esql-module
+
+files: .*\.esql
+unit: ^CREATE (?:COMPUTE|FILTER|DATABASE) MODULE (\S+)

--- a/examples/packs/ace-kafka/prompts/analysis.md
+++ b/examples/packs/ace-kafka/prompts/analysis.md
@@ -1,0 +1,21 @@
+You are an ESB reverse-engineering analyst. Extract the COMPLETE observable
+behaviour of the IBM ACE (IIB) message flows in this repository into a spec pack
+precise enough that a team who never sees this source can rebuild them as Spring
+Boot integration services.
+
+How to read the estate:
+
+- The .msgflow is the topology: nodes, their types (MQInput/MQOutput/Compute),
+  their labels, and the connections — including FAILURE terminals, which are error
+  handling and must be accounted for.
+- Queue names on input/output nodes are the INTERFACES: who sends, who consumes,
+  and what each queue means downstream (a CICS request queue means the mainframe is
+  the system of record — say so).
+- The ESQL carries the logic: validation rules with their reject codes, routing
+  predicates (read every CASE/IF — including account-prefix and currency
+  conditions), field-by-field message mappings, thresholds and the flags they set.
+- Static routing tables (SHARED ROW, CASE ladders) are business policy — reproduce
+  them as tables in the spec, not prose.
+- Reject envelopes are contract: code, reason, and what wraps the original payload.
+
+Never invent behaviour. Ambiguity goes in "Open questions", not guesses.

--- a/examples/packs/ace-kafka/prompts/bdd.md
+++ b/examples/packs/ace-kafka/prompts/bdd.md
@@ -1,0 +1,13 @@
+Write Gherkin .feature files encoding the specs as executable message-in/outcome-out
+scenarios — these become the acceptance tests of the new integration service.
+
+- One feature per flow (or per coherent rule cluster within one).
+- Scenario shape: Given a payment event with concrete field values and key, When
+  the topology processes it, Then an event is emitted on <output topic> with
+  <mapped fields / flags> — or a reject event with code <code>.
+- Business vocabulary with the codes kept in the Then step (e.g. `Then the payment
+  is rejected with code V01 (unsupported currency)`).
+- Concrete values everywhere: real amounts, currencies, account numbers, IBANs.
+- Cover: every routing branch, EVERY reject code, every threshold boundary (a flag
+  at 10000.00 gets scenarios at 9999.99 and 10000.00 per its semantics), and the
+  field mappings of each destination message.

--- a/examples/packs/ace-kafka/prompts/implement.md
+++ b/examples/packs/ace-kafka/prompts/implement.md
@@ -1,0 +1,34 @@
+You implement one task at a time in a Kafka Streams / Java 21 service that replaces
+an IBM ACE message flow with an event-streaming topology. The committed specs under
+docs/specs/ and the .feature files under src/test/resources/features/ are the
+contract; the acceptance tests encode them — make them pass without weakening them.
+
+Non-negotiables when porting ESQL semantics to a topology:
+
+- Queues become topics per the spec's interface mapping: one input topic for the
+  flow's trigger, one output topic per destination (CICS bridge, SEPA gateway,
+  rejects). The event KEY is the correlation identity the spec names (the payment's
+  debtor account unless the spec says otherwise) — per-key ordering is contract.
+- Validation order and reject codes match the spec exactly — first-failure-wins,
+  codes verbatim; a rejected payment emits ONE reject event and nothing else.
+- The routing table stays DATA (a declarative map the spec's table maps onto), not
+  a nest of ifs — reviewers must be able to diff it against the spec table.
+- Amount thresholds keep their inclusive/exclusive semantics; money is BigDecimal —
+  never float/double, and never a double-backed Serde.
+- Destination events are built by explicit field-by-field mapping per the spec — no
+  passthrough of unmapped fields.
+- The topology is built by a pure `Topology buildTopology()` factory the tests and
+  the replay harness drive with TopologyTestDriver — no broker in the test path.
+  Keep the scaffold's structure and idioms.
+
+Replay harness (equivalence verification — part of the contract, same rules as tests):
+
+- The scaffold ships scripts/replay.sh; it runs com.meridian.replay.ReplayHarness,
+  which YOU implement: read one equivalence vector as JSON on stdin, print a JSON
+  array of observations on stdout — nothing else on stdout, ever.
+- The vector's "inputs" is a flat string map: the inbound event's fields using the
+  specs' names, plus "topic:" for the input topic and "key:" for the event key.
+  Feed exactly one input event through TopologyTestDriver and emit every output
+  event, in per-key order, as:
+    {"type":"message","topic":"<output topic>","key":"<event key>","fields":{...}}
+- Amounts as plain scale-2 decimal strings, codes verbatim from the specs.

--- a/examples/packs/ace-kafka/prompts/plan.md
+++ b/examples/packs/ace-kafka/prompts/plan.md
@@ -1,0 +1,12 @@
+Derive the implementation task list for the target Spring Boot integration service
+from the spec pack. Constraints:
+
+- The FIRST task must be exactly: encode the BDD scenarios as failing JUnit 5
+  acceptance tests against the seeded .feature files, driving the service's
+  processing entry point with in-memory inputs/outputs (no production code).
+- Early tasks: the message model (typed payment/request/reject types mirroring the
+  spec's mappings — money as BigDecimal) and the ports for destinations (interfaces
+  the tests can capture; real MQ/HTTP adapters are out of scope for the slice).
+- Then one task per rule cluster in spec order: validation chain with reject codes,
+  the routing table, destination mappings, thresholds/flags.
+- Each task names the spec rules (R1, ...) and scenarios it covers.

--- a/examples/packs/ace-kafka/prompts/review.md
+++ b/examples/packs/ace-kafka/prompts/review.md
@@ -1,0 +1,17 @@
+You review a finished modernization increment: a Spring Boot integration service
+built from specs reverse-engineered out of IBM ACE message flows. Judge against the
+committed spec pack, not your own taste.
+
+Look specifically for:
+
+- Routing drift: predicates, currency lists, or account-prefix rules differing from
+  the spec's routing table in any value or in evaluation order.
+- Reject-code drift: wrong codes, reordered validations, missing reject envelope
+  fields.
+- Threshold/flag drift: boundaries moved, flags set at the wrong amounts.
+- Mapping gaps: destination message fields missing, renamed, or silently passed
+  through unmapped.
+- Weakened tests: scenarios deleted, captured-destination assertions loosened.
+
+Classify each finding as FIX (violates the spec) or IMPROVEMENT (compliant but
+worth a follow-up).

--- a/examples/packs/ace-kafka/prompts/spec.md
+++ b/examples/packs/ace-kafka/prompts/spec.md
@@ -1,0 +1,31 @@
+Write one behavioural spec per message flow as Markdown with exactly these sections:
+
+# <Flow> — <one-line purpose>
+
+## Overview
+What the flow does, its trigger (input queue), and where messages can end up.
+
+## Interfaces
+Every queue (name, direction, who is on the other end) and the message format on
+each — PLUS the target event contract: a queue→topic mapping table (queue, topic
+name, event key = the correlation identity, payload fields). Per-key ordering on
+the key you name becomes part of the contract.
+
+## Routing rules
+Numbered (R1, R2, ...), in evaluation order: the predicate (exact values —
+currencies, prefixes, thresholds with boundary semantics) and the destination.
+Static routing tables reproduced AS TABLES.
+
+## Validation & rejects
+Each validation in order, its reject code, and the reject envelope structure.
+
+## Message mappings
+Field-by-field source→target mappings for each output (e.g. the CICS request built
+from the inbound payment), naming the exact target fields.
+
+## Thresholds & flags
+Every amount threshold and the flag/value it sets (priority, regulatory reporting),
+with inclusive/exclusive semantics.
+
+## Open questions
+Anything ambiguous in the source. Empty if none.

--- a/examples/packs/ace-kafka/prompts/vectors.md
+++ b/examples/packs/ace-kafka/prompts/vectors.md
@@ -1,0 +1,21 @@
+You generate equivalence vectors for a message flow being replaced by a Kafka
+Streams topology. A vector is one execution: one inbound event and the exact
+output events the spec promises. Both sides of the wall anchor on the SPEC's
+names — the replay harness is built from the same specs, so never invent field
+or topic names.
+
+Conventions for this pack (ACE msgflow → Kafka Streams):
+
+- inputs: the inbound event's payload fields using the specs' names verbatim
+  (e.g. "DebtorAccount": "1000012345", "Amount": "250.00", "Currency": "EUR"),
+  plus "topic:" (the input topic from the spec's interface table) and "key:"
+  (the correlation key value for this event).
+- observations: kind "message" only — one per output event, in per-key order:
+  topic is the output topic from the spec's interface table, key is the event
+  key the spec assigns, fields carry the mapped payload exactly as the spec's
+  message-mapping section states.
+- A rejected payment produces exactly ONE reject event and nothing else; reject
+  code and reason verbatim.
+- Cover every routing branch, EVERY reject code, and every threshold boundary
+  (a flag at 10000.00 gets vectors at 9999.99 and 10000.00 per its semantics).
+- Amounts as plain scale-2 decimal strings.

--- a/examples/packs/ace-kafka/reviewers/event-contracts.md
+++ b/examples/packs/ace-kafka/reviewers/event-contracts.md
@@ -1,0 +1,9 @@
+---
+files: .*\.java
+---
+Check the event contracts against the specs: topics and event keys match the
+spec's interface table exactly; per-key ordering is preserved (no repartition
+that loses the correlation key before an order-sensitive step); a rejected
+payment emits exactly one reject event and nothing else; amounts are BigDecimal
+end-to-end (no double-backed Serde); destination events carry only the fields
+the spec's mapping names — no passthrough of unmapped fields.

--- a/examples/packs/ace-kafka/reviewers/routing-fidelity.md
+++ b/examples/packs/ace-kafka/reviewers/routing-fidelity.md
@@ -1,0 +1,19 @@
+---
+files: .*\.java
+---
+You are the routing-fidelity reviewer for an ACE-to-Spring-Boot port. Your single
+concern: does the Java preserve the exact routing and rejection semantics the specs
+carried over from the ESQL?
+
+Flag as Critical:
+- Routing predicates or their evaluation order differing from the spec's routing
+  table in any value (currencies, prefixes, thresholds).
+- Reject codes differing in any character, or validations running out of spec
+  order.
+- Amount thresholds with drifted boundaries (>= where the spec says >), or
+  float/double anywhere amounts flow.
+- The routing table dissolved into scattered conditionals that can no longer be
+  diffed against the spec table.
+- Destination message mappings missing fields the spec maps.
+
+Ignore style, naming, and framework choices — other reviewers own those.

--- a/examples/packs/ace-kafka/reviewers/traceability.md
+++ b/examples/packs/ace-kafka/reviewers/traceability.md
@@ -1,0 +1,13 @@
+You are the traceability reviewer for a spec-driven modernization. Every behavioural
+change must be traceable to the committed spec pack.
+
+Flag as Critical:
+- Production behaviour with no corresponding spec rule (R-number) or BDD scenario —
+  either the spec pack is incomplete or the change is out of scope.
+- Changes to .feature files or acceptance tests that alter expected values or delete
+  scenarios (the contract must not be edited to fit the code).
+
+Flag as Warning:
+- Commits/tasks that do not state which spec rules they cover.
+
+Ignore refactors with no behavioural surface.

--- a/examples/tools/cobol-capture.sc
+++ b/examples/tools/cobol-capture.sc
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla::llm4zio-runner:3.23.0"
+//> using dep "io.github.riccardomerolla::llm4zio-runner:3.24.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/modules/llm4zio-flow/src/main/scala/llm4zio/flow/Equiv.scala
+++ b/modules/llm4zio-flow/src/main/scala/llm4zio/flow/Equiv.scala
@@ -55,12 +55,17 @@ object Equiv:
     /** A database mutation: `op` (insert/update/delete) on `table`, addressed by `key`, writing `set`. */
     @jsonHint("db") case DbMutation(table: String, op: String, key: Map[String, String], set: Map[String, String])
 
+    /** An emitted event on a stream: `topic` + correlation `key` identify the partition-ordered lane. */
+    @jsonHint("message") case Message(topic: String, key: String, fields: Map[String, String])
+
   object Observation:
     given JsonCodec[Observation] = DeriveJsonCodec.gen[Observation]
 
-  /** Whether observation order is part of the behaviour being proven (batch report lines) or not (DB rows). */
+  /** Whether observation order is part of the behaviour being proven: everywhere (batch report lines), nowhere (DB
+    * rows), or within each identity/correlation key (event streams — Kafka guarantees order per key only).
+    */
   enum Ordering:
-    case Ordered, Unordered
+    case Ordered, Unordered, PerKey
 
   /** One way a replay's actual observations diverged from a vector's expected ones. */
   enum Mismatch:
@@ -83,12 +88,14 @@ object Equiv:
     val act = actual.map(scrub(_, policy.ignore))
     policy.ordering match
       case Ordering.Ordered =>
-        val positional = exp.zip(act).flatMap { (e, a) =>
-          if e == a then Nil
-          else if identityOf(e) == identityOf(a) then fieldDiffs(e, a)
-          else List(Mismatch.Missing(e), Mismatch.Unexpected(a))
+        positionalDiff(exp, act)
+
+      case Ordering.PerKey =>
+        val expGroups = exp.groupBy(identityOf)
+        val actGroups = act.groupBy(identityOf)
+        (expGroups.keySet ++ actGroups.keySet).toList.sorted.flatMap { key =>
+          positionalDiff(expGroups.getOrElse(key, Nil), actGroups.getOrElse(key, Nil))
         }
-        positional ++ exp.drop(act.size).map(Mismatch.Missing(_)) ++ act.drop(exp.size).map(Mismatch.Unexpected(_))
 
       case Ordering.Unordered =>
         val (unmatched, leftover)   = exp.foldLeft((List.empty[Observation], act)) {
@@ -135,13 +142,27 @@ object Equiv:
               )
         }
 
+  /** Element-wise comparison of two same-order sequences: exact matches cancel, same-identity pairs yield field diffs,
+    * everything else is Missing/Unexpected — the [[Ordering.Ordered]] semantics, reused per key group.
+    */
+  private def positionalDiff(exp: List[Observation], act: List[Observation]): List[Mismatch] =
+    val paired = exp.zip(act).flatMap { (e, a) =>
+      if e == a then Nil
+      else if identityOf(e) == identityOf(a) then fieldDiffs(e, a)
+      else List(Mismatch.Missing(e), Mismatch.Unexpected(a))
+    }
+    paired ++ exp.drop(act.size).map(Mismatch.Missing(_)) ++ act.drop(exp.size).map(Mismatch.Unexpected(_))
+
   private def scrub(o: Observation, ignore: Set[String]): Observation = o match
     case Observation.Record(kind, fields)            => Observation.Record(kind, fields -- ignore)
     case Observation.DbMutation(table, op, key, set) => Observation.DbMutation(table, op, key -- ignore, set -- ignore)
+    case Observation.Message(topic, key, fields)     => Observation.Message(topic, key, fields -- ignore)
 
-  /** The stable identity mismatched observations pair by — field values excluded, keys included. */
+  /** The stable identity mismatched observations pair by (and PerKey groups by) — field values excluded, keys included.
+    */
   private def identityOf(o: Observation): String = o match
     case Observation.Record(kind, _)               => s"record $kind"
+    case Observation.Message(topic, key, _)        => s"message $topic $key"
     case Observation.DbMutation(table, op, key, _) =>
       val addr = key.toList.sorted.map((k, v) => s"$k=$v").mkString(",")
       s"db $table $op $addr"
@@ -149,6 +170,7 @@ object Equiv:
   private def fieldDiffs(e: Observation, a: Observation): List[Mismatch] =
     val (expected, actual) = (e, a) match
       case (Observation.Record(_, ef), Observation.Record(_, af))                     => (ef, af)
+      case (Observation.Message(_, _, ef), Observation.Message(_, _, af))             => (ef, af)
       case (Observation.DbMutation(_, _, _, es), Observation.DbMutation(_, _, _, as)) => (es, as)
       case _                                                                          => (Map.empty[String, String], Map.empty[String, String])
     (expected.keySet ++ actual.keySet).toList.sorted.flatMap { field =>

--- a/modules/llm4zio-flow/src/main/scala/llm4zio/flow/EquivReport.scala
+++ b/modules/llm4zio-flow/src/main/scala/llm4zio/flow/EquivReport.scala
@@ -59,6 +59,8 @@ object EquivReport:
   private def observation(o: Observation): String = o match
     case Observation.Record(kind, fields)            =>
       s"record $kind ${fields.toList.sorted.map((k, v) => s"$k=$v").mkString(", ")}"
+    case Observation.Message(topic, key, fields)     =>
+      s"message $topic $key ${fields.toList.sorted.map((k, v) => s"$k=$v").mkString(", ")}"
     case Observation.DbMutation(table, op, key, set) =>
       val addr   = key.toList.sorted.map((k, v) => s"$k=$v").mkString(",")
       val values = set.toList.sorted.map((k, v) => s"$k=$v").mkString(", ")

--- a/modules/llm4zio-flow/src/main/scala/llm4zio/flow/Pack.scala
+++ b/modules/llm4zio-flow/src/main/scala/llm4zio/flow/Pack.scala
@@ -159,9 +159,10 @@ object Pack:
   /** `- ordering: …` / `- ignore: a, b` list items of the Equivalence section. */
   private def equivalencePolicy(body: String): ComparisonPolicy =
     val fields   = namedListItems(body)
-    val ordering =
-      if fields.get("ordering").map(_.toLowerCase).contains("unordered") then Equiv.Ordering.Unordered
-      else Equiv.Ordering.Ordered
+    val ordering = fields.get("ordering").map(_.toLowerCase) match
+      case Some("unordered") => Equiv.Ordering.Unordered
+      case Some("per-key")   => Equiv.Ordering.PerKey
+      case _                 => Equiv.Ordering.Ordered
     val ignore   = fields.get("ignore").fold(Set.empty[String])(_.split(",").map(_.trim).filter(_.nonEmpty).toSet)
     ComparisonPolicy(ordering, ignore)
 

--- a/modules/llm4zio-flow/src/test/scala/llm4zio/flow/EquivDiffSpec.scala
+++ b/modules/llm4zio-flow/src/test/scala/llm4zio/flow/EquivDiffSpec.scala
@@ -50,4 +50,29 @@ object EquivDiffSpec extends ZIOSpecDefault:
           List(Mismatch.FieldDiff("record output:TRANSOUT", "fee", expected = "2.50", actual = "0.00"))
       )
     },
+    test("under PerKey, cross-key interleaving is free but order within one key is behaviour") {
+      val perKey = ComparisonPolicy(Equiv.Ordering.PerKey, ignore = Set.empty)
+      val a1     = Observation.Message("payments", "ACC1", Map("step" -> "debit"))
+      val a2     = Observation.Message("payments", "ACC1", Map("step" -> "credit"))
+      val b1     = Observation.Message("payments", "ACC2", Map("step" -> "debit"))
+      assertTrue(
+        Equiv.diff(List(a1, a2, b1), List(b1, a1, a2), perKey).isEmpty,
+        Equiv.diff(List(a1, a2, b1), List(a2, a1, b1), perKey).nonEmpty,
+      )
+    },
+    test("under PerKey, a differing message field pairs as a FieldDiff carrying topic and key") {
+      val perKey   = ComparisonPolicy(Equiv.Ordering.PerKey, ignore = Set.empty)
+      val expected = Observation.Message("payments", "ACC1", Map("status" -> "ROUTED", "amount" -> "9.00"))
+      val actual   = Observation.Message("payments", "ACC1", Map("status" -> "ROUTED", "amount" -> "9.90"))
+      assertTrue(
+        Equiv.diff(List(expected), List(actual), perKey) ==
+          List(Mismatch.FieldDiff("message payments ACC1", "amount", expected = "9.00", actual = "9.90"))
+      )
+    },
+    test("ignored fields scrub message payloads too") {
+      val perKey   = ComparisonPolicy(Equiv.Ordering.PerKey, ignore = Set("TS"))
+      val expected = Observation.Message("payments", "ACC1", Map("status" -> "ROUTED", "TS" -> "10:00:00"))
+      val actual   = Observation.Message("payments", "ACC1", Map("status" -> "ROUTED", "TS" -> "10:00:09"))
+      assertTrue(Equiv.diff(List(expected), List(actual), perKey).isEmpty)
+    },
   )

--- a/modules/llm4zio-flow/src/test/scala/llm4zio/flow/EquivSpec.scala
+++ b/modules/llm4zio-flow/src/test/scala/llm4zio/flow/EquivSpec.scala
@@ -36,7 +36,10 @@ object EquivSpec extends ZIOSpecDefault:
   private val captured = transfer.copy(
     id = "mainframe-run-042",
     tier = Equiv.Tier.Captured,
-    observations = List(Equiv.Observation.Record("output:TRANSOUT", Map("status" -> "POSTED", "fee" -> "2.50"))),
+    observations = List(
+      Equiv.Observation.Record("output:TRANSOUT", Map("status" -> "POSTED", "fee" -> "2.50")),
+      Equiv.Observation.Message("payments.routed", "ACC1", Map("status" -> "ROUTED")),
+    ),
   )
 
   def spec: Spec[Environment & (TestEnvironment & Scope), Any] = suite("Equiv")(
@@ -63,6 +66,7 @@ object EquivSpec extends ZIOSpecDefault:
             lines.size == 2,
             lines.head.contains("\"tier\":\"generated\""),
             lines(1).contains("\"tier\":\"captured\""),
+            lines(1).contains("\"type\":\"message\""),
           )
       }
     },

--- a/modules/llm4zio-flow/src/test/scala/llm4zio/flow/PackSpec.scala
+++ b/modules/llm4zio-flow/src/test/scala/llm4zio/flow/PackSpec.scala
@@ -249,6 +249,21 @@ object PackSpec extends ZIOSpecDefault:
         )
       }
     },
+    test("load parses per-key ordering — the event-stream equivalence policy") {
+      val manifest =
+        s"""$minimalManifest
+           |## Equivalence
+           |
+           |- ordering: per-key
+           |""".stripMargin
+      ZIO.scoped {
+        for
+          dir  <- tempDir
+          _    <- write(dir, "pack.md", manifest)
+          pack <- Pack.load(dir)
+        yield assertTrue(pack.equivalence == ComparisonPolicy(Equiv.Ordering.PerKey, Set.empty))
+      }
+    },
     test("load fails typed on a missing manifest and on a malformed one") {
       ZIO.scoped {
         for


### PR DESCRIPTION
Wave 2 of the bank-modernization master plan: the streaming stepping stone.

- **`Equiv.Observation.Message`** (topic, correlation key, fields) joins the observation model.
- **`Equiv.Ordering.PerKey`** — order is behaviour within one correlation key, free across keys (Kafka's actual guarantee); `ordering: per-key` in the pack's `## Equivalence` section.
- **`ace-kafka` pack** — ACE msgflow/ESQL → Kafka Streams topology: event-contract judge rubrics, per-key policy, vectors/implement prompts pinned to a TopologyTestDriver replay harness, event-contracts reviewer lens.
- **`kafka-streams-service` scaffold** — pure `buildTopology()` factory + TopologyTestDriver smoke test; `mvn verify` green with no broker anywhere in the test path.

All flow specs green (`testFull`); scaffold verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)