### PR TITLE
Wave 4 — modernize-survey: the front bookend + pilot playbook (v3.26.0)

### DIFF
--- a/docs/legacy-modernization.md
+++ b/docs/legacy-modernization.md
@@ -1,21 +1,39 @@
 # Legacy modernization flows
 
-Five pack-parameterized flows that take a legacy estate (mainframe COBOL/JCL + DB2,
+Six pack-parameterized flows that take a legacy estate (mainframe COBOL/JCL + DB2,
 old J2EE/JSP, IBM ACE message flows) to a modern target (Spring Boot on a PaaS,
-Next.js SPA) through judged reverse-engineering, a human approval gate, gated
-implementation behind an **enforced clean-room wall**, a per-rule **equivalence
-proof**, and a review that feeds lessons back into future runs.
+Kafka Streams, Next.js SPA) through a deterministic estate survey, judged
+reverse-engineering, a human approval gate, gated implementation behind an
+**enforced clean-room wall**, a per-rule **equivalence proof**, and a review that
+feeds lessons back into future runs. Running a pilot on your own estate? Start
+with the [pilot playbook](pilot-playbook.md).
 
 ```
-modernize-extract.sc ──▶ (human approves) ──▶ modernize-seed.sc ──▶ modernize-implement.sc
-     legacy repo                                  target repo            target repo
-                                                                              │
-                              ┌── fix specs + plan ◀── modernize-verify.sc ◀──┘
-                              ▼                            target repo
-                     modernize-implement.sc ──▶ … ──▶ modernize-review.sc
-                                                          target repo
-                                                     lessons → the pack
+modernize-survey.sc ──▶ (human approves waves) ──▶ modernize-extract.sc ──▶ (human approves)
+     legacy repo                                        legacy repo
+        ──▶ modernize-seed.sc ──▶ modernize-implement.sc
+                target repo            target repo
+                                            │
+            ┌── fix specs + plan ◀── modernize-verify.sc ◀──┘
+            ▼                            target repo
+   modernize-implement.sc ──▶ … ──▶ modernize-review.sc
+                                        target repo
+                                   lessons → the pack
 ```
+
+## Phase 0 — survey (rooted at the legacy repo)
+
+`modernize-survey.sc` answers "what do we have, what depends on what, in what
+order" — deterministic-first (`flow.Survey`): one inventory node per source file
+(size = lines + coverage units), one dependency edge per `## Survey:` regex match
+(`CALL`, `COPY`, `EXEC PGM=`) → `inventory.md` + `graph.json`, committed and
+auditable at any estate size. The LLM enters only for what regexes cannot decide:
+classifying each unit **rewrite / retire / wrap** (wrap = keep + front with an
+API; building wraps is out of scope), resolving dynamic `CALL` variables, and
+proposing dependency-coherent **waves**. The wave plan lands with an unchecked
+approval marker — and when `bench-results.jsonl` exists from `modernize-bench.sc`
+runs, it carries a per-wave **cost projection from measured runs**. After
+approval, `LLM4ZIO_WAVE=wave-1` scopes extraction to that wave's programs.
 
 The clean-room split is enforced, not just practiced: only extract and its gate ever
 touch legacy source; implement/verify/review refuse to start if anything matching the

--- a/docs/pilot-playbook.md
+++ b/docs/pilot-playbook.md
@@ -1,0 +1,86 @@
+# Bank pilot playbook
+
+The operator's guide to running a modernization pilot on your own estate with
+llm4zio — written for the platform engineer who must convince their risk
+committee. A pilot is one wave of ~10–20 programs through all six phases, ending
+with an evidence bundle, not a demo.
+
+## What you need
+
+- **The legacy repo**: your COBOL/JCL (or JSP, or ACE) sources in git. Nothing
+  leaves it — extraction runs rooted there.
+- **An empty target repo** and, ideally, your own scaffold (your golden-path
+  Spring Boot/Kafka starter). The shipped scaffolds are stand-ins.
+- **A pack**: copy the closest shipped pack (`examples/packs/…`) and rewrite it
+  in your estate's vocabulary — prompts, judge rubrics, coverage and survey
+  regexes, gates. The pack is where your know-how accumulates; version it.
+- **Seats**: a reasoning/judge model and a CLI coder (`claude`, `codex`,
+  `gemini`). JDK 21+, scala-cli, maven, git.
+
+## Residency: the wall is the boundary
+
+Only two phases ever read legacy source: **extract** and its **gate judge**.
+If your source is licensed or classified, point those seats at your on-prem
+OpenAI-compatible endpoint (vLLM on your GPU infra — the `LmStudio`/`OpenAI`
+connectors speak to any such endpoint) and let the rest of the pipeline use
+cloud coders: past the human approval, the enforced wall (`flow.Wall`)
+guarantees there is no source left to leak — implement/verify/review refuse to
+start if any file matching the pack's `sources:` regex is present in the
+target.
+
+## The six phases
+
+```bash
+export LLM4ZIO_PACK=packs/your-pack
+export LLM4ZIO_RUN_LABEL=pilot-wave-1     # correlates every phase in the cost ledger
+export LLM4ZIO_APPROVER="your name"       # recorded in the provenance manifest
+
+# 0) survey: inventory + dependency graph + triage + wave plan (halts for approval)
+scala-cli run modernize-survey.sc -- --repo ~/estates/your-legacy
+
+#    review docs/modernization/wave-plan.md, flip "- [x] Approved"
+
+# 1) extract wave 1 into a judged spec pack (halts unapproved)
+LLM4ZIO_WAVE=wave-1 scala-cli run modernize-extract.sc -- --repo ~/estates/your-legacy
+
+#    review docs/modernization/README.md, flip "- [x] Approved"
+
+# 2) seed the target (deterministic; writes the provenance manifest)
+LLM4ZIO_LEGACY_REPO=~/estates/your-legacy \
+  scala-cli run modernize-seed.sc -- --repo ~/services/your-target
+
+# 3) implement, gated until green (RED-first acceptance tests, pack gates, judge)
+scala-cli run modernize-implement.sc -- --repo ~/services/your-target
+
+# 4) prove equivalence (generated-first vectors; halts non-green)
+scala-cli run modernize-verify.sc -- --repo ~/services/your-target
+
+# 5) review: fix specs + plan increment + lessons back into your pack
+scala-cli run modernize-review.sc -- --repo ~/services/your-target
+```
+
+Every phase is resumable (plans, per-program spec files, cached gate verdicts,
+per-program vector files); rerunning skips what exists. Provider quota
+exhaustion fails fast with the reset time (`LLM4ZIO_USAGE_WAIT=24h` waits it
+out and auto-resumes).
+
+## Captured vectors: upgrading the proof
+
+Generated vectors prove **spec conformance** from day one. To upgrade to
+**behavioural equivalence**, record real legacy runs into the vector JSONL
+format (`docs/modernization/vectors/*.jsonl`, `"tier":"captured"` — see
+`tools/cobol-capture.sc` for the worked GnuCOBOL example and the format) using
+your existing parallel-run capture tooling. llm4zio never needs mainframe
+access; the JSONL file is the hand-off.
+
+## The evidence bundle you end with
+
+| Artifact | What it proves |
+| -------- | -------------- |
+| `inventory.md` + `graph.json` + approved `wave-plan.md` | You know what you have and migrate in dependency order, with a cost projection from measured runs |
+| Spec pack + `gate/*.json` verdicts | Every paragraph/step covered; specs judged complete, faithful, testable — per program |
+| `provenance.json` | What crossed the wall, hashed (`shasum`-checkable), who approved, which models ran |
+| `equivalence.md` | Per spec rule: proven (generated / captured, never summed), failing, or unexercised |
+| `.llm4zio/costs.jsonl` | Every token and estimated cost, per stage × agent × model, correlated by run label |
+
+That bundle — not a slide deck — is what goes to the risk committee.

--- a/examples/modernize-extract.sc
+++ b/examples/modernize-extract.sc
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla::llm4zio-runner:3.25.0"
+//> using dep "io.github.riccardomerolla::llm4zio-runner:3.26.0"
 //> using scala "3.8.3"
 //> using jvm 21
 
@@ -144,6 +144,16 @@ def capText(text: String, limit: Int): String =
   else
     val head = limit * 3 / 4
     s"${text.take(head)}\n\n… [truncated] …\n\n${text.takeRight(limit - head)}"
+
+/** The `- PROG` entries of `## Wave: <name>` in the survey's wave plan. */
+def wavePrograms(planText: String, wave: String): List[String] =
+  val lines = planText.linesIterator.toList
+  lines
+    .dropWhile(_.trim != s"## Wave: $wave")
+    .drop(1)
+    .takeWhile(l => !l.trim.startsWith("## "))
+    .map(_.trim)
+    .collect { case l if l.startsWith("- ") => l.drop(2).trim }
 
 /** `cobol/ACCTXFR.cbl` → `ACCTXFR`: the program name that keys every per-program artifact. */
 def programName(rel: String): String =
@@ -437,9 +447,23 @@ flow(
                   pack.lessons.map(l => s"Lessons from previous modernization runs — apply them:\n$l"),
                 ).flatten.mkString("\n\n")
     judge     = Judge.of(reasoning, pack.judgeDimensions)
-    programs <- stage("Inventory")(
+    all      <- stage("Inventory")(
                   SpecChecks.matchingFiles(workDir, pack.programs.orElse(pack.sources).getOrElse(""".*"""))
                 )
+    programs <- sys.env.get("LLM4ZIO_WAVE").map(_.trim).filter(_.nonEmpty) match
+                  case None       => ZIO.succeed(all)
+                  case Some(wave) => // survey's wave plan scopes this run — and must be human-approved first
+                    for
+                      _     <- stage("Wave")(
+                                 ApprovalGate.gate(modDir.resolve("wave-plan.md"), Interaction.noninteractive)
+                               )
+                      text  <- readFileOr(modDir.resolve("wave-plan.md"), "")
+                      names  = wavePrograms(text, wave).toSet
+                      scoped = all.filter(rel => names.contains(programName(rel)))
+                      _     <- ZIO.when(scoped.isEmpty)(
+                                 fail(s"wave '$wave' matches no programs in $ModDir/wave-plan.md")
+                               )
+                    yield scoped
     _        <- ZIO.when(programs.isEmpty)(
                   fail(s"no source units matched the pack's programs/sources regex under $workDir")
                 )

--- a/examples/modernize-implement.sc
+++ b/examples/modernize-implement.sc
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla::llm4zio-runner:3.25.0"
+//> using dep "io.github.riccardomerolla::llm4zio-runner:3.26.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/examples/modernize-review.sc
+++ b/examples/modernize-review.sc
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla::llm4zio-runner:3.25.0"
+//> using dep "io.github.riccardomerolla::llm4zio-runner:3.26.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/examples/modernize-seed.sc
+++ b/examples/modernize-seed.sc
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla::llm4zio-runner:3.25.0"
+//> using dep "io.github.riccardomerolla::llm4zio-runner:3.26.0"
 //> using scala "3.8.3"
 //> using jvm 21
 
@@ -44,7 +44,7 @@ import llm4zio.flow.*
 import llm4zio.runner.*
 
 val ModDir         = "docs/modernization"
-val Llm4zioVersion = "3.25.0" // keep in step with the `using dep` header pin
+val Llm4zioVersion = "3.26.0" // keep in step with the `using dep` header pin
 
 def writeFile(path: Path, content: String): IO[FlowError, Unit] =
   ZIO

--- a/examples/modernize-survey.sc
+++ b/examples/modernize-survey.sc
@@ -1,0 +1,192 @@
+//> using dep "io.github.riccardomerolla::llm4zio-runner:3.26.0"
+//> using scala "3.8.3"
+//> using jvm 21
+
+/** Legacy-modernization phase 0 of 5: survey the estate — inventory, dependency graph, triage,
+  * and a human-approved wave plan with a cost projection.
+  *
+  *   modernize-survey.sc → (human approves waves) → modernize-extract.sc → … → modernize-review.sc
+  *
+  * Runs ROOTED AT THE LEGACY REPO (`--repo <legacy>`). Banks stall before extraction because
+  * nobody can answer "what do we have, what depends on what, in what order do we migrate" —
+  * this phase answers all three, deterministic-first:
+  *
+  *   1. GRAPH (deterministic, `flow.Survey` — no LLM): one node per file matching the pack's
+  *      `sources:` regex (size = lines + coverage units), one edge per `## Survey:` rule match
+  *      (CALL / COPY / EXEC PGM=…). Written as `docs/modernization/inventory.md` (auditable
+  *      Markdown) + `graph.json` (machine-readable), committed.
+  *   2. TRIAGE (LLM, bounded to the graph): `reasoning` classifies each unit
+  *      rewrite | retire | wrap (wrap = keep and front with an API — classified here,
+  *      implementing wraps is out of scope), resolves what the regexes could not (dynamic CALL
+  *      variables), and proposes dependency-coherent WAVES.
+  *   3. WAVE PLAN (human-gated): `docs/modernization/wave-plan.md` carries the waves, the
+  *      per-unit dispositions, and — when `bench-results.jsonl` exists next to the scripts — a
+  *      per-wave cost/duration projection from real measured runs (`bench-report --project`).
+  *      The plan gets an UNCHECKED approval marker: a person reviews, flips it, and only then
+  *      does extraction start. Scope extraction to one wave with LLM4ZIO_WAVE=<name>.
+  *
+  * Run:  scala-cli run modernize-survey.sc -- --repo ~/estates/meridian-legacy
+  */
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{ Files, Path }
+
+import zio.json.*
+import zio.{ IO, ZIO }
+
+import llm4zio.core.SchemaDerivation
+import llm4zio.flow.*
+import llm4zio.runner.*
+
+val ProModel = "gemini-2.5-pro" // point these at whatever your `gemini` CLI offers
+val ModDir   = "docs/modernization"
+
+val (coderCfg, reasoningCfg) =
+  sys.env.get("LLM4ZIO_CODER").map(_.trim.toLowerCase).filter(_.nonEmpty) match
+    case None | Some("gemini") => (gemini, gemini.withModel(ProModel).copy(readOnly = true))
+    case Some(_)               =>
+      val agent = Connectors.coderFromEnv()
+      (agent, agent.copy(readOnly = true))
+
+/** One unit's disposition: rewrite (full modernization), retire (dead — decommission), or wrap
+  * (keep on the mainframe, front with an API; implementing the wrap is out of scope here).
+  */
+case class NodeTriage(name: String, disposition: String, rationale: String) derives JsonCodec
+
+case class WaveSlice(name: String, programs: List[String], rationale: String) derives JsonCodec
+
+case class SurveyOutcome(triage: List[NodeTriage], waves: List[WaveSlice], notes: List[String]) derives JsonCodec
+
+def writeFile(path: Path, content: String): IO[FlowError, Unit] =
+  ZIO
+    .attemptBlocking {
+      Option(path.getParent).foreach(Files.createDirectories(_))
+      Files.write(path, content.getBytes(StandardCharsets.UTF_8))
+      ()
+    }
+    .mapError(e => FlowError.Persistence(s"failed to write $path", Some(e)))
+
+def triagePrompt(graph: SurveyGraph, inventory: String): String =
+  s"""You are triaging a legacy estate for modernization. Below are its deterministic
+     |inventory and dependency graph (regex-derived from the source — trust them).
+     |
+     |Produce:
+     |- "triage": for EVERY unit in the inventory, a disposition:
+     |  - "rewrite": actively used business logic to modernize;
+     |  - "retire": unreferenced/dead — candidate for decommissioning, with the evidence;
+     |  - "wrap": keep on the legacy platform and front with an API (shared utilities other
+     |    estates still call, or units out of this program's scope).
+     |  Rationale in one sentence, grounded in the graph (degrees, callers, size).
+     |- "waves": dependency-coherent migration slices for the REWRITE units: a wave's programs
+     |  should depend only on already-migrated or same-wave units where possible; leaves and
+     |  low-fan-in units first; name each wave (wave-1, wave-2, …) and give the ordering
+     |  rationale.
+     |- "notes": anything the graph could not resolve — dynamic CALL variables, cycles worth a
+     |  human look. Empty if none.
+     |
+     |Inventory:
+     |$inventory
+     |
+     |Graph (JSON):
+     |${graph.toJson}""".stripMargin
+
+def renderWavePlan(outcome: SurveyOutcome, graph: SurveyGraph, projection: Option[String]): String =
+  val triageRows = outcome.triage
+    .sortBy(_.name)
+    .map(t => s"| ${t.name} | ${t.disposition} | ${t.rationale} |")
+  val waveSecs   = outcome.waves.map { w =>
+    (s"## Wave: ${w.name}" ::
+      "" ::
+      s"${w.rationale}" ::
+      "" ::
+      w.programs.map(p => s"- $p")).mkString("\n") + "\n"
+  }
+  val notes      =
+    if outcome.notes.isEmpty then Nil
+    else "## Needs a human look" :: "" :: outcome.notes.map(n => s"- $n") ::: List("")
+  (List(
+    "# Modernization wave plan",
+    "",
+    s"${graph.nodes.size} unit(s) surveyed, ${outcome.waves.size} wave(s) proposed.",
+    "Scope extraction to one wave with `LLM4ZIO_WAVE=<name>` once this plan is approved.",
+    "",
+    "| Unit | Disposition | Rationale |",
+    "| ---- | ----------- | --------- |",
+  ) ++ triageRows ++ List("") ++ waveSecs ++ notes ++ projection.toList).mkString("\n") + "\n"
+
+flow(
+  args,
+  coder = coderCfg,
+  reasoning = Some(reasoningCfg),
+  defaultPrompt = Some("Survey the legacy estate and propose a migration wave plan"),
+):
+  val packDir = workspace.resolve(sys.env.getOrElse("LLM4ZIO_PACK", "packs/cobol-springboot"))
+  val modDir  = workDir.resolve(ModDir)
+  val events  = summon[FlowEvents]
+
+  for
+    pack      <- stage("Pack")(Pack.load(packDir))
+    _         <- ZIO.when(pack.survey.isEmpty)(
+                   ZIO.fail(FlowError.Aborted(
+                     s"pack '${pack.name}' has no '## Survey:' sections — add the dependency-edge regexes " +
+                       "(CALL/COPY/EXEC PGM…) the graph should be built from"
+                   ))
+                 )
+    graph     <- stage("Graph") {
+                   for
+                     g <- Survey.graph(
+                            workDir,
+                            sources = pack.sources.getOrElse(""".*"""),
+                            units = pack.coverage,
+                            edges = pack.survey,
+                          )
+                     _ <- writeFile(modDir.resolve("inventory.md"), Survey.renderInventory(g))
+                     _ <- writeFile(modDir.resolve("graph.json"), g.toJsonPretty)
+                     _ <- events.publish(FlowEvent.Info(s"${g.nodes.size} unit(s), ${g.edges.size} edge(s)"))
+                   yield g
+                 }
+    outcome   <- stage("Triage") {
+                   reasoning
+                     .executeStructured[SurveyOutcome](
+                       triagePrompt(graph, Survey.renderInventory(graph)),
+                       SchemaDerivation.derive[SurveyOutcome],
+                     )
+                     .mapError(e => FlowError.Llm(e.message, Some(e)))
+                 }
+    projection <- stage("Projection") {
+                    val bench = workspace.resolve("bench-results.jsonl")
+                    ZIO
+                      .attemptBlocking(Files.exists(bench))
+                      .orDie
+                      .flatMap {
+                        case false =>
+                          events
+                            .publish(FlowEvent.Info(
+                              "no bench-results.jsonl next to the scripts — wave plan ships without cost projection " +
+                                "(run modernize-bench.sc to measure, then rerun the survey)"
+                            ))
+                            .as(None)
+                        case true  =>
+                          BenchReport.load(List(bench)).map { records =>
+                            val first = outcome.waves.headOption.map(_.programs.size).getOrElse(0)
+                            Some(
+                              s"## Cost projection (wave-1, $first program(s), from measured runs)\n\n" +
+                                BenchReport.render(records, projectPrograms = Some(first)) +
+                                "\n\nOther waves: `scala-cli run bench-report.sc -- bench-results.jsonl --project <n>`.\n"
+                            )
+                          }
+                      }
+                  }
+    planMd     = renderWavePlan(outcome, graph, projection)
+    _         <- stage("Wave plan")(
+                   writeFile(modDir.resolve("wave-plan.md"), ApprovalGate.withDraftMarker(planMd))
+                 )
+    _         <- stage("Commit")(
+                   git.commitAll(s"modernize(${pack.name}): survey — ${graph.nodes.size} unit(s), " +
+                     s"${outcome.waves.size} wave(s) proposed").unit
+                 )
+    _         <- events.publish(FlowEvent.Info(
+                   s"review $ModDir/wave-plan.md, flip '- [x] Approved', then run modernize-extract.sc " +
+                     "(LLM4ZIO_WAVE=<name> scopes it to one wave)"
+                 ))
+  yield s"units=${graph.nodes.size} waves=${outcome.waves.size}"

--- a/examples/modernize-verify.sc
+++ b/examples/modernize-verify.sc
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla::llm4zio-runner:3.25.0"
+//> using dep "io.github.riccardomerolla::llm4zio-runner:3.26.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/examples/packs/cobol-kafka/pack.md
+++ b/examples/packs/cobol-kafka/pack.md
@@ -34,3 +34,18 @@ unit: ^ {7}(\d{4}-[A-Z0-9-]+)\.
 
 files: .*\.(jcl|JCL)
 unit: ^//([A-Z0-9]+) +EXEC
+
+## Survey: calls
+
+files: .*\.(cbl|CBL)
+unit: CALL '([A-Z0-9]+)'
+
+## Survey: copies
+
+files: .*\.(cbl|CBL)
+unit: ^ {6}[ ]*COPY +([A-Z0-9]+)
+
+## Survey: exec-pgm
+
+files: .*\.(jcl|JCL)
+unit: EXEC +PGM=([A-Z0-9]+)

--- a/examples/packs/cobol-springboot/pack.md
+++ b/examples/packs/cobol-springboot/pack.md
@@ -34,3 +34,18 @@ unit: ^ {7}(\d{4}-[A-Z0-9-]+)\.
 
 files: .*\.(jcl|JCL)
 unit: ^//([A-Z0-9]+) +EXEC
+
+## Survey: calls
+
+files: .*\.(cbl|CBL)
+unit: CALL '([A-Z0-9]+)'
+
+## Survey: copies
+
+files: .*\.(cbl|CBL)
+unit: ^ {6}[ ]*COPY +([A-Z0-9]+)
+
+## Survey: exec-pgm
+
+files: .*\.(jcl|JCL)
+unit: EXEC +PGM=([A-Z0-9]+)

--- a/examples/tools/cobol-capture.sc
+++ b/examples/tools/cobol-capture.sc
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla::llm4zio-runner:3.25.0"
+//> using dep "io.github.riccardomerolla::llm4zio-runner:3.26.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/modules/llm4zio-flow/src/main/scala/llm4zio/flow/Pack.scala
+++ b/modules/llm4zio-flow/src/main/scala/llm4zio/flow/Pack.scala
@@ -33,6 +33,9 @@ final case class Pack(
   equivalence: ComparisonPolicy,
   judgeDimensions: List[Dimension],
   coverage: List[CoverageRule],
+  // Dependency-edge regexes (`## Survey: <name>` sections) the survey flow scans the estate with:
+  // each match in a file becomes an edge from that file's unit to the captured name.
+  survey: List[CoverageRule],
   prompts: Map[String, String],
   lenses: List[Reviewer],
   lessons: Option[String],
@@ -135,6 +138,7 @@ object Pack:
                 equivalence = section(sections, "Equivalence").fold(ComparisonPolicy.default)(equivalencePolicy),
                 judgeDimensions = section(sections, "Judge").fold(List.empty[Dimension])(dimensions),
                 coverage = coverageRules(sections),
+                survey = prefixedRules(sections, "## Survey: "),
                 prompts = Map.empty,
                 lenses = Nil,
                 lessons = None,
@@ -175,14 +179,18 @@ object Pack:
 
   /** Every `## Coverage: <name>` section, each carrying `files:` and `unit:` regexes. */
   private def coverageRules(sections: List[String]): List[CoverageRule] =
+    prefixedRules(sections, "## Coverage: ")
+
+  /** Every `## <prefix><name>` section carrying `files:` and `unit:` regexes — the shape Coverage and Survey share. */
+  private def prefixedRules(sections: List[String], prefix: String): List[CoverageRule] =
     sections.flatMap { s =>
       val lines = s.linesIterator.toList
-      lines.headOption.map(_.trim).filter(_.startsWith("## Coverage: ")).flatMap { header =>
+      lines.headOption.map(_.trim).filter(_.startsWith(prefix)).flatMap { header =>
         val fields = keyValues(lines.tail)
         for
           files <- fields.get("files")
           unit  <- fields.get("unit")
-        yield CoverageRule(header.drop("## Coverage: ".length).trim, files, unit)
+        yield CoverageRule(header.drop(prefix.length).trim, files, unit)
       }
     }
 

--- a/modules/llm4zio-flow/src/main/scala/llm4zio/flow/Survey.scala
+++ b/modules/llm4zio-flow/src/main/scala/llm4zio/flow/Survey.scala
@@ -1,0 +1,99 @@
+package llm4zio.flow
+
+import java.nio.file.{ Files, Path }
+
+import scala.jdk.CollectionConverters.*
+
+import zio.json.JsonCodec
+import zio.{ IO, ZIO }
+
+/** One unit in the estate inventory: a program, job, copybook, or descriptor — whatever the pack's `sources:` regex
+  * enumerates. `units` counts the pack's coverage units inside it (paragraphs, steps) as a size signal.
+  */
+final case class SurveyNode(path: String, name: String, lines: Int, units: Int) derives JsonCodec
+
+/** One dependency edge, named after the survey rule that found it (`calls`, `copies`, `exec-pgm`, …). */
+final case class SurveyEdge(from: String, to: String, kind: String) derives JsonCodec
+
+final case class SurveyGraph(nodes: List[SurveyNode], edges: List[SurveyEdge]) derives JsonCodec:
+  def incoming(name: String): List[SurveyEdge] = edges.filter(_.to == name)
+  def outgoing(name: String): List[SurveyEdge] = edges.filter(_.from == name)
+
+/** The deterministic front bookend: inventory + dependency graph built from regexes alone — `SpecChecks` style, no LLM.
+  * Banks stall before extraction because nobody can say what the estate contains and what depends on what; this answers
+  * both, cheaply and auditable, at any estate size. The LLM enters only afterwards, for the judgments the graph cannot
+  * make (dynamic CALL targets, rewrite/retire/wrap triage, wave slicing).
+  */
+object Survey:
+
+  /** Build the estate graph: one node per file matching `sources` (unit counts via `units` rules), one edge per
+    * survey-rule match — from the containing file's unit name to the captured target name.
+    */
+  def graph(root: Path, sources: String, units: List[CoverageRule], edges: List[CoverageRule])
+    : IO[FlowError, SurveyGraph] =
+    ZIO
+      .attemptBlocking {
+        val stream = Files.walk(root)
+        val files  =
+          try stream.iterator().asScala.filter(Files.isRegularFile(_)).toList.sortBy(_.toString)
+          finally stream.close()
+        val scoped = files
+          .map(f => root.relativize(f).toString.replace('\\', '/') -> f)
+          .filter((rel, _) => rel.matches(sources))
+
+        val nodes = scoped.map { (rel, file) =>
+          val text      = Files.readString(file)
+          val lineCount = text.linesIterator.size
+          val unitCount = units
+            .filter(rule => rel.matches(rule.files))
+            .map(rule => text.linesIterator.flatMap(rule.unit.r.findFirstMatchIn(_)).size)
+            .sum
+          SurveyNode(rel, unitName(rel), lineCount, unitCount)
+        }
+
+        val found = edges.flatMap { rule =>
+          scoped
+            .filter((rel, _) => rel.matches(rule.files))
+            .flatMap { (rel, file) =>
+              val text  = Files.readString(file)
+              val regex = rule.unit.r
+              regex
+                .findAllMatchIn(text)
+                .map(m => if m.groupCount >= 1 then m.group(1) else m.matched)
+                .toList
+                .distinct
+                .map(target => SurveyEdge(unitName(rel), target, rule.name))
+            }
+        }
+        SurveyGraph(nodes, found.distinct)
+      }
+      .mapError(e => FlowError.Persistence(s"failed to survey $root", Some(e)))
+
+  /** The inventory as Markdown: one row per node with size and degree signals; nodes nothing references and that
+    * reference nothing are flagged `unreferenced` — the deterministic retire-candidate floor (entry points like jobs
+    * have outgoing edges, so they never trip it).
+    */
+  def renderInventory(graph: SurveyGraph): String =
+    val rows = graph.nodes.sortBy(_.name).map { n =>
+      val in    = graph.incoming(n.name).size
+      val out   = graph.outgoing(n.name).size
+      val flags = if in == 0 && out == 0 then "unreferenced — retire candidate?" else ""
+      s"| ${n.name} | ${n.path} | ${n.lines} | ${n.units} | $in | $out | $flags |"
+    }
+    (List(
+      "# Estate inventory",
+      "",
+      "| Unit | Path | Lines | Units | In | Out | Flags |",
+      "| ---- | ---- | ----- | ----- | -- | --- | ----- |",
+    ) ++ rows ++ List(
+      "",
+      s"${graph.nodes.size} unit(s), ${graph.edges.size} edge(s). Edges and counts are regex-derived",
+      "(`## Survey:` / `## Coverage:` rules in the pack) — deterministic, auditable, re-runnable.",
+    )).mkString("", "\n", "\n")
+
+  /** `cobol/ACCTXFR.cbl` → `ACCTXFR`. */
+  private def unitName(rel: String): String =
+    val base = rel.split('/').last
+    base.take(base.lastIndexOf('.') match
+      case -1 => base.length
+      case i  => i)

--- a/modules/llm4zio-flow/src/test/scala/llm4zio/flow/PackSpec.scala
+++ b/modules/llm4zio-flow/src/test/scala/llm4zio/flow/PackSpec.scala
@@ -264,6 +264,35 @@ object PackSpec extends ZIOSpecDefault:
         yield assertTrue(pack.equivalence == ComparisonPolicy(Equiv.Ordering.PerKey, Set.empty))
       }
     },
+    test("load parses Survey sections — the dependency-edge regexes the survey flow scans with") {
+      val manifest =
+        s"""$minimalManifest
+           |## Survey: calls
+           |
+           |files: .*\\.cbl
+           |unit: CALL '([A-Z0-9]+)'
+           |
+           |## Survey: exec-pgm
+           |
+           |files: .*\\.jcl
+           |unit: EXEC PGM=([A-Z0-9]+)
+           |""".stripMargin
+      ZIO.scoped {
+        for
+          dir      <- tempDir
+          _        <- write(dir, "pack.md", manifest)
+          pack     <- Pack.load(dir)
+          _        <- write(dir, "pack.md", minimalManifest)
+          defaults <- Pack.load(dir)
+        yield assertTrue(
+          pack.survey == List(
+            CoverageRule("calls", """.*\.cbl""", """CALL '([A-Z0-9]+)'"""),
+            CoverageRule("exec-pgm", """.*\.jcl""", """EXEC PGM=([A-Z0-9]+)"""),
+          ),
+          defaults.survey.isEmpty,
+        )
+      }
+    },
     test("load fails typed on a missing manifest and on a malformed one") {
       ZIO.scoped {
         for

--- a/modules/llm4zio-flow/src/test/scala/llm4zio/flow/SurveySpec.scala
+++ b/modules/llm4zio-flow/src/test/scala/llm4zio/flow/SurveySpec.scala
@@ -1,0 +1,101 @@
+package llm4zio.flow
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{ Files, Path }
+
+import zio.*
+import zio.test.*
+
+object SurveySpec extends ZIOSpecDefault:
+
+  private val tempDir: ZIO[Scope, Nothing, Path] =
+    ZIO.acquireRelease(ZIO.attempt(Files.createTempDirectory("llm4zio-survey-")).orDie)(d =>
+      ZIO.attempt {
+        Files.walk(d).sorted(java.util.Comparator.reverseOrder()).forEach(Files.delete(_))
+      }.orDie
+    )
+
+  private def write(dir: Path, name: String, content: String): UIO[Path] =
+    ZIO.attemptBlocking {
+      val path = dir.resolve(name)
+      Option(path.getParent).foreach(Files.createDirectories(_))
+      Files.write(path, content.getBytes(StandardCharsets.UTF_8))
+      path
+    }.orDie
+
+  private val acctxfr =
+    """       IDENTIFICATION DIVISION.
+      |       COPY ACCTREC.
+      |       PROCEDURE DIVISION.
+      |       2100-VALIDATE.
+      |           CALL 'INTCALC' USING WS-X.
+      |""".stripMargin
+
+  private val intcalc =
+    """       IDENTIFICATION DIVISION.
+      |       PROCEDURE DIVISION.
+      |       1000-RATES.
+      |           CONTINUE.
+      |""".stripMargin
+
+  private val jcl = "//STEP020 EXEC PGM=ACCTXFR\n"
+
+  private val surveyRules = List(
+    CoverageRule("calls", """.*\.cbl""", """CALL '([A-Z0-9]+)'"""),
+    CoverageRule("copies", """.*\.cbl""", """COPY ([A-Z0-9]+)"""),
+    CoverageRule("exec-pgm", """.*\.jcl""", """EXEC PGM=([A-Z0-9]+)"""),
+  )
+
+  private def estate(dir: Path): UIO[Unit] =
+    (write(dir, "cobol/ACCTXFR.cbl", acctxfr) *>
+      write(dir, "cobol/INTCALC.cbl", intcalc) *>
+      write(dir, "cobol/copybooks/ACCTREC.cpy", "       01  ACCT-REC.\n") *>
+      write(dir, "jobs/XFERDLY.jcl", jcl)).unit
+
+  def spec: Spec[Environment & (TestEnvironment & Scope), Any] = suite("Survey")(
+    test("graph enumerates nodes from the sources regex with line and unit counts") {
+      ZIO.scoped {
+        for
+          dir   <- tempDir
+          _     <- estate(dir)
+          graph <- Survey.graph(
+                     dir,
+                     sources = """.*\.(cbl|cpy|jcl)""",
+                     units = List(CoverageRule("paragraph", """.*\.cbl""", """^ {7}(\d{4}-[A-Z0-9-]+)\.""")),
+                     edges = surveyRules,
+                   )
+        yield assertTrue(
+          graph.nodes.map(_.name).sorted == List("ACCTREC", "ACCTXFR", "INTCALC", "XFERDLY"),
+          graph.nodes.find(_.name == "ACCTXFR").exists(n => n.lines == 5 && n.units == 1),
+        )
+      }
+    },
+    test("graph resolves edges by scanning each file with the pack's survey regexes") {
+      ZIO.scoped {
+        for
+          dir   <- tempDir
+          _     <- estate(dir)
+          graph <- Survey.graph(dir, """.*\.(cbl|cpy|jcl)""", Nil, surveyRules)
+        yield assertTrue(
+          graph.edges.contains(SurveyEdge("ACCTXFR", "INTCALC", "calls")),
+          graph.edges.contains(SurveyEdge("ACCTXFR", "ACCTREC", "copies")),
+          graph.edges.contains(SurveyEdge("XFERDLY", "ACCTXFR", "exec-pgm")),
+        )
+      }
+    },
+    test("renderInventory lists every node and flags unreferenced non-job nodes as retire candidates") {
+      ZIO.scoped {
+        for
+          dir   <- tempDir
+          _     <- estate(dir)
+          _     <- write(dir, "cobol/ORPHAN.cbl", "       IDENTIFICATION DIVISION.\n")
+          graph <- Survey.graph(dir, """.*\.(cbl|cpy|jcl)""", Nil, surveyRules)
+          md     = Survey.renderInventory(graph)
+        yield assertTrue(
+          md.linesIterator.exists(l => l.contains("ACCTXFR")),
+          md.linesIterator.exists(l => l.contains("ORPHAN") && l.contains("unreferenced")),
+          !md.linesIterator.exists(l => l.contains("XFERDLY") && l.contains("unreferenced")),
+        )
+      }
+    },
+  )


### PR DESCRIPTION
Wave 4 of the bank-modernization master plan.

- **`flow.Survey`** (TDD): deterministic inventory + dependency graph from the pack's `## Survey:` regexes; unreferenced units flagged as retire candidates.
- **`modernize-survey.sc`** (phase 0 of 6): Graph (no LLM) → Triage (rewrite/retire/wrap, waves) → human-gated `wave-plan.md` with per-wave **cost projection from measured bench runs**.
- **Wave-scoped extraction**: `LLM4ZIO_WAVE=<name>` gates on the approved plan.
- **`docs/pilot-playbook.md`**: the operator's guide — residency boundary, six phases, captured-vector upgrade, the evidence bundle.

All flow specs green (`testFull`); survey/extract scripts compile against publishLocal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)