### PR TITLE
Wave 3 — pattern cards + cobol-kafka: the batch-window kill (v3.25.0)

### DIFF
--- a/docs/legacy-modernization.md
+++ b/docs/legacy-modernization.md
@@ -41,6 +41,7 @@ seeding (default `cobol-springboot`):
 | `jsp-bff-nextjs` | J2EE servlets + JSP | Spring Boot BFF + Next.js SPA monorepo |
 | `ace-integration` | IBM ACE msgflow + ESQL | Spring Boot integration service |
 | `ace-kafka` | IBM ACE msgflow + ESQL | Kafka Streams topology (per-key equivalence, TopologyTestDriver replay) |
+| `cobol-kafka` | COBOL/JCL batch + DB2 | Kafka Streams topology — the batch-window kill (records → keyed events, accumulators → state stores) |
 
 ## The pack: modernization knowledge as data
 
@@ -61,6 +62,24 @@ new pack — the shipped four packs are worked examples. Packs are git-versioned
 bank's modernization know-how is reviewable, diffable, and grows run over run.
 `Pack.load` is the library entry
 ([Pack.scala](../modules/llm4zio-flow/src/main/scala/llm4zio/flow/Pack.scala)).
+
+## Pattern cards: curated modernization knowledge
+
+Alongside per-estate `lessons.md` (run-accumulated) live **pattern cards** —
+universal, curated translations of known legacy idioms, as data (`flow.Patterns`):
+`examples/patterns/` ships ~25 COBOL→Java cards (COMP-3 → BigDecimal/HALF_UP,
+REDEFINES → sealed variants, 88-levels → enums, cursor loops → pageable queries…)
+and the `cobol-kafka` pack adds ~10 batch→streaming cards (records → keyed events,
+commit intervals → idempotence, accumulators → keyed state stores). Each card is a
+Markdown file whose frontmatter `match:` regex fires on legacy source:
+
+- **extract** runs the matchers per program and deterministically tags the
+  program's traceability fragment (`Patterns: PAT-…`) — selection is regex-decided,
+  never model-decided;
+- **implement** injects exactly the cited cards into the coder's brief — bounded
+  context, and the briefs say why each card is there;
+- a **`pattern-conformance` reviewer lens** checks the code against the cited
+  cards — advisory only, never a gate: patterns are heuristics and the specs win.
 
 ## Phase 1 — extract (rooted at the legacy repo)
 

--- a/examples/modernize-extract.sc
+++ b/examples/modernize-extract.sc
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla::llm4zio-runner:3.24.0"
+//> using dep "io.github.riccardomerolla::llm4zio-runner:3.25.0"
 //> using scala "3.8.3"
 //> using jvm 21
 
@@ -183,7 +183,9 @@ def turnLimitRecovery(spec: Path, rel: String)(using ctx: FlowContext): PartialF
 /** One analyst turn per program, skipping programs whose spec already exists and committing each one —
   * the resume unit is a single program, so a flaky stream or crash costs one turn, not the estate.
   */
-def extractPrograms(pack: Pack, system: String, programs: List[String])(using ctx: FlowContext): IO[FlowError, Unit] =
+def extractPrograms(pack: Pack, system: String, programs: List[String], cards: List[PatternCard])(using
+  ctx: FlowContext
+): IO[FlowError, Unit] =
   val modDir = workDir.resolve(ModDir)
   ZIO.foreachDiscard(programs.zipWithIndex) { (rel, i) =>
     val name     = programName(rel)
@@ -195,10 +197,30 @@ def extractPrograms(pack: Pack, system: String, programs: List[String])(using ct
         _    <- ctx.events.publish(FlowEvent.Info(s"extracting $rel $progress"))
         chat <- Chat.start(coder, system = Some(system))
         _    <- chat.ask(programAsk(pack, rel, name)).unit.catchSome(turnLimitRecovery(spec, rel))
+        _    <- tagPatterns(workDir.resolve(rel), modDir.resolve("traceability").resolve(s"$name.md"), cards)
         _    <- git.commitAll(s"modernize(${pack.name}): spec $name").unit
       yield (),
     )
   }
+
+/** Deterministically tag the program's traceability fragment with the pattern cards its SOURCE matches —
+  * implement injects exactly the cited cards into its briefs, so selection is regex-decided, not model-decided.
+  */
+def tagPatterns(source: Path, fragment: Path, cards: List[PatternCard]): IO[FlowError, Unit] =
+  ZIO
+    .attemptBlocking {
+      val matched = Patterns.matching(Files.readString(source), cards)
+      if matched.nonEmpty then
+        Option(fragment.getParent).foreach(Files.createDirectories(_))
+        Files.write(
+          fragment,
+          s"\nPatterns: ${matched.map(_.id).mkString(", ")}\n".getBytes(java.nio.charset.StandardCharsets.UTF_8),
+          java.nio.file.StandardOpenOption.CREATE,
+          java.nio.file.StandardOpenOption.APPEND,
+        )
+      ()
+    }
+    .mapError(e => FlowError.Persistence(s"failed to tag patterns on $fragment", Some(e)))
 
 /** Write `rules.txt` — every coverage unit enumerated from the legacy source, one per line. Deterministic;
   * this is the rule universe modernize-verify.sc reports equivalence against (the target side never
@@ -421,7 +443,10 @@ flow(
     _        <- ZIO.when(programs.isEmpty)(
                   fail(s"no source units matched the pack's programs/sources regex under $workDir")
                 )
-    _        <- stage("Extract")(extractPrograms(pack, system, programs))
+    cards    <- Patterns
+                  .load(packDir.resolve("patterns"))
+                  .zipWith(Patterns.load(workspace.resolve("patterns")))(_ ++ _)
+    _        <- stage("Extract")(extractPrograms(pack, system, programs, cards))
     // Commit the (ungated) draft: extraction is the expensive step, and a gate failure or crash must
     // not cost it. The Gate/Commit stages amend the picture with the verdict afterwards.
     _        <- stage("Draft")(

--- a/examples/modernize-implement.sc
+++ b/examples/modernize-implement.sc
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla::llm4zio-runner:3.24.0"
+//> using dep "io.github.riccardomerolla::llm4zio-runner:3.25.0"
 //> using scala "3.8.3"
 //> using jvm 21
 
@@ -169,9 +169,19 @@ flow(
                   Reviewers.lintCommand(_, workDir)
                 )
     _        <- stage("Branch")(git.checkoutOrCreate(plan.epicId))
+    cards    <- Patterns
+                  .load(packDir.resolve("patterns"))
+                  .zipWith(Patterns.load(workspace.resolve("patterns")))(_ ++ _)
+    specText <- gatherSpecs(workDir, pack.specsDir)
+    cited     = Patterns.tagged(specText) // extraction tagged the fragments; specs cite the ids
+    playbook  = cards.filter(c => cited.contains(c.id))
     system    = List(
                   pack.prompt("implement"),
                   pack.lessons.map(l => s"Lessons from previous modernization runs — apply them:\n$l"),
+                  Option.when(playbook.nonEmpty)(
+                    "Pattern cards cited by the specs — the translation playbook (advisory, the specs win):\n\n" +
+                      playbook.map(c => s"### ${c.id}\n${c.body}").mkString("\n\n")
+                  ),
                 ).flatten.mkString("\n\n")
     coderChat <- Chat.start(coder, system = Some(system))
     _         <- implementTaskLoop(planFile, plan) { task =>

--- a/examples/modernize-review.sc
+++ b/examples/modernize-review.sc
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla::llm4zio-runner:3.24.0"
+//> using dep "io.github.riccardomerolla::llm4zio-runner:3.25.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/examples/modernize-seed.sc
+++ b/examples/modernize-seed.sc
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla::llm4zio-runner:3.24.0"
+//> using dep "io.github.riccardomerolla::llm4zio-runner:3.25.0"
 //> using scala "3.8.3"
 //> using jvm 21
 
@@ -44,7 +44,7 @@ import llm4zio.flow.*
 import llm4zio.runner.*
 
 val ModDir         = "docs/modernization"
-val Llm4zioVersion = "3.24.0" // keep in step with the `using dep` header pin
+val Llm4zioVersion = "3.25.0" // keep in step with the `using dep` header pin
 
 def writeFile(path: Path, content: String): IO[FlowError, Unit] =
   ZIO

--- a/examples/modernize-verify.sc
+++ b/examples/modernize-verify.sc
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla::llm4zio-runner:3.24.0"
+//> using dep "io.github.riccardomerolla::llm4zio-runner:3.25.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/examples/packs/cobol-kafka/lessons.md
+++ b/examples/packs/cobol-kafka/lessons.md
@@ -1,0 +1,3 @@
+- COBOL COMP-3 (packed decimal) money fields are exact decimals: port them as
+  BigDecimal with explicit scale 2 and RoundingMode.HALF_UP (COBOL COMPUTE ROUNDED);
+  never float/double.

--- a/examples/packs/cobol-kafka/pack.md
+++ b/examples/packs/cobol-kafka/pack.md
@@ -1,0 +1,36 @@
+# Pack: cobol-kafka
+
+source: cobol
+scaffold: ../../fixtures/scaffolds/kafka-streams-service
+sources: .*\.(cbl|CBL|cpy|CPY|jcl|JCL)
+programs: .*\.(cbl|CBL|jcl|JCL)
+specs-dir: docs/specs
+features-dir: src/test/resources/features
+replay: scripts/replay.sh
+
+## Gates
+
+- build: mvn -q -B test-compile
+- test: mvn -q -B test
+- verify: mvn -q -B verify
+
+## Judge
+
+- completeness (0..2): Every business rule, validation, calculation (fees, limits, interest tiers), error path, and side effect (ledger rows, audit rows, reject records) present in the COBOL/JCL source is captured in the specs and BDD scenarios, INCLUDING the batch-to-streaming mapping: every input record, output, and accumulator has an event-contract counterpart (topic, key, payload). Score 2 only if nothing material is missing.
+- faithfulness (0..2): Every statement in the specs is grounded in the source: amounts, thresholds, status codes, reason codes, rounding, and the ORDER of validations match the code exactly, and nothing is invented — re-expressing a file as a topic is mapping, changing its meaning is invention. Score 2 only if fully source-grounded.
+- testability (0..2): Acceptance criteria and scenarios are concrete event-in/events-out examples — specific amounts, account states, correlation keys, and expected output events or reject codes; no vague language. Score 2 only if every scenario is directly encodable as a TopologyTestDriver test.
+
+## Equivalence
+
+- ordering: per-key
+- ignore: TIMESTAMP, TS, PROCESSED_AT
+
+## Coverage: cobol-paragraph
+
+files: .*\.(cbl|CBL)
+unit: ^ {7}(\d{4}-[A-Z0-9-]+)\.
+
+## Coverage: jcl-step
+
+files: .*\.(jcl|JCL)
+unit: ^//([A-Z0-9]+) +EXEC

--- a/examples/packs/cobol-kafka/patterns/PAT-STREAM-001-record-to-event.md
+++ b/examples/packs/cobol-kafka/patterns/PAT-STREAM-001-record-to-event.md
@@ -1,0 +1,7 @@
+---
+match: READ |ORGANIZATION IS SEQUENTIAL
+---
+Each input file record becomes one keyed event: the record layout maps to the event
+payload, and the correlation key is the entity the batch processes per record (the
+source account for transfers). The event schema lives in the spec&apos;s interface
+table — never invent fields the record does not carry.

--- a/examples/packs/cobol-kafka/patterns/PAT-STREAM-002-job-step-topology.md
+++ b/examples/packs/cobol-kafka/patterns/PAT-STREAM-002-job-step-topology.md
@@ -1,0 +1,6 @@
+---
+match: PERFORM [0-9]|^//[A-Z0-9]+ +EXEC
+---
+The batch main loop and JCL steps map to topology stages: validate → enrich → route
+→ post, one named processor per paragraph cluster. Keep stage boundaries where the
+batch had paragraph boundaries so traceability survives the paradigm shift.

--- a/examples/packs/cobol-kafka/patterns/PAT-STREAM-003-checkpoint-idempotence.md
+++ b/examples/packs/cobol-kafka/patterns/PAT-STREAM-003-checkpoint-idempotence.md
@@ -1,0 +1,7 @@
+---
+match: COMMIT|RESTART
+---
+Commit-every-N restart logic becomes idempotence: enable exactly-once processing
+(or idempotent writes keyed by the event id) instead of chunked commits. A replayed
+event must produce the same ledger rows, not duplicates — that is the equivalence
+property the batch checkpoint was protecting.

--- a/examples/packs/cobol-kafka/patterns/PAT-STREAM-004-eod-totals-window.md
+++ b/examples/packs/cobol-kafka/patterns/PAT-STREAM-004-eod-totals-window.md
@@ -1,0 +1,7 @@
+---
+match: FINALIZE|FEE-TOTAL|DISPLAY .*TOTAL
+---
+End-of-run totals become windowed aggregations: the batch summary (posted count,
+fees collected) maps to a daily tumbling window keyed by run date, emitted on window
+close. The cutoff that was implicit in the batch schedule becomes an explicit
+window boundary in the spec.

--- a/examples/packs/cobol-kafka/patterns/PAT-STREAM-005-reject-topic.md
+++ b/examples/packs/cobol-kafka/patterns/PAT-STREAM-005-reject-topic.md
@@ -1,0 +1,6 @@
+---
+match: REJECT
+---
+The reject file becomes a reject topic: same codes, same reasons, one reject event
+per failed input event, keyed like the input. Downstream consumers replace the
+morning reject-report job; a rejected event NEVER also produces output events.

--- a/examples/packs/cobol-kafka/patterns/PAT-STREAM-006-keyed-state-store.md
+++ b/examples/packs/cobol-kafka/patterns/PAT-STREAM-006-keyed-state-store.md
@@ -1,0 +1,7 @@
+---
+match: ACCUM|WORKING-STORAGE
+---
+Per-account working-storage accumulators (daily transfer totals) become keyed state
+stores: the accumulator is state keyed by the event key, updated transactionally
+with the emit. Reset jobs (EOD accumulator reset) become punctuator/window
+lifecycle, named in the spec.

--- a/examples/packs/cobol-kafka/patterns/PAT-STREAM-007-outbox.md
+++ b/examples/packs/cobol-kafka/patterns/PAT-STREAM-007-outbox.md
@@ -1,0 +1,7 @@
+---
+match: INSERT INTO|WRITE 
+---
+A batch that both writes DB rows and emits records must not dual-write from a
+stream: either the topology emits events and a downstream projector owns the DB, or
+writes go through a transactional outbox. Pick per the spec&apos;s system-of-record
+statement — the mainframe ledger owner decides.

--- a/examples/packs/cobol-kafka/patterns/PAT-STREAM-008-partition-key.md
+++ b/examples/packs/cobol-kafka/patterns/PAT-STREAM-008-partition-key.md
@@ -1,0 +1,7 @@
+---
+match: ACCT
+---
+Rules scoped per account (limits, balances, validation order) require the account
+id as the partition key: per-key ordering is the only ordering Kafka guarantees, and
+it is exactly the ordering the batch had after its sort step. Repartitioning away
+from the account key mid-topology breaks the contract.

--- a/examples/packs/cobol-kafka/patterns/PAT-STREAM-009-batch-window-cutoff.md
+++ b/examples/packs/cobol-kafka/patterns/PAT-STREAM-009-batch-window-cutoff.md
@@ -1,0 +1,7 @@
+---
+match: DAILY|NIGHTLY|XFERDLY
+---
+The nightly batch window becomes continuous processing with explicit cutoffs:
+"posted today" turns into event-time windows with a documented business cutoff, and
+same-day semantics (daily limits) key on the event-time date. State the timezone —
+the mainframe had one implicitly.

--- a/examples/packs/cobol-kafka/patterns/PAT-STREAM-010-replay-backfill.md
+++ b/examples/packs/cobol-kafka/patterns/PAT-STREAM-010-replay-backfill.md
@@ -1,0 +1,7 @@
+---
+match: RERUN|RESUBMIT
+---
+Batch rerun-from-file becomes topic replay: reprocessing is resetting offsets over
+an immutable input topic, which is only safe because of idempotent processing
+(PAT-STREAM-003). Document the replay procedure in the runbook the way rerun JCL
+was documented.

--- a/examples/packs/cobol-kafka/prompts/analysis.md
+++ b/examples/packs/cobol-kafka/prompts/analysis.md
@@ -1,0 +1,23 @@
+You are a mainframe reverse-engineering analyst. Your job is to extract the COMPLETE
+observable behaviour of the COBOL/JCL estate in this repository into a spec pack —
+precise enough that a team who never sees this source can reimplement it.
+
+How to read the estate:
+
+- Start from the JCL: each job step names a program and its files — that is the
+  orchestration (order, condition codes, restart behaviour).
+- For each COBOL program, follow the PERFORM graph from the first paragraph; every
+  paragraph exists for a reason and must be accounted for.
+- Copybooks are the record layouts: field names, PIC clauses (COMP-3 = packed decimal
+  money), 88-levels (status values). REPLACING tells you the same layout is used for
+  more than one role.
+- EXEC SQL blocks are the data contract: tables, columns, and how SQLCODE 0 / +100 /
+  negative are each handled.
+- Reject/error paths ARE business rules: every reason code, its trigger condition, and
+  the exact order validations run in. First-failure-wins ordering must be preserved.
+- Constants are business policy: thresholds, fees, rates, caps, floors. Record the
+  exact values and their rounding behaviour (COMPUTE ROUNDED = half-up).
+
+Never invent behaviour. If the source does not do it, the spec must not say it.
+If something is genuinely ambiguous, record it in an "Open questions" section rather
+than guessing.

--- a/examples/packs/cobol-kafka/prompts/bdd.md
+++ b/examples/packs/cobol-kafka/prompts/bdd.md
@@ -1,0 +1,15 @@
+Write Gherkin .feature files encoding the specs' business rules as executable
+scenarios — these become the acceptance tests of the new Spring Boot service.
+
+- One feature file per COBOL program (or per coherent rule cluster within one).
+- Business vocabulary, not mainframe vocabulary: "the transfer is rejected because the
+  source account is frozen", not "reject code 11 is written to REJFILE" — but keep the
+  reason code in the Then step so traceability holds (e.g. `Then the transfer is
+  rejected with reason code 11 (source account frozen)`).
+- Every scenario uses concrete values: real amounts, statuses, and expected balances
+  after posting — never "a large amount" or "the correct fee".
+- Cover: the happy path, EVERY reject reason, every fee tier and its boundary values
+  (e.g. exactly 1000.00), limit boundaries (exactly at the daily limit), overdraft
+  floor boundaries, and rounding-sensitive amounts.
+- Boundary discipline: when a rule says "< 1000.00", write scenarios at 999.99 and
+  1000.00.

--- a/examples/packs/cobol-kafka/prompts/implement.md
+++ b/examples/packs/cobol-kafka/prompts/implement.md
@@ -1,0 +1,47 @@
+You implement one task at a time in a Kafka Streams / Java 21 service that replaces
+a COBOL batch program with an event-streaming topology — this is the batch-window
+kill: continuous processing with the batch's exact business rules. The committed
+specs under docs/specs/ and the .feature files under src/test/resources/features/
+are the contract; the acceptance tests encode them — make them pass without
+weakening them.
+
+The batch→streaming mapping (the paradigm shift, applied mechanically):
+
+- Each input file record becomes one keyed event; the correlation key is the entity
+  the batch processed per record (the source account for transfers). Per-key
+  ordering replaces the batch's sort step — never repartition away from that key
+  mid-topology.
+- The batch main loop's paragraph clusters become named topology stages (validate →
+  route → post); posted side effects (ledger rows, audit rows) become output events
+  per the spec's event-contract table; the reject file becomes a reject topic with
+  the same codes.
+- Per-account accumulators (daily limits) become keyed state stores updated
+  transactionally with the emit; commit-interval restart logic becomes idempotent,
+  exactly-once processing.
+- The pattern cards tagged in the task's specs (PAT-STREAM-*, PAT-COBOL-*) are the
+  translation playbook — follow them, and say in the commit which cards applied.
+
+Non-negotiables carried over from the COBOL:
+
+- Money is BigDecimal scale 2; COMPUTE ROUNDED is RoundingMode.HALF_UP; never
+  float/double, never a double-backed Serde.
+- Preserve the specs' validation ORDER exactly (first-failure-wins) and reason codes
+  verbatim; a rejected event emits ONE reject event and no other output.
+- Boundary conditions match the spec: "< 1000.00" means 999.99 qualifies and 1000.00
+  does not.
+- The topology is built by a pure `Topology buildTopology()` factory driven by
+  TopologyTestDriver in tests and in the replay harness — no broker in the test
+  path. Keep the scaffold's structure and idioms.
+
+Replay harness (equivalence verification — part of the contract, same rules as tests):
+
+- The scaffold ships scripts/replay.sh; it runs com.meridian.replay.ReplayHarness,
+  which YOU implement: read one equivalence vector as JSON on stdin, print a JSON
+  array of observations on stdout — nothing else on stdout, ever.
+- The vector's "inputs" is a flat string map keyed by the specs' COBOL field names
+  ("XFER-AMOUNT", "FROM-ACCT", …) plus "state:"-prefixed pre-existing state
+  ("state:ACCOUNT:<id>": account row, "state:RUN-DATE"). Arrange the state (seeded
+  state stores), feed exactly one input event through TopologyTestDriver, and emit
+  every output event in per-key order as:
+    {"type":"message","topic":"<output topic>","key":"<event key>","fields":{...}}
+- Amounts as plain scale-2 decimal strings, status and reason codes verbatim.

--- a/examples/packs/cobol-kafka/prompts/plan.md
+++ b/examples/packs/cobol-kafka/prompts/plan.md
@@ -1,0 +1,13 @@
+Derive the implementation task list for the target Spring Boot service from the spec
+pack. Constraints:
+
+- The FIRST task must be exactly: encode the BDD scenarios as failing JUnit 5
+  acceptance tests against the seeded .feature files (no production code). Every later
+  task implements production code towards making those tests pass.
+- Early tasks lay the data model: JPA entities derived from the copybook layouts /
+  DB2 tables named in the specs (packed-decimal money → BigDecimal columns).
+- Then one task per business-rule cluster (validation chain, fee calculation, limit
+  tracking, overdraft, posting, interest tiers), in dependency order.
+- Each task description names the spec rules (R1, R2, ...) and scenarios it covers —
+  reviewers check changes against those references.
+- Keep tasks small enough to implement and review in one sitting.

--- a/examples/packs/cobol-kafka/prompts/review.md
+++ b/examples/packs/cobol-kafka/prompts/review.md
@@ -1,0 +1,17 @@
+You review a finished modernization increment: a Spring Boot implementation built from
+specs reverse-engineered out of COBOL. Judge the implementation against the committed
+spec pack (docs/specs/, the .feature files, docs/modernization/plan.md), not against
+your own taste.
+
+Look specifically for:
+
+- Spec drift: behaviour present in the specs but missing, weakened, or reordered in
+  the implementation (validation order matters).
+- Weakened tests: scenarios deleted, loosened tolerances, boundary values moved,
+  assertions commented out.
+- COBOL semantic traps that survived review: double arithmetic on money, banker's
+  rounding where half-up is specified, off-by-one on inclusive/exclusive boundaries.
+- Silent scope: behaviour in the implementation that no spec rule requires.
+
+Classify each finding as either a FIX (the implementation violates the spec — needs a
+fix spec and a rework task) or an IMPROVEMENT (spec-compliant but worth a follow-up).

--- a/examples/packs/cobol-kafka/prompts/spec.md
+++ b/examples/packs/cobol-kafka/prompts/spec.md
@@ -1,0 +1,28 @@
+Write one behavioural spec per COBOL program as Markdown with exactly these sections:
+
+# <PROGRAM> — <one-line purpose>
+
+## Overview
+What the program does, when it runs (from the JCL), and its inputs/outputs (files,
+tables).
+
+## Business rules
+A numbered list (R1, R2, ...) of every rule, in the order the code applies them.
+Each rule states its exact values (amounts, rates, codes) and its outcome. Validation
+rules state what is checked, in what order, and which reject reason code fires.
+
+## Error handling
+Reject reason codes with trigger conditions; database error behaviour (SQLCODE
+handling, rollback, abend code, return code).
+
+## Data access
+Tables read/written, per operation, including commit frequency.
+
+## Orchestration
+The JCL steps that run this program: order, condition codes, restart notes.
+
+## Open questions
+Anything ambiguous in the source. Empty section if none.
+
+Rules must be source-grounded: every number, code, and ordering comes from the code,
+not from banking domain knowledge.

--- a/examples/packs/cobol-kafka/prompts/vectors.md
+++ b/examples/packs/cobol-kafka/prompts/vectors.md
@@ -1,0 +1,21 @@
+You generate equivalence vectors for a COBOL batch program being replaced by a
+Kafka Streams topology. A vector is one execution: one input record (as its keyed
+event) and the exact output events the spec promises. Both sides of the wall anchor
+on the SPEC's names — the replay harness is built from the same specs, so never
+invent field, topic, or code names.
+
+Conventions for this pack (COBOL batch → Kafka Streams):
+
+- inputs: use the COBOL record/field names from the spec verbatim as keys
+  (e.g. "XFER-AMOUNT": "500.00", "XFER-SRC-ACCT": "A1000012"), plus pre-existing
+  state: "state:ACCOUNT:<id>" account rows (CUST_ID=…,STATUS=…,BALANCE=…,
+  OD_FLAG=…,ACCUM=…,BRANCH=…) and "state:RUN-DATE" (ISO date). Amounts are plain
+  scale-2 decimal strings.
+- observations: kind "message" only — one per output event, in per-key order:
+  topic from the spec's event-contract table (posted movements, audit events,
+  rejects), key = the correlation key the spec assigns (the source account unless
+  stated otherwise), fields exactly as the spec's mapping states them.
+- Respect the spec's validation ORDER: first failure wins — a rejected input emits
+  ONE reject event (code and reason verbatim) and nothing else.
+- Cover the happy path, each fee/limit boundary (at/over/under), each reject code,
+  and the overdraft path where the spec has one.

--- a/examples/packs/cobol-kafka/reviewers/cobol-fidelity.md
+++ b/examples/packs/cobol-kafka/reviewers/cobol-fidelity.md
@@ -1,0 +1,16 @@
+---
+files: .*\.java
+---
+You are the COBOL-fidelity reviewer for a mainframe-to-Spring-Boot port. Your single
+concern: does the Java preserve the exact semantics the specs carried over from COBOL?
+
+Flag as Critical:
+- float/double anywhere money, rates, or balances flow; BigDecimal without explicit
+  scale or with a rounding mode other than HALF_UP where the spec says COBOL ROUNDED.
+- Validation checks that run in a different order than the spec's numbered rules
+  (first-failure-wins means order is observable behaviour).
+- Reason codes, thresholds, fees, caps, or floors that differ from the spec values in
+  any digit.
+- Boundary drift: <= where the spec says <, exclusive where inclusive.
+
+Ignore style, naming, and framework choices — other reviewers own those.

--- a/examples/packs/cobol-kafka/reviewers/pattern-conformance.md
+++ b/examples/packs/cobol-kafka/reviewers/pattern-conformance.md
@@ -1,0 +1,10 @@
+---
+files: .*\.(java|kt|scala)
+---
+The specs cite pattern cards (PAT-… ids) — the translation playbook for known
+legacy idioms. For each cited card, check the implementation follows its
+translation (BigDecimal/HALF_UP where comp3-money is cited, sealed variants for
+redefines, keyed state stores where keyed-state-store is cited, …). Patterns are
+ADVISORY heuristics: report divergence as minor findings naming the card id, and
+accept divergence the specs or target architecture explicitly justify — the
+specs always win over the cards.

--- a/examples/packs/cobol-kafka/reviewers/traceability.md
+++ b/examples/packs/cobol-kafka/reviewers/traceability.md
@@ -1,0 +1,13 @@
+You are the traceability reviewer for a spec-driven modernization. Every behavioural
+change must be traceable to the committed spec pack.
+
+Flag as Critical:
+- Production behaviour with no corresponding spec rule (R-number) or BDD scenario —
+  either the spec pack is incomplete or the change is out of scope.
+- Changes to .feature files or acceptance tests that alter expected values or delete
+  scenarios (the contract must not be edited to fit the code).
+
+Flag as Warning:
+- Commits/tasks that do not state which spec rules they cover.
+
+Ignore refactors with no behavioural surface.

--- a/examples/packs/cobol-springboot/reviewers/pattern-conformance.md
+++ b/examples/packs/cobol-springboot/reviewers/pattern-conformance.md
@@ -1,0 +1,10 @@
+---
+files: .*\.(java|kt|scala)
+---
+The specs cite pattern cards (PAT-… ids) — the translation playbook for known
+legacy idioms. For each cited card, check the implementation follows its
+translation (BigDecimal/HALF_UP where comp3-money is cited, sealed variants for
+redefines, keyed state stores where keyed-state-store is cited, …). Patterns are
+ADVISORY heuristics: report divergence as minor findings naming the card id, and
+accept divergence the specs or target architecture explicitly justify — the
+specs always win over the cards.

--- a/examples/patterns/PAT-COBOL-001-comp3-money.md
+++ b/examples/patterns/PAT-COBOL-001-comp3-money.md
@@ -1,0 +1,7 @@
+---
+match: COMP-3|COMPUTE .* ROUNDED
+---
+COBOL packed-decimal money (COMP-3) maps to BigDecimal with scale 2; COMPUTE ROUNDED
+is RoundingMode.HALF_UP. Never float/double for amounts, rates, or balances; scale is
+part of the contract (S9(5)V99 means exactly 2 decimals). Trap: intermediate COMPUTE
+results keep COBOL truncation rules — round only where the source says ROUNDED.

--- a/examples/patterns/PAT-COBOL-002-redefines.md
+++ b/examples/patterns/PAT-COBOL-002-redefines.md
@@ -1,0 +1,7 @@
+---
+match: REDEFINES
+---
+A REDEFINES clause is two interpretations of one buffer. Map to a sealed interface
+with one variant per interpretation and an explicit discriminator — never two mutable
+views of shared state. Trap: the discriminator is often implicit in which paragraph
+reads the field; the spec must name it.

--- a/examples/patterns/PAT-COBOL-003-88-levels.md
+++ b/examples/patterns/PAT-COBOL-003-88-levels.md
@@ -1,0 +1,7 @@
+---
+match: ^ {10,}88  
+---
+Level-88 condition names are the domain vocabulary: map each group to a Java enum
+(ACCT-STATUS 88s → AccountStatus.ACTIVE/FROZEN/CLOSED/DORMANT) and keep the raw code
+as the enum field. Trap: several 88s can overlap one value range — model predicates,
+not just constants, when ranges appear.

--- a/examples/patterns/PAT-COBOL-004-perform-thru.md
+++ b/examples/patterns/PAT-COBOL-004-perform-thru.md
@@ -1,0 +1,7 @@
+---
+match: PERFORM .* THRU|GO TO .*-EXIT
+---
+PERFORM…THRU with GO TO <para>-EXIT is early-exit control flow: map to a method with
+early returns (or a validation chain), one method per performed range. Trap: a GO TO
+that escapes its PERFORM range is a latent fall-through bug in the original — flag it
+in the spec instead of reproducing it.

--- a/examples/patterns/PAT-COBOL-005-file-status.md
+++ b/examples/patterns/PAT-COBOL-005-file-status.md
@@ -1,0 +1,6 @@
+---
+match: FILE STATUS
+---
+FILE STATUS codes are typed I/O outcomes: 00 ok, 10 EOF, others errors. Map the
+handled codes to the value channel (sealed result), unexpected ones to exceptions.
+Trap: an unchecked OPEN status in the source is a silent-failure path — surface it.

--- a/examples/patterns/PAT-COBOL-006-sqlcode.md
+++ b/examples/patterns/PAT-COBOL-006-sqlcode.md
@@ -1,0 +1,7 @@
+---
+match: SQLCODE
+---
+The SQLCODE ladder (0 / +100 / other) maps to Optional-plus-typed-error: +100 is
+Optional.empty (not found), 0 is a value, anything else is an exception. Trap:
+WHENEVER clauses and per-statement EVALUATEs can differ per call site — port each
+site as it is, not one global policy.

--- a/examples/patterns/PAT-COBOL-007-validation-order.md
+++ b/examples/patterns/PAT-COBOL-007-validation-order.md
@@ -1,0 +1,7 @@
+---
+match: GO TO .*-EXIT|EVALUATE TRUE
+---
+First-failure-wins validation ladders are contract: port as an ordered chain where
+the first failing rule short-circuits with its exact reason code. Property to keep:
+at most ONE reject reason per input, and its code is the first violated rule in
+source order.

--- a/examples/patterns/PAT-COBOL-008-zoned-decimal.md
+++ b/examples/patterns/PAT-COBOL-008-zoned-decimal.md
@@ -1,0 +1,6 @@
+---
+match: PIC S9\([0-9]+\)V99(?! +COMP)
+---
+Zoned-decimal DISPLAY amounts (overpunched sign) are a wire format: parse at the
+boundary into BigDecimal, serialize back only at the edge. Trap: sign overpunch
+conventions differ (EBCDIC { A-I / } J-R); never let the raw bytes leak inland.

--- a/examples/patterns/PAT-COBOL-009-occurs-table.md
+++ b/examples/patterns/PAT-COBOL-009-occurs-table.md
@@ -1,0 +1,6 @@
+---
+match: OCCURS
+---
+OCCURS tables are fixed-capacity lists: map to List<T> with the capacity as a
+validated invariant, not an array with sentinel rows. Trap: DEPENDING ON means the
+effective size is data — carry it, do not scan for blanks.

--- a/examples/patterns/PAT-COBOL-010-copybook-record.md
+++ b/examples/patterns/PAT-COBOL-010-copybook-record.md
@@ -1,0 +1,7 @@
+---
+match: ^ {6,}COPY  *[A-Z]
+---
+One copybook = one record type shared across programs: generate a single Java record
+per copybook and reuse it, mirroring COPY REPLACING prefixes as field-identical
+wrapper types. Trap: two programs copying the same book may honor different subsets
+of fields — the SPEC, not the layout, says which fields are behaviour.

--- a/examples/patterns/PAT-COBOL-011-batch-counters.md
+++ b/examples/patterns/PAT-COBOL-011-batch-counters.md
@@ -1,0 +1,6 @@
+---
+match: ADD 1 TO WS-.*(COUNT|CNT)
+---
+Run counters and totals (read/posted/rejected/fees) are the batch run report: map to
+an immutable RunSummary the use case returns, not logging. The summary is observable
+behaviour when the source DISPLAYs it — keep field-for-field parity.

--- a/examples/patterns/PAT-COBOL-012-commit-frequency.md
+++ b/examples/patterns/PAT-COBOL-012-commit-frequency.md
@@ -1,0 +1,7 @@
+---
+match: COMMIT
+---
+COMMIT every N records is restart-safety, not business logic: in the target, one
+transaction per unit of work (per transfer) replaces chunked commits, and the spec
+notes the difference. Trap: never reproduce partial-batch visibility as behaviour —
+it was an artifact of the mainframe transaction monitor.

--- a/examples/patterns/PAT-COBOL-013-abend.md
+++ b/examples/patterns/PAT-COBOL-013-abend.md
@@ -1,0 +1,6 @@
+---
+match: ABEND|ILBOABN0|RETURN-CODE
+---
+ABEND U-codes and RETURN-CODE are process-exit contract with the scheduler: map to
+typed exceptions caught at the entrypoint that set the process exit status. Keep the
+distinction: expected rejects are data, ABENDs are crashes.

--- a/examples/patterns/PAT-COBOL-014-reject-file.md
+++ b/examples/patterns/PAT-COBOL-014-reject-file.md
@@ -1,0 +1,6 @@
+---
+match: REJECT
+---
+A reject file with code+reason is a first-class output: map to a reject record
+entity (code, reason, original payload) written through a port, with codes verbatim.
+The reject set is closed — port it as an enum and cover every code with a test.

--- a/examples/patterns/PAT-COBOL-015-accept-date.md
+++ b/examples/patterns/PAT-COBOL-015-accept-date.md
@@ -1,0 +1,6 @@
+---
+match: ACCEPT .* FROM DATE
+---
+ACCEPT FROM DATE is ambient time: inject a Clock; the run date is a parameter of the
+use case, never LocalDate.now() inline. This is what makes replay/equivalence
+deterministic.

--- a/examples/patterns/PAT-COBOL-016-string-building.md
+++ b/examples/patterns/PAT-COBOL-016-string-building.md
@@ -1,0 +1,6 @@
+---
+match: STRING .*DELIMITED
+---
+STRING…DELIMITED builds fixed-format text: map to an explicit formatter with the
+exact widths/delimiters, tested against golden strings. Trap: DELIMITED BY SIZE vs
+BY SPACE differ on trailing blanks — match the source.

--- a/examples/patterns/PAT-COBOL-017-cursor-loop.md
+++ b/examples/patterns/PAT-COBOL-017-cursor-loop.md
@@ -1,0 +1,6 @@
+---
+match: DECLARE .* CURSOR|FETCH 
+---
+DB2 cursor loops map to pageable repository queries or streams; the loop body is a
+per-row use case. Trap: cursors see uncommitted own-writes under the same unit of
+work — if the source relies on that, the spec must say so explicitly.

--- a/examples/patterns/PAT-COBOL-018-yn-switches.md
+++ b/examples/patterns/PAT-COBOL-018-yn-switches.md
@@ -1,0 +1,6 @@
+---
+match: PIC X\(0?1\).*VALUE '[YN]'
+---
+X(1) Y/N switches are booleans with domain names: WS-OD-TRIGGERED → boolean
+odFeeDue. Keep the original flag name in a comment or mapping doc for traceability.
+Trap: some are tri-state in practice (space = unknown) — check every writer first.

--- a/examples/patterns/PAT-COBOL-019-shared-accumulators.md
+++ b/examples/patterns/PAT-COBOL-019-shared-accumulators.md
@@ -1,0 +1,6 @@
+---
+match: DAILY.*ACCUM|ACCUM.*DAILY
+---
+Accumulators maintained across programs (daily transfer totals reset by another job)
+are shared domain state: model as an explicit entity with named reset semantics, and
+document WHICH process resets it — the invariant lives between programs.

--- a/examples/patterns/PAT-COBOL-020-tiered-fees.md
+++ b/examples/patterns/PAT-COBOL-020-tiered-fees.md
@@ -1,0 +1,7 @@
+---
+match: FEE
+---
+Threshold fee ladders (flat under X, percent capped over) are a policy value object:
+one pure function amount→fee, boundary semantics exactly as the source (< vs <=),
+tested at each boundary and cap. Trap: waivers (same-customer) are part of the
+policy, not the caller.

--- a/examples/patterns/PAT-COBOL-021-overdraft-floor.md
+++ b/examples/patterns/PAT-COBOL-021-overdraft-floor.md
@@ -1,0 +1,7 @@
+---
+match: OD-FLOOR|OVERDRAFT
+---
+Overdraft floors including fees are guard clauses with exact arithmetic: compute the
+post-transaction balance INCLUDING all fees the source includes before comparing to
+the floor. Trap: the OD fee itself may count against the floor — read the COMPUTE
+order, not the comment.

--- a/examples/patterns/PAT-COBOL-022-jcl-job-net.md
+++ b/examples/patterns/PAT-COBOL-022-jcl-job-net.md
@@ -1,0 +1,6 @@
+---
+match: ^//[A-Z0-9]+ +EXEC
+---
+A JCL job is an orchestration: each EXEC step maps to a use-case invocation, COND
+codes to conditional continuation, DD statements to the step&apos;s ports. The job net
+belongs in the orchestrator (scheduler config), never hidden inside one service.

--- a/examples/patterns/PAT-COBOL-023-sort-step.md
+++ b/examples/patterns/PAT-COBOL-023-sort-step.md
@@ -1,0 +1,6 @@
+---
+match: SORT 
+---
+DFSORT steps are contract about processing ORDER: map to repository ORDER BY (or an
+explicit sort at the boundary) and record WHY the order matters — usually a control
+break downstream. Trap: sort keys include type/sign quirks of the raw record.

--- a/examples/patterns/PAT-COBOL-024-fixed-width-records.md
+++ b/examples/patterns/PAT-COBOL-024-fixed-width-records.md
@@ -1,0 +1,6 @@
+---
+match: RECORD CONTAINS|RECORDING MODE
+---
+Fixed-width record layouts (LRECL) are wire formats: one explicit parser/serializer
+per layout at the boundary, tested against byte-exact golden records; inland types
+are domain records. Never index into strings mid-service.

--- a/examples/patterns/PAT-COBOL-025-audit-rows.md
+++ b/examples/patterns/PAT-COBOL-025-audit-rows.md
@@ -1,0 +1,6 @@
+---
+match: AUDIT
+---
+One audit row per posted action is compliance behaviour: write the audit entity in
+the SAME transaction as the mutation it records, field-for-field per the spec.
+Missing audit rows are a spec violation, not an optimization.

--- a/examples/tools/cobol-capture.sc
+++ b/examples/tools/cobol-capture.sc
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla::llm4zio-runner:3.24.0"
+//> using dep "io.github.riccardomerolla::llm4zio-runner:3.25.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/modules/llm4zio-flow/src/main/scala/llm4zio/flow/Patterns.scala
+++ b/modules/llm4zio-flow/src/main/scala/llm4zio/flow/Patterns.scala
@@ -1,0 +1,60 @@
+package llm4zio.flow
+
+import java.nio.file.{ Files, Path }
+
+import scala.jdk.CollectionConverters.*
+
+import zio.{ IO, ZIO }
+
+/** One reusable modernization pattern: a legacy idiom, its target translation, and the known traps — knowledge as data,
+  * like packs and lessons, but universal and curated rather than estate-local and run-accumulated. `matches` is a regex
+  * over legacy source: extraction tags each program's spec with the ids of the cards that hit, and implementation
+  * injects only the tagged cards into the coder's brief — deterministic selection, bounded context.
+  */
+final case class PatternCard(id: String, matches: String, body: String)
+
+object Patterns:
+
+  /** All `*.md` cards under `dir`, sorted by id (the filename stem). An absent directory is an empty set — patterns are
+    * optional everywhere.
+    */
+  def load(dir: Path): IO[FlowError, List[PatternCard]] =
+    ZIO
+      .attemptBlocking {
+        if !Files.isDirectory(dir) then Nil
+        else
+          val stream = Files.list(dir)
+          val files  =
+            try stream.iterator().asScala.filter(_.getFileName.toString.endsWith(".md")).toList
+            finally stream.close()
+          files
+            .map(f => parse(f.getFileName.toString.stripSuffix(".md"), Files.readString(f)))
+            .sortBy(_.id)
+      }
+      .mapError(e => FlowError.Persistence(s"failed to read pattern cards under $dir", Some(e)))
+
+  /** The cards whose `match` regex hits anywhere in `source` — how extraction decides which patterns a program
+    * embodies.
+    */
+  def matching(source: String, cards: List[PatternCard]): List[PatternCard] =
+    cards.filter(c => c.matches.nonEmpty && c.matches.r.findFirstIn(source).isDefined)
+
+  /** Every `PAT-…` id cited in a spec text, in order of first appearance — how implementation finds the cards its
+    * current task's specs were tagged with.
+    */
+  def tagged(spec: String): List[String] =
+    """PAT-[A-Za-z0-9-]+""".r.findAllIn(spec).toList.distinct
+
+  private def parse(id: String, text: String): PatternCard =
+    val stripped = text.strip
+    if stripped.startsWith("---") then
+      stripped.drop(3).split("(?m)^---\\s*$", 2) match
+        case Array(front, body) =>
+          val fields = front.linesIterator.collect {
+            case l if l.contains(":") =>
+              val (k, v) = l.span(_ != ':')
+              k.trim -> v.drop(1).trim
+          }.toMap
+          PatternCard(id, fields.getOrElse("match", ""), body.strip)
+        case _                  => PatternCard(id, "", stripped)
+    else PatternCard(id, "", stripped)

--- a/modules/llm4zio-flow/src/test/scala/llm4zio/flow/PatternsSpec.scala
+++ b/modules/llm4zio-flow/src/test/scala/llm4zio/flow/PatternsSpec.scala
@@ -1,0 +1,78 @@
+package llm4zio.flow
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{ Files, Path }
+
+import zio.*
+import zio.test.*
+
+object PatternsSpec extends ZIOSpecDefault:
+
+  private val tempDir: ZIO[Scope, Nothing, Path] =
+    ZIO.acquireRelease(ZIO.attempt(Files.createTempDirectory("llm4zio-patterns-")).orDie)(d =>
+      ZIO.attempt {
+        Files.walk(d).sorted(java.util.Comparator.reverseOrder()).forEach(Files.delete(_))
+      }.orDie
+    )
+
+  private def write(dir: Path, name: String, content: String): UIO[Path] =
+    ZIO.attemptBlocking {
+      val path = dir.resolve(name)
+      Option(path.getParent).foreach(Files.createDirectories(_))
+      Files.write(path, content.getBytes(StandardCharsets.UTF_8))
+      path
+    }.orDie
+
+  private val comp3Card =
+    """---
+      |match: COMP-3|COMPUTE .* ROUNDED
+      |---
+      |COBOL packed-decimal money maps to BigDecimal scale 2; COMPUTE ROUNDED is
+      |RoundingMode.HALF_UP. Never float/double.""".stripMargin
+
+  private val redefinesCard =
+    """---
+      |match: REDEFINES
+      |---
+      |A REDEFINES view of a record maps to a sealed interface with one variant per
+      |interpretation — never two mutable views of one buffer.""".stripMargin
+
+  def spec: Spec[Environment & (TestEnvironment & Scope), Any] = suite("Patterns")(
+    test("load reads pattern cards from a directory — id from filename, match regex from frontmatter") {
+      ZIO.scoped {
+        for
+          dir   <- tempDir
+          _     <- write(dir, "PAT-COBOL-001-comp3-money.md", comp3Card)
+          _     <- write(dir, "PAT-COBOL-002-redefines.md", redefinesCard)
+          cards <- Patterns.load(dir)
+        yield assertTrue(
+          cards.map(_.id) == List("PAT-COBOL-001-comp3-money", "PAT-COBOL-002-redefines"),
+          cards.head.body.contains("HALF_UP"),
+          cards.head.matches == "COMP-3|COMPUTE .* ROUNDED",
+        )
+      }
+    },
+    test("load of an absent directory is an empty card set — patterns are optional") {
+      ZIO.scoped {
+        for
+          dir   <- tempDir
+          cards <- Patterns.load(dir.resolve("nope"))
+        yield assertTrue(cards.isEmpty)
+      }
+    },
+    test("matching selects exactly the cards whose regex hits the source text") {
+      ZIO.scoped {
+        for
+          dir   <- tempDir
+          _     <- write(dir, "PAT-COBOL-001-comp3-money.md", comp3Card)
+          _     <- write(dir, "PAT-COBOL-002-redefines.md", redefinesCard)
+          cards <- Patterns.load(dir)
+          cobol  = "       05  WS-FEE  PIC S9(5)V99 COMP-3.\n           COMPUTE WS-FEE ROUNDED = X * Y\n"
+        yield assertTrue(Patterns.matching(cobol, cards).map(_.id) == List("PAT-COBOL-001-comp3-money"))
+      }
+    },
+    test("tagged extracts the PAT- ids cited anywhere in a spec text") {
+      val spec = "Fee rounding follows PAT-COBOL-001-comp3-money; layout via PAT-COBOL-002-redefines."
+      assertTrue(Patterns.tagged(spec) == List("PAT-COBOL-001-comp3-money", "PAT-COBOL-002-redefines"))
+    },
+  )


### PR DESCRIPTION
Wave 3 of the bank-modernization master plan.

- **`flow.Patterns`** (TDD): pattern cards as data — frontmatter `match:` regex + translation body. Extraction tags traceability fragments deterministically; implementation injects only the cited cards; conformance is an advisory reviewer lens, never a gate.
- **Seed sets**: 25 COBOL→Java cards + 10 batch→streaming cards.
- **`cobol-kafka` pack**: COBOL batch → Kafka Streams topology with the batch→streaming mapping (records → keyed events, accumulators → keyed state stores, commit intervals → idempotence, reject file → reject topic), per-key equivalence, TopologyTestDriver replay harness.

All flow specs green (`testFull`); extract/implement scripts compile against publishLocal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)