### PR TITLE
Wave 5 — llm4zio-modernize: the pipeline as a product (v4.0.0)

### DIFF
--- a/.github/workflows/oci.yml
+++ b/.github/workflows/oci.yml
@@ -1,0 +1,55 @@
+name: OCI image
+
+# Builds and pushes ghcr.io/riccardomerolla/llm4zio-modernize:<version> after a
+# release tag. Maven Central sync can lag the publish job, so the build retries
+# resolution for up to ~20 minutes before giving up.
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "llm4zio version to package (e.g. 4.0.0)"
+        required: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  oci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Resolve version
+        id: v
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+        run: |
+          V="${INPUT_VERSION:-${GITHUB_REF_NAME#v}}"
+          echo "$V" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+([.-][A-Za-z0-9.-]+)?$' \
+            || { echo "refusing suspicious version '$V'" >&2; exit 1; }
+          echo "version=$V" >> "$GITHUB_OUTPUT"
+      - name: Wait for Maven Central sync
+        run: |
+          V="${{ steps.v.outputs.version }}"
+          URL="https://repo1.maven.org/maven2/io/github/riccardomerolla/llm4zio-modernize_3/$V/llm4zio-modernize_3-$V.pom"
+          for i in $(seq 1 40); do
+            if curl -sfo /dev/null "$URL"; then echo "available"; exit 0; fi
+            echo "not yet on Central ($i/40) — sleeping 30s"; sleep 30
+          done
+          echo "artifact never appeared on Central" >&2; exit 1
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          build-args: |
+            LLM4ZIO_VERSION=${{ steps.v.outputs.version }}
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/llm4zio-modernize:${{ steps.v.outputs.version }}
+            ghcr.io/${{ github.repository_owner }}/llm4zio-modernize:latest

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,46 @@
+name: Docs & benchmark page
+
+# Publishes docs/ (plus the current benchmark.md from examples/) to GitHub Pages.
+# Benchmark numbers are refreshed manually per release — bench runs burn real
+# provider quota, so CI never runs them.
+on:
+  push:
+    branches: [main]
+    paths: ["docs/**", "examples/benchmark.md", ".github/workflows/pages.yml"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Assemble site sources
+        run: |
+          mkdir -p _site_src
+          cp -R docs/* _site_src/
+          [ -f examples/benchmark.md ] && cp examples/benchmark.md _site_src/benchmark.md || true
+          [ -f _site_src/index.md ] || cp _site_src/legacy-modernization.md _site_src/index.md
+      - uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./_site_src
+          destination: ./_site
+      - uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# llm4zio-modernize — the modernization pipeline as an OCI image, for air-gapped
+# and CI use: JDK 21 + git + maven + the published module resolved at build time,
+# so at run time nothing is fetched.
+#
+#   docker build --build-arg LLM4ZIO_VERSION=4.0.0 -t llm4zio-modernize .
+#   docker run --rm -v $ESTATE:/work -w /work \
+#     -e LLM4ZIO_PACK=/packs/your-pack ghcr.io/riccardomerolla/llm4zio-modernize:4.0.0 \
+#     survey -- --repo /work
+#
+# CLI coding agents (claude/codex/gemini) must be present for the phases that use
+# them — mount or bake them per your seat configuration; survey/seed run without.
+FROM eclipse-temurin:21-jre-jammy
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends git maven curl ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fLo /usr/local/bin/cs https://github.com/coursier/launchers/raw/master/coursier \
+ && chmod +x /usr/local/bin/cs
+
+ARG LLM4ZIO_VERSION
+RUN test -n "$LLM4ZIO_VERSION" || (echo "build with --build-arg LLM4ZIO_VERSION=<x.y.z>" && exit 1)
+
+# Resolve the module and its full dependency graph into the image.
+RUN cs fetch "io.github.riccardomerolla:llm4zio-modernize_3:${LLM4ZIO_VERSION}" > /opt/llm4zio-cp.txt \
+ && paste -sd: /opt/llm4zio-cp.txt > /opt/llm4zio-classpath
+
+COPY docker-entrypoint.sh /usr/local/bin/llm4zio-modernize
+RUN chmod +x /usr/local/bin/llm4zio-modernize
+
+ENTRYPOINT ["llm4zio-modernize"]

--- a/README.md
+++ b/README.md
@@ -21,6 +21,18 @@ Start at [docs/legacy-modernization.md](docs/legacy-modernization.md), or run th
 examples/seed.sh modernize
 ```
 
+For bank platform teams the pipeline also ships as a **product** — no Scala to
+edit: the `llm4zio-modernize` artifact carries all six phases behind one
+subcommand main (`survey|extract|seed|implement|verify|review`), configured by
+your pack + env/`modernize.conf`:
+
+```bash
+cs launch io.github.riccardomerolla:llm4zio-modernize_3:4.0.0 -- survey -- --repo ~/estates/your-legacy
+```
+
+or, air-gapped/CI, the OCI image `ghcr.io/riccardomerolla/llm4zio-modernize`.
+The operator's guide is [docs/pilot-playbook.md](docs/pilot-playbook.md).
+
 Under it sits the general-purpose library: llm4zio lets you programmatically
 define software-development workflows where AI agents do the coding. If you want
 AI-generated code to always be reviewed by another agent, don't coerce the

--- a/build.sbt
+++ b/build.sbt
@@ -163,8 +163,26 @@ lazy val llm4zioJava = (project in file("modules/llm4zio-java"))
     quietDocLinks,
   )
 
+// ── llm4zio-modernize ─────────────────────────────────────────────────────────
+// The modernization pipeline as a product: the six flows (survey → extract →
+// seed → implement → verify → review) behind one subcommand main, so a bank
+// platform team runs the pipeline without editing Scala (`cs launch` / OCI).
+// The .sc examples remain the authoring/customization surface; this module is
+// the operator surface. See .claude/plans/bank-modernization-master-plan.md.
+lazy val llm4zioModernize = (project in file("modules/llm4zio-modernize"))
+  .dependsOn(llm4zioRunner, llm4zioFlow, llm4zioCore)
+  .settings(
+    name                 := "llm4zio-modernize",
+    description          := "The llm4zio legacy-modernization pipeline as a runnable product",
+    Compile / mainClass  := Some("llm4zio.modernize.Main"),
+    libraryDependencySchemes += "dev.zio" %% "zio-json" % VersionScheme.Always,
+    libraryDependencies ++= zioCoreDeps ++ Seq(zioJsonDep, zioHttpDep, fansiDep) ++ zioLoggingDeps ++ zioTestDeps,
+    testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
+    quietDocLinks,
+  )
+
 lazy val root = (project in file("."))
-  .aggregate(llm4zioCore, llm4zioFlow, llm4zioRunner, llm4zioJava)
+  .aggregate(llm4zioCore, llm4zioFlow, llm4zioRunner, llm4zioJava, llm4zioModernize)
   .settings(
     name           := "llm4zio",
     publish / skip := true,

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Entrypoint for the llm4zio-modernize OCI image: run the pipeline main on the
+# classpath resolved at image-build time (no network at run time).
+exec java -cp "$(cat /opt/llm4zio-classpath)" llm4zio.modernize.Main "$@"

--- a/docs/legacy-modernization.md
+++ b/docs/legacy-modernization.md
@@ -276,6 +276,31 @@ ways out:
 - Point the seats at a model with remaining quota (e.g. swap the `ProModel` val
   to `gemini-2.5-flash`) and rerun.
 
+## The operator surface: llm4zio-modernize
+
+The six flows also ship as a published module with a subcommand main —
+`llm4zio-modernize survey|extract|seed|implement|verify|review` — so an
+operator runs the pipeline without editing Scala: `cs launch
+io.github.riccardomerolla:llm4zio-modernize_3:<version> -- <phase> -- --repo
+<dir>`, or the `ghcr.io/riccardomerolla/llm4zio-modernize` OCI image
+(air-gapped/CI; JDK + git + maven + the resolved classpath baked in).
+Configuration is env-first with `./modernize.conf` (KEY=value) filling gaps —
+deployment choices (seats, models, endpoints) live there, estate knowledge
+stays in the pack. The `.sc` scripts remain the authoring surface and the two
+stay in lockstep (the module is a direct port of the scripts).
+
+### The local-model lane (on-prem extraction)
+
+Only extract and its gate judge ever read legacy source, so those are the
+seats to pin on-prem when source is protected: any OpenAI-compatible endpoint
+works for the API seats (vLLM/TGI on bank GPU infra — the `LmStudio`/`OpenAI`
+connectors take a base URL), and `LLM4ZIO_CODER=opencode` runs the analyst on
+a local-model-backed CLI coder. Benchmark the lane before claiming numbers:
+point `modernize-bench.sc` at the local seat exactly like any other coder —
+its judged extraction scores (coverage %, completeness/faithfulness) are the
+evidence that a 30–70B open-weight model holds up on your estate; publish
+nothing you have not measured.
+
 ## Token & cost traceability
 
 Every flow run appends one structured record to an append-only ledger —

--- a/docs/pilot-playbook.md
+++ b/docs/pilot-playbook.md
@@ -28,6 +28,21 @@ guarantees there is no source left to leak — implement/verify/review refuse to
 start if any file matching the pack's `sources:` regex is present in the
 target.
 
+## Two ways to run the pipeline
+
+Everything below shows the `.sc` scripts (clone the repo, `scala-cli run …`) —
+the authoring surface, best when you are customizing flows. The **operator
+surface** is the published product, no repo clone and no Scala:
+
+```bash
+cs launch io.github.riccardomerolla:llm4zio-modernize_3:4.0.0 -- <phase> -- --repo <dir>
+```
+
+or the OCI image for air-gapped/CI use
+(`ghcr.io/riccardomerolla/llm4zio-modernize`). Both read the same env vars,
+plus `./modernize.conf` (KEY=value) for whatever env leaves unset — keep seats
+and endpoints in the conf, estate knowledge in the pack.
+
 ## The six phases
 
 ```bash

--- a/examples/modernize-extract.sc
+++ b/examples/modernize-extract.sc
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla::llm4zio-runner:3.26.0"
+//> using dep "io.github.riccardomerolla::llm4zio-runner:4.0.0"
 //> using scala "3.8.3"
 //> using jvm 21
 
@@ -222,7 +222,7 @@ def tagPatterns(source: Path, fragment: Path, cards: List[PatternCard]): IO[Flow
       val matched = Patterns.matching(Files.readString(source), cards)
       if matched.nonEmpty then
         Option(fragment.getParent).foreach(Files.createDirectories(_))
-        Files.write(
+        val _ = Files.write(
           fragment,
           s"\nPatterns: ${matched.map(_.id).mkString(", ")}\n".getBytes(java.nio.charset.StandardCharsets.UTF_8),
           java.nio.file.StandardOpenOption.CREATE,

--- a/examples/modernize-implement.sc
+++ b/examples/modernize-implement.sc
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla::llm4zio-runner:3.26.0"
+//> using dep "io.github.riccardomerolla::llm4zio-runner:4.0.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/examples/modernize-review.sc
+++ b/examples/modernize-review.sc
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla::llm4zio-runner:3.26.0"
+//> using dep "io.github.riccardomerolla::llm4zio-runner:4.0.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/examples/modernize-seed.sc
+++ b/examples/modernize-seed.sc
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla::llm4zio-runner:3.26.0"
+//> using dep "io.github.riccardomerolla::llm4zio-runner:4.0.0"
 //> using scala "3.8.3"
 //> using jvm 21
 
@@ -44,7 +44,7 @@ import llm4zio.flow.*
 import llm4zio.runner.*
 
 val ModDir         = "docs/modernization"
-val Llm4zioVersion = "3.26.0" // keep in step with the `using dep` header pin
+val Llm4zioVersion = "4.0.0" // keep in step with the `using dep` header pin
 
 def writeFile(path: Path, content: String): IO[FlowError, Unit] =
   ZIO

--- a/examples/modernize-survey.sc
+++ b/examples/modernize-survey.sc
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla::llm4zio-runner:3.26.0"
+//> using dep "io.github.riccardomerolla::llm4zio-runner:4.0.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/examples/modernize-verify.sc
+++ b/examples/modernize-verify.sc
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla::llm4zio-runner:3.26.0"
+//> using dep "io.github.riccardomerolla::llm4zio-runner:4.0.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/examples/tools/cobol-capture.sc
+++ b/examples/tools/cobol-capture.sc
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla::llm4zio-runner:3.26.0"
+//> using dep "io.github.riccardomerolla::llm4zio-runner:4.0.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/modules/llm4zio-flow/src/it/scala/llm4zio/flow/ModernizationPipelineSpec.scala
+++ b/modules/llm4zio-flow/src/it/scala/llm4zio/flow/ModernizationPipelineSpec.scala
@@ -67,7 +67,7 @@ object ModernizationPipelineSpec extends ZIOSpecDefault:
         pack.name == "cobol-springboot",
         pack.gate("test").contains(List("mvn", "-q", "-B", "test")),
         pack.judgeDimensions.map(_.name) == List("completeness", "faithfulness", "testability"),
-        pack.lenses.map(_.name).sorted == List("cobol-fidelity", "traceability"),
+        pack.lenses.map(_.name).sorted == List("cobol-fidelity", "pattern-conformance", "traceability"),
         pack.lessons.exists(_.contains("BigDecimal")),
         pack.scaffold.exists(rel => Files.exists(packDir().resolve(rel).normalize.resolve("pom.xml"))),
         units("cobol-paragraph").size == 25, // 21 in ACCTXFR + 8 in INTCALC, 4 names shared between the two

--- a/modules/llm4zio-modernize/src/main/scala/llm4zio/modernize/ExtractFlow.scala
+++ b/modules/llm4zio-modernize/src/main/scala/llm4zio/modernize/ExtractFlow.scala
@@ -6,56 +6,53 @@ object ExtractFlow:
 
   /** Legacy-modernization phase 1 of 5: reverse-engineer the legacy estate into a judged spec pack.
     *
-    *   modernize-extract.sc → (human approves) → modernize-seed.sc → modernize-implement.sc
-    *     → modernize-verify.sc → modernize-review.sc
+    * modernize-extract.sc → (human approves) → modernize-seed.sc → modernize-implement.sc → modernize-verify.sc →
+    * modernize-review.sc
     *
-    * Runs ROOTED AT THE LEGACY REPO (`--repo <legacy>`): a coder-as-analyst explores the COBOL/JCL
-    * (or JSP, or ACE — whatever the pack says) in place and writes the spec pack under
-    * `docs/modernization/`: behavioural specs, BDD features, a traceability matrix, and a data/
-    * interface mapping. Everything estate-specific — prompts, judge rubrics, coverage regexes —
-    * comes from a modernization PACK (`flow.Pack`), a plain versioned directory.
+    * Runs ROOTED AT THE LEGACY REPO (`--repo <legacy>`): a coder-as-analyst explores the COBOL/JCL (or JSP, or ACE —
+    * whatever the pack says) in place and writes the spec pack under `docs/modernization/`: behavioural specs, BDD
+    * features, a traceability matrix, and a data/ interface mapping. Everything estate-specific — prompts, judge
+    * rubrics, coverage regexes — comes from a modernization PACK (`flow.Pack`), a plain versioned directory.
     *
     * Extraction is PER PROGRAM, so it is resumable and bounded on real estates:
-    *   - the pack's `programs:` regex (falling back to `sources:`) enumerates the spec-worthy
-    *     files; each gets its own analyst turn, its own commit, and its own artifacts:
-    *     `specs/<NAME>.md`, `features/<name>.feature`, `traceability/<NAME>.md`, `mapping/<NAME>.md`;
-    *   - a rerun skips every program whose spec already exists (delete `specs/<NAME>.md` to
-    *     re-extract just that program) — a flaky stream costs one program's turn, not the estate;
-    *   - `traceability.md` and `mapping.md` are REGENERATED deterministically from the per-program
-    *     fragments before every gate round — fix findings in the fragments, never in the indexes;
-    *   - each analyst turn runs under a turn limit (`AnalystTurns`), so a confused headless agent
-    *     cannot burn quota on no-op commands; if the limit trips after the spec was written the
-    *     flow keeps the work and moves on.
+    *   - the pack's `programs:` regex (falling back to `sources:`) enumerates the spec-worthy files; each gets its own
+    *     analyst turn, its own commit, and its own artifacts: `specs/<NAME>.md`, `features/<name>.feature`,
+    *     `traceability/<NAME>.md`, `mapping/<NAME>.md`;
+    *   - a rerun skips every program whose spec already exists (delete `specs/<NAME>.md` to re-extract just that
+    *     program) — a flaky stream costs one program's turn, not the estate;
+    *   - `traceability.md` and `mapping.md` are REGENERATED deterministically from the per-program fragments before
+    *     every gate round — fix findings in the fragments, never in the indexes;
+    *   - each analyst turn runs under a turn limit (`AnalystTurns`), so a confused headless agent cannot burn quota on
+    *     no-op commands; if the limit trips after the spec was written the flow keeps the work and moves on.
     *
     * The gate is layered, and nothing auto-approves:
-    *   - Layer 1 (deterministic, `SpecChecks`): every COBOL paragraph / JCL step found in the source
-    *     must appear in the traceability matrix; the .feature files must be well-formed Gherkin;
-    *     traceability.md and mapping.md must exist.
-    *   - Layer 2 (LLM-as-a-Judge on `reasoning`): completeness / faithfulness / testability scored
-    *     PER PROGRAM against the pack's rubrics — each judge call sees one program's source and its
-    *     spec, so a production estate can't blow the model context. Full marks required. An empty
-    *     judge response is retried at half, then quarter context before giving up (deterministic
-    *     context overflows shrink instead of repeating).
-    *   - The gate is RESUMABLE per program: every verdict persists in `gate/<NAME>.json`
-    *     (`flow.ReviewCache`), fingerprinted over the source + spec + feature + rubric it judged.
-    *     Unchanged content reuses its stored verdict with no LLM call — a crash, quota death, or
-    *     auto-resume re-entry re-judges only what changed. Delete `gate/` to force a full re-judge.
-    *   - `fixLoop` feeds failures back to the analyst up to MaxRounds — one bounded fix turn per
-    *     sub-bar program (own commit) plus one residual turn for estate-wide findings; a still-dirty
-    *     pack is committed as an explicit DRAFT and the flow HALTS for human triage.
+    *   - Layer 1 (deterministic, `SpecChecks`): every COBOL paragraph / JCL step found in the source must appear in the
+    *     traceability matrix; the .feature files must be well-formed Gherkin; traceability.md and mapping.md must
+    *     exist.
+    *   - Layer 2 (LLM-as-a-Judge on `reasoning`): completeness / faithfulness / testability scored PER PROGRAM against
+    *     the pack's rubrics — each judge call sees one program's source and its spec, so a production estate can't blow
+    *     the model context. Full marks required. An empty judge response is retried at half, then quarter context
+    *     before giving up (deterministic context overflows shrink instead of repeating).
+    *   - The gate is RESUMABLE per program: every verdict persists in `gate/<NAME>.json` (`flow.ReviewCache`),
+    *     fingerprinted over the source + spec + feature + rubric it judged. Unchanged content reuses its stored verdict
+    *     with no LLM call — a crash, quota death, or auto-resume re-entry re-judges only what changed. Delete `gate/`
+    *     to force a full re-judge.
+    *   - `fixLoop` feeds failures back to the analyst up to MaxRounds — one bounded fix turn per sub-bar program (own
+    *     commit) plus one residual turn for estate-wide findings; a still-dirty pack is committed as an explicit DRAFT
+    *     and the flow HALTS for human triage.
     *   - Even a clean pack only gets an UNCHECKED `- [ ] Approved` marker: a human reviews
     *     `docs/modernization/README.md`, flips it, and runs modernize-seed.sc.
     *
-    * Pack:  LLM4ZIO_PACK=<dir> (default packs/cobol-springboot, resolved against the launch dir).
-    * Run:   scala-cli run modernize-extract.sc -- --repo ~/estates/meridian-legacy
+    * Pack: LLM4ZIO_PACK=<dir> (default packs/cobol-springboot, resolved against the launch dir). Run: scala-cli run
+    * modernize-extract.sc -- --repo ~/estates/meridian-legacy
     *
-    * Seats (all-gemini defaults; LLM4ZIO_CODER=claude|codex|gemini|pi swaps the whole flow):
-    * analyst + reasoning + judge on the Pro model — extraction quality is the product here.
+    * Seats (all-gemini defaults; LLM4ZIO_CODER=claude|codex|gemini|pi swaps the whole flow): analyst + reasoning +
+    * judge on the Pro model — extraction quality is the product here.
     *
-    * Quota: if gemini exhausts the model's quota the flow fails fast with the reset time
-    * (set LLM4ZIO_USAGE_WAIT=24h to wait it out and auto-resume, or point ProModel at a model
-    * with remaining quota). A WARN is logged if the CLI serves a different model than requested.
-    * Judge context is bounded per program by LLM4ZIO_JUDGE_SOURCES_LIMIT (chars, default 400000).
+    * Quota: if gemini exhausts the model's quota the flow fails fast with the reset time (set LLM4ZIO_USAGE_WAIT=24h to
+    * wait it out and auto-resume, or point ProModel at a model with remaining quota). A WARN is logged if the CLI
+    * serves a different model than requested. Judge context is bounded per program by LLM4ZIO_JUDGE_SOURCES_LIMIT
+    * (chars, default 400000).
     */
 
   import java.nio.charset.StandardCharsets
@@ -70,9 +67,9 @@ object ExtractFlow:
   import llm4zio.flow.*
   import llm4zio.runner.*
 
-  val ProModel: String     = "gemini-2.5-pro" // point these at whatever your `gemini` CLI offers
+  val ProModel: String  = "gemini-2.5-pro" // point these at whatever your `gemini` CLI offers
   val MaxRounds: Int    = 3
-  val ModDir: String       = "docs/modernization"
+  val ModDir: String    = "docs/modernization"
   val AnalystTurns: Int = 48               // per-program turn budget — bounds a wedged agent, generous for real work
 
   val CoderKind: String = Env.get("LLM4ZIO_CODER").map(_.trim.toLowerCase).filter(_.nonEmpty).getOrElse("gemini")
@@ -88,8 +85,8 @@ object ExtractFlow:
         val agent = Connectors.coderFromEnv()
         (agent, agent.copy(readOnly = true))
 
-  /** The seats this extraction ran on, recorded as a sidecar (`seats.json`) so seed can carry them into
-    * provenance.json — the models that produced the specs are part of the evidence chain.
+  /** The seats this extraction ran on, recorded as a sidecar (`seats.json`) so seed can carry them into provenance.json
+    * — the models that produced the specs are part of the evidence chain.
     */
   val seatNames: Map[String, String] =
     val analyst = if CoderKind == "gemini" then s"gemini:$ProModel" else CoderKind
@@ -135,8 +132,8 @@ object ExtractFlow:
   def gatherSpecPack(modDir: Path): IO[FlowError, String] =
     gatherSources(modDir, """.*\.(md|feature)""")
 
-  /** Bound a judge/planner input: past the limit keep head + tail so both the entry points and the
-    * trailing rules stay visible. Oversized prompts are gemini's deterministic-empty-response path.
+  /** Bound a judge/planner input: past the limit keep head + tail so both the entry points and the trailing rules stay
+    * visible. Oversized prompts are gemini's deterministic-empty-response path.
     */
   val JudgeSourcesLimit: Int =
     Env.get("LLM4ZIO_JUDGE_SOURCES_LIMIT").flatMap(_.toIntOption).getOrElse(400_000)
@@ -185,17 +182,23 @@ object ExtractFlow:
        |spec ONLY $rel and do not modify legacy sources. Write the four files, then stop.""".stripMargin
 
   /** A turn-limit trip after the spec landed is the wedged-agent tail, not a failure — keep the work. */
-  def turnLimitRecovery(spec: Path, rel: String)(using ctx: FlowContext): PartialFunction[FlowError, IO[FlowError, Unit]] =
+  def turnLimitRecovery(spec: Path, rel: String)(using ctx: FlowContext)
+    : PartialFunction[FlowError, IO[FlowError, Unit]] =
     case e @ FlowError.Llm(_, Some(_: LlmError.TurnLimitError)) =>
       ZIO.ifZIO(fileExists(spec))(
         ctx.events.publish(FlowEvent.Info(s"turn limit hit on $rel after its spec was written — keeping the work")),
         ZIO.fail(e),
       )
 
-  /** One analyst turn per program, skipping programs whose spec already exists and committing each one —
-    * the resume unit is a single program, so a flaky stream or crash costs one turn, not the estate.
+  /** One analyst turn per program, skipping programs whose spec already exists and committing each one — the resume
+    * unit is a single program, so a flaky stream or crash costs one turn, not the estate.
     */
-  def extractPrograms(pack: Pack, system: String, programs: List[String], cards: List[PatternCard])(using
+  def extractPrograms(
+    pack: Pack,
+    system: String,
+    programs: List[String],
+    cards: List[PatternCard],
+  )(using
     ctx: FlowContext
   ): IO[FlowError, Unit] =
     val modDir = workDir.resolve(ModDir)
@@ -215,8 +218,8 @@ object ExtractFlow:
       )
     }
 
-  /** Deterministically tag the program's traceability fragment with the pattern cards its SOURCE matches —
-    * implement injects exactly the cited cards into its briefs, so selection is regex-decided, not model-decided.
+  /** Deterministically tag the program's traceability fragment with the pattern cards its SOURCE matches — implement
+    * injects exactly the cited cards into its briefs, so selection is regex-decided, not model-decided.
     */
   def tagPatterns(source: Path, fragment: Path, cards: List[PatternCard]): IO[FlowError, Unit] =
     ZIO
@@ -234,9 +237,9 @@ object ExtractFlow:
       }
       .mapError(e => FlowError.Persistence(s"failed to tag patterns on $fragment", Some(e)))
 
-  /** Write `rules.txt` — every coverage unit enumerated from the legacy source, one per line. Deterministic;
-    * this is the rule universe modernize-verify.sc reports equivalence against (the target side never
-    * re-enumerates it: doing so would need legacy source, which the clean-room wall forbids).
+  /** Write `rules.txt` — every coverage unit enumerated from the legacy source, one per line. Deterministic; this is
+    * the rule universe modernize-verify.sc reports equivalence against (the target side never re-enumerates it: doing
+    * so would need legacy source, which the clean-room wall forbids).
     */
   def writeRules(pack: Pack, root: java.nio.file.Path, modDir: java.nio.file.Path): IO[FlowError, Unit] =
     SpecChecks
@@ -246,9 +249,9 @@ object ExtractFlow:
         ZIO.when(all.nonEmpty)(writeFile(modDir.resolve("rules.txt"), all.mkString("", "\n", "\n"))).unit
       }
 
-  /** Rebuild `traceability.md` and `mapping.md` from their per-program fragments. Deterministic and
-    * idempotent — runs before every gate round, so fixes belong in the fragments, never the indexes.
-    * When no fragments exist (e.g. a pack extracted by an older run) the existing indexes are kept.
+  /** Rebuild `traceability.md` and `mapping.md` from their per-program fragments. Deterministic and idempotent — runs
+    * before every gate round, so fixes belong in the fragments, never the indexes. When no fragments exist (e.g. a pack
+    * extracted by an older run) the existing indexes are kept.
     */
   def rebuildIndexes(modDir: Path): IO[FlowError, Unit] =
     def rebuild(fragmentDir: Path, index: Path): IO[FlowError, Unit] =
@@ -286,12 +289,12 @@ object ExtractFlow:
     case FlowError.Llm(message, _) => message.contains("empty response")
     case _                         => false
 
-  /** Evaluate with a shrinking context ladder: an empty judge response that survives the in-run flaky
-    * retries is usually DETERMINISTIC (context overflow) — repeating the same prompt cannot succeed,
-    * so retry at half, then quarter context instead.
+  /** Evaluate with a shrinking context ladder: an empty judge response that survives the in-run flaky retries is
+    * usually DETERMINISTIC (context overflow) — repeating the same prompt cannot succeed, so retry at half, then
+    * quarter context instead.
     */
   def judgeWithShrink(judge: Evaluator[Sample], sample: Sample)(using ctx: FlowContext): IO[FlowError, EvalResult] =
-    def capped(cap: Int): Sample =
+    def capped(cap: Int): Sample                                      =
       sample.copy(context = sample.context.map(capText(_, cap)), response = capText(sample.response, cap))
     def attempt(cap: Int, rest: List[Int]): IO[FlowError, EvalResult] =
       judge
@@ -305,12 +308,13 @@ object ExtractFlow:
         }
     attempt(JudgeSourcesLimit, List(JudgeSourcesLimit / 2, JudgeSourcesLimit / 4))
 
-  /** Judge ONE program — resumably: its verdict persists in `gate/<NAME>.json`, fingerprinted over the
-    * source, spec, feature, and rubric it judged. Unchanged content reuses the stored verdict with NO
-    * LLM call, so a crash, quota death, or auto-resume re-entry re-judges only what actually changed.
-    * Delete a `gate/<NAME>.json` (or the whole `gate/` dir) to force a re-judge.
+  /** Judge ONE program — resumably: its verdict persists in `gate/<NAME>.json`, fingerprinted over the source, spec,
+    * feature, and rubric it judged. Unchanged content reuses the stored verdict with NO LLM call, so a crash, quota
+    * death, or auto-resume re-entry re-judges only what actually changed. Delete a `gate/<NAME>.json` (or the whole
+    * `gate/` dir) to force a re-judge.
     */
-  def judgeProgram(pack: Pack, judge: Evaluator[Sample], rel: String)(using ctx: FlowContext): IO[FlowError, (String, ReviewResult)] =
+  def judgeProgram(pack: Pack, judge: Evaluator[Sample], rel: String)(using ctx: FlowContext)
+    : IO[FlowError, (String, ReviewResult)] =
     val name   = programName(rel)
     val modDir = workDir.resolve(ModDir)
     for
@@ -323,16 +327,18 @@ object ExtractFlow:
                    ReviewCache.fingerprint(source, spec, feature, rubric),
                  ) {
                    ctx.events.publish(FlowEvent.Info(s"judging $name")) *>
-                     judgeWithShrink(judge, Sample(response = s"$spec\n\n$feature", context = Some(source), query = Some(userPrompt)))
+                     judgeWithShrink(
+                       judge,
+                       Sample(response = s"$spec\n\n$feature", context = Some(source), query = Some(userPrompt)),
+                     )
                        .map(judgeIssues(_, pack.judgeDimensions, name))
                  }
     yield name -> result
 
-  /** One evaluation of the spec pack: indexes rebuilt, deterministic SpecChecks, then the per-program
-    * judge over the verdict cache — every program is consulted every round, but only programs whose
-    * files changed since their last verdict cost a judge call. An untouched dirty program keeps its
-    * stored findings ("you didn't change the files, the findings stand") instead of a fresh roll of
-    * the dice.
+  /** One evaluation of the spec pack: indexes rebuilt, deterministic SpecChecks, then the per-program judge over the
+    * verdict cache — every program is consulted every round, but only programs whose files changed since their last
+    * verdict cost a judge call. An untouched dirty program keeps its stored findings ("you didn't change the files, the
+    * findings stand") instead of a fresh roll of the dice.
     */
   def gateEvaluate(
     pack: Pack,
@@ -374,18 +380,19 @@ object ExtractFlow:
        |fragments — do not edit them directly. Fix the findings in place, then stop:
        |${issueLines(issues)}""".stripMargin
 
-  /** Fix turns mirror the judge: one bounded turn per sub-bar program (fresh chat, own commit — a crash
-    * mid-round keeps the programs already fixed), plus a single residual turn for estate-wide findings
-    * (coverage gaps, malformed features, missing indexes). Editing a program's files changes its
-    * fingerprint, so exactly the programs touched here get re-judged next round.
+  /** Fix turns mirror the judge: one bounded turn per sub-bar program (fresh chat, own commit — a crash mid-round keeps
+    * the programs already fixed), plus a single residual turn for estate-wide findings (coverage gaps, malformed
+    * features, missing indexes). Editing a program's files changes its fingerprint, so exactly the programs touched
+    * here get re-judged next round.
     */
-  def fixOnce(pack: Pack, system: String, programs: List[String])(result: ReviewResult)(using ctx: FlowContext): IO[FlowError, Unit] =
-    val recover: PartialFunction[FlowError, IO[FlowError, Unit]] =
+  def fixOnce(pack: Pack, system: String, programs: List[String])(result: ReviewResult)(using ctx: FlowContext)
+    : IO[FlowError, Unit] =
+    val recover: PartialFunction[FlowError, IO[FlowError, Unit]]  =
       case FlowError.Llm(_, Some(_: LlmError.TurnLimitError)) =>
         ctx.events.publish(FlowEvent.Info("turn limit hit during a fix turn — re-evaluating what was written"))
-    val relOf            = programs.map(rel => programName(rel) -> rel).toMap
-    val (scoped, global) = result.issues.partition(i => issueProgram(i).exists(relOf.contains))
-    val byProgram        = scoped.groupBy(i => issueProgram(i).getOrElse("")).toList.sortBy(_._1)
+    val relOf                                                     = programs.map(rel => programName(rel) -> rel).toMap
+    val (scoped, global)                                          = result.issues.partition(i => issueProgram(i).exists(relOf.contains))
+    val byProgram                                                 = scoped.groupBy(i => issueProgram(i).getOrElse("")).toList.sortBy(_._1)
     def turn(ask: String, commitMsg: String): IO[FlowError, Unit] =
       for
         chat <- Chat.start(coder, system = Some(system))
@@ -484,7 +491,8 @@ object ExtractFlow:
                         ) *>
                         git.commitAll(s"modernize(${pack.name}): spec pack draft (ungated)").unit
                     )
-        result   <- stage("Gate")(fixLoop(gateEvaluate(pack, judge, programs), fixOnce(pack, system, programs), MaxRounds))
+        result   <-
+          stage("Gate")(fixLoop(gateEvaluate(pack, judge, programs), fixOnce(pack, system, programs), MaxRounds))
         _        <- ZIO.when(result.isClean)(stage("Plan") {
                       for
                         specText <- gatherSpecPack(modDir)
@@ -496,7 +504,8 @@ object ExtractFlow:
                         _        <- writeFile(modDir.resolve("plan.md"), plan.render)
                       yield ()
                     })
-        verdict   = if result.isClean then "PASSED — pending human approval" else s"DRAFT — ${result.issues.size} open issue(s)"
+        verdict   =
+          if result.isClean then "PASSED — pending human approval" else s"DRAFT — ${result.issues.size} open issue(s)"
         _        <- stage("Commit")(
                       writeFile(modDir.resolve("README.md"), ApprovalGate.withDraftMarker(indexFor(pack, verdict))) *>
                         git.commitAll(s"modernize(${pack.name}): spec pack ($verdict)").unit

--- a/modules/llm4zio-modernize/src/main/scala/llm4zio/modernize/ExtractFlow.scala
+++ b/modules/llm4zio-modernize/src/main/scala/llm4zio/modernize/ExtractFlow.scala
@@ -1,0 +1,505 @@
+package llm4zio.modernize
+
+import scala.util.matching.Regex
+
+object ExtractFlow:
+
+  /** Legacy-modernization phase 1 of 5: reverse-engineer the legacy estate into a judged spec pack.
+    *
+    *   modernize-extract.sc → (human approves) → modernize-seed.sc → modernize-implement.sc
+    *     → modernize-verify.sc → modernize-review.sc
+    *
+    * Runs ROOTED AT THE LEGACY REPO (`--repo <legacy>`): a coder-as-analyst explores the COBOL/JCL
+    * (or JSP, or ACE — whatever the pack says) in place and writes the spec pack under
+    * `docs/modernization/`: behavioural specs, BDD features, a traceability matrix, and a data/
+    * interface mapping. Everything estate-specific — prompts, judge rubrics, coverage regexes —
+    * comes from a modernization PACK (`flow.Pack`), a plain versioned directory.
+    *
+    * Extraction is PER PROGRAM, so it is resumable and bounded on real estates:
+    *   - the pack's `programs:` regex (falling back to `sources:`) enumerates the spec-worthy
+    *     files; each gets its own analyst turn, its own commit, and its own artifacts:
+    *     `specs/<NAME>.md`, `features/<name>.feature`, `traceability/<NAME>.md`, `mapping/<NAME>.md`;
+    *   - a rerun skips every program whose spec already exists (delete `specs/<NAME>.md` to
+    *     re-extract just that program) — a flaky stream costs one program's turn, not the estate;
+    *   - `traceability.md` and `mapping.md` are REGENERATED deterministically from the per-program
+    *     fragments before every gate round — fix findings in the fragments, never in the indexes;
+    *   - each analyst turn runs under a turn limit (`AnalystTurns`), so a confused headless agent
+    *     cannot burn quota on no-op commands; if the limit trips after the spec was written the
+    *     flow keeps the work and moves on.
+    *
+    * The gate is layered, and nothing auto-approves:
+    *   - Layer 1 (deterministic, `SpecChecks`): every COBOL paragraph / JCL step found in the source
+    *     must appear in the traceability matrix; the .feature files must be well-formed Gherkin;
+    *     traceability.md and mapping.md must exist.
+    *   - Layer 2 (LLM-as-a-Judge on `reasoning`): completeness / faithfulness / testability scored
+    *     PER PROGRAM against the pack's rubrics — each judge call sees one program's source and its
+    *     spec, so a production estate can't blow the model context. Full marks required. An empty
+    *     judge response is retried at half, then quarter context before giving up (deterministic
+    *     context overflows shrink instead of repeating).
+    *   - The gate is RESUMABLE per program: every verdict persists in `gate/<NAME>.json`
+    *     (`flow.ReviewCache`), fingerprinted over the source + spec + feature + rubric it judged.
+    *     Unchanged content reuses its stored verdict with no LLM call — a crash, quota death, or
+    *     auto-resume re-entry re-judges only what changed. Delete `gate/` to force a full re-judge.
+    *   - `fixLoop` feeds failures back to the analyst up to MaxRounds — one bounded fix turn per
+    *     sub-bar program (own commit) plus one residual turn for estate-wide findings; a still-dirty
+    *     pack is committed as an explicit DRAFT and the flow HALTS for human triage.
+    *   - Even a clean pack only gets an UNCHECKED `- [ ] Approved` marker: a human reviews
+    *     `docs/modernization/README.md`, flips it, and runs modernize-seed.sc.
+    *
+    * Pack:  LLM4ZIO_PACK=<dir> (default packs/cobol-springboot, resolved against the launch dir).
+    * Run:   scala-cli run modernize-extract.sc -- --repo ~/estates/meridian-legacy
+    *
+    * Seats (all-gemini defaults; LLM4ZIO_CODER=claude|codex|gemini|pi swaps the whole flow):
+    * analyst + reasoning + judge on the Pro model — extraction quality is the product here.
+    *
+    * Quota: if gemini exhausts the model's quota the flow fails fast with the reset time
+    * (set LLM4ZIO_USAGE_WAIT=24h to wait it out and auto-resume, or point ProModel at a model
+    * with remaining quota). A WARN is logged if the CLI serves a different model than requested.
+    * Judge context is bounded per program by LLM4ZIO_JUDGE_SOURCES_LIMIT (chars, default 400000).
+    */
+
+  import java.nio.charset.StandardCharsets
+  import java.nio.file.{ Files, Path }
+
+  import scala.jdk.CollectionConverters.*
+
+  import zio.{ IO, UIO, ZIO }
+
+  import llm4zio.core.LlmError
+  import llm4zio.eval.*
+  import llm4zio.flow.*
+  import llm4zio.runner.*
+
+  val ProModel: String     = "gemini-2.5-pro" // point these at whatever your `gemini` CLI offers
+  val MaxRounds: Int    = 3
+  val ModDir: String       = "docs/modernization"
+  val AnalystTurns: Int = 48               // per-program turn budget — bounds a wedged agent, generous for real work
+
+  val CoderKind: String = Env.get("LLM4ZIO_CODER").map(_.trim.toLowerCase).filter(_.nonEmpty).getOrElse("gemini")
+
+  val (coderCfg, reasoningCfg) =
+    CoderKind match
+      case "gemini" =>
+        (
+          gemini.withModel(ProModel).withTurnLimit(AnalystTurns),
+          gemini.withModel(ProModel).copy(readOnly = true),
+        )
+      case _        =>
+        val agent = Connectors.coderFromEnv()
+        (agent, agent.copy(readOnly = true))
+
+  /** The seats this extraction ran on, recorded as a sidecar (`seats.json`) so seed can carry them into
+    * provenance.json — the models that produced the specs are part of the evidence chain.
+    */
+  val seatNames: Map[String, String] =
+    val analyst = if CoderKind == "gemini" then s"gemini:$ProModel" else CoderKind
+    Map("analyst" -> analyst, "reasoning" -> analyst, "judge" -> analyst)
+
+  def fileExists(path: Path): UIO[Boolean] =
+    ZIO.attemptBlocking(Files.exists(path)).orDie
+
+  def dirExists(path: Path): UIO[Boolean] =
+    ZIO.attemptBlocking(Files.isDirectory(path)).orDie
+
+  def readFileOr(path: Path, fallback: String): IO[FlowError, String] =
+    ZIO
+      .attemptBlocking(if Files.exists(path) then Files.readString(path) else fallback)
+      .mapError(e => FlowError.Persistence(s"failed to read $path", Some(e)))
+
+  def writeFile(path: Path, content: String): IO[FlowError, Unit] =
+    ZIO
+      .attemptBlocking {
+        Option(path.getParent).foreach(Files.createDirectories(_))
+        Files.write(path, content.getBytes(StandardCharsets.UTF_8))
+        ()
+      }
+      .mapError(e => FlowError.Persistence(s"failed to write $path", Some(e)))
+
+  /** Concatenate every file under `root` whose relative path matches `regex`. */
+  def gatherSources(root: Path, regex: String): IO[FlowError, String] =
+    ZIO
+      .attemptBlocking {
+        val stream = Files.walk(root)
+        val files  =
+          try stream.iterator().asScala.filter(Files.isRegularFile(_)).toList
+          finally stream.close()
+        files
+          .filter(f => root.relativize(f).toString.replace('\\', '/').matches(regex))
+          .sortBy(_.toString)
+          .map(f => s"===== ${root.relativize(f)} =====\n${Files.readString(f)}")
+          .mkString("\n\n")
+      }
+      .mapError(e => FlowError.Persistence(s"failed to gather sources under $root", Some(e)))
+
+  /** Concatenate the spec pack the analyst wrote — the planner's input. */
+  def gatherSpecPack(modDir: Path): IO[FlowError, String] =
+    gatherSources(modDir, """.*\.(md|feature)""")
+
+  /** Bound a judge/planner input: past the limit keep head + tail so both the entry points and the
+    * trailing rules stay visible. Oversized prompts are gemini's deterministic-empty-response path.
+    */
+  val JudgeSourcesLimit: Int =
+    Env.get("LLM4ZIO_JUDGE_SOURCES_LIMIT").flatMap(_.toIntOption).getOrElse(400_000)
+
+  def capText(text: String, limit: Int): String =
+    if text.length <= limit then text
+    else
+      val head = limit * 3 / 4
+      s"${text.take(head)}\n\n… [truncated] …\n\n${text.takeRight(limit - head)}"
+
+  /** The `- PROG` entries of `## Wave: <name>` in the survey's wave plan. */
+  def wavePrograms(planText: String, wave: String): List[String] =
+    val lines = planText.linesIterator.toList
+    lines
+      .dropWhile(_.trim != s"## Wave: $wave")
+      .drop(1)
+      .takeWhile(l => !l.trim.startsWith("## "))
+      .map(_.trim)
+      .collect { case l if l.startsWith("- ") => l.drop(2).trim }
+
+  /** `cobol/ACCTXFR.cbl` → `ACCTXFR`: the program name that keys every per-program artifact. */
+  def programName(rel: String): String =
+    val base = rel.substring(rel.lastIndexOf('/') + 1)
+    val dot  = base.lastIndexOf('.')
+    if dot > 0 then base.take(dot) else base
+
+  def programAsk(pack: Pack, rel: String, name: String): String =
+    s"""Extract the behavioural spec for ONE source unit of this repository: $rel
+       |
+       |Write exactly these files (create directories as needed):
+       |
+       |- $ModDir/specs/$name.md — the behavioural spec for $rel.
+       |${pack.prompt("spec").getOrElse("")}
+       |
+       |- $ModDir/features/${name.toLowerCase}.feature — BDD scenarios encoding that spec.
+       |${pack.prompt("bdd").getOrElse("")}
+       |
+       |- $ModDir/traceability/$name.md — EVERY source unit of $rel (each COBOL paragraph, each JCL
+       |  step) on its own line, mapped to the spec rules/scenarios that cover it: `<UNIT-NAME> — <refs>`.
+       |  Unit names verbatim as they appear in the source.
+       |
+       |- $ModDir/mapping/$name.md — data & interface mapping for $rel: tables/record layouts → target
+       |  entities; files/screens/queues → target service contracts.
+       |
+       |Read $rel and anything it references (copybooks, includes, called programs) for context, but
+       |spec ONLY $rel and do not modify legacy sources. Write the four files, then stop.""".stripMargin
+
+  /** A turn-limit trip after the spec landed is the wedged-agent tail, not a failure — keep the work. */
+  def turnLimitRecovery(spec: Path, rel: String)(using ctx: FlowContext): PartialFunction[FlowError, IO[FlowError, Unit]] =
+    case e @ FlowError.Llm(_, Some(_: LlmError.TurnLimitError)) =>
+      ZIO.ifZIO(fileExists(spec))(
+        ctx.events.publish(FlowEvent.Info(s"turn limit hit on $rel after its spec was written — keeping the work")),
+        ZIO.fail(e),
+      )
+
+  /** One analyst turn per program, skipping programs whose spec already exists and committing each one —
+    * the resume unit is a single program, so a flaky stream or crash costs one turn, not the estate.
+    */
+  def extractPrograms(pack: Pack, system: String, programs: List[String], cards: List[PatternCard])(using
+    ctx: FlowContext
+  ): IO[FlowError, Unit] =
+    val modDir = workDir.resolve(ModDir)
+    ZIO.foreachDiscard(programs.zipWithIndex) { (rel, i) =>
+      val name     = programName(rel)
+      val spec     = modDir.resolve("specs").resolve(s"$name.md")
+      val progress = s"(${i + 1}/${programs.size})"
+      ZIO.ifZIO(fileExists(spec))(
+        ctx.events.publish(FlowEvent.Info(s"resume: specs/$name.md exists — skipping $rel $progress")),
+        for
+          _    <- ctx.events.publish(FlowEvent.Info(s"extracting $rel $progress"))
+          chat <- Chat.start(coder, system = Some(system))
+          _    <- chat.ask(programAsk(pack, rel, name)).unit.catchSome(turnLimitRecovery(spec, rel))
+          _    <- tagPatterns(workDir.resolve(rel), modDir.resolve("traceability").resolve(s"$name.md"), cards)
+          _    <- git.commitAll(s"modernize(${pack.name}): spec $name").unit
+        yield (),
+      )
+    }
+
+  /** Deterministically tag the program's traceability fragment with the pattern cards its SOURCE matches —
+    * implement injects exactly the cited cards into its briefs, so selection is regex-decided, not model-decided.
+    */
+  def tagPatterns(source: Path, fragment: Path, cards: List[PatternCard]): IO[FlowError, Unit] =
+    ZIO
+      .attemptBlocking {
+        val matched = Patterns.matching(Files.readString(source), cards)
+        if matched.nonEmpty then
+          Option(fragment.getParent).foreach(Files.createDirectories(_))
+          val _ = Files.write(
+            fragment,
+            s"\nPatterns: ${matched.map(_.id).mkString(", ")}\n".getBytes(java.nio.charset.StandardCharsets.UTF_8),
+            java.nio.file.StandardOpenOption.CREATE,
+            java.nio.file.StandardOpenOption.APPEND,
+          )
+        ()
+      }
+      .mapError(e => FlowError.Persistence(s"failed to tag patterns on $fragment", Some(e)))
+
+  /** Write `rules.txt` — every coverage unit enumerated from the legacy source, one per line. Deterministic;
+    * this is the rule universe modernize-verify.sc reports equivalence against (the target side never
+    * re-enumerates it: doing so would need legacy source, which the clean-room wall forbids).
+    */
+  def writeRules(pack: Pack, root: java.nio.file.Path, modDir: java.nio.file.Path): IO[FlowError, Unit] =
+    SpecChecks
+      .coverageUnits(root, pack.coverage)
+      .flatMap { units =>
+        val all = units.values.flatten.toList.distinct.sorted
+        ZIO.when(all.nonEmpty)(writeFile(modDir.resolve("rules.txt"), all.mkString("", "\n", "\n"))).unit
+      }
+
+  /** Rebuild `traceability.md` and `mapping.md` from their per-program fragments. Deterministic and
+    * idempotent — runs before every gate round, so fixes belong in the fragments, never the indexes.
+    * When no fragments exist (e.g. a pack extracted by an older run) the existing indexes are kept.
+    */
+  def rebuildIndexes(modDir: Path): IO[FlowError, Unit] =
+    def rebuild(fragmentDir: Path, index: Path): IO[FlowError, Unit] =
+      ZIO.whenZIO(dirExists(fragmentDir)) {
+        gatherSources(fragmentDir, """.*\.md""").flatMap(text => ZIO.when(text.nonEmpty)(writeFile(index, text)))
+      }.unit
+    rebuild(modDir.resolve("traceability"), modDir.resolve("traceability.md")) *>
+      rebuild(modDir.resolve("mapping"), modDir.resolve("mapping.md"))
+
+  /** Layer-1 existence check: an estate-wide gate needs both indexes present and non-blank. */
+  def requiredDocs(modDir: Path): IO[FlowError, ReviewResult] =
+    for
+      trace <- readFileOr(modDir.resolve("traceability.md"), "")
+      map   <- readFileOr(modDir.resolve("mapping.md"), "")
+    yield
+      val issues = List(
+        Option.when(trace.isBlank)(
+          ReviewIssue(Severity.Critical, "missing traceability", s"no $ModDir/traceability/ fragments were written")
+        ),
+        Option.when(map.isBlank)(
+          ReviewIssue(Severity.Critical, "missing mapping", s"no $ModDir/mapping/ fragments were written")
+        ),
+      ).flatten
+      ReviewResult(issues, "docs")
+
+  /** Sub-bar judge dimensions as Critical review issues, titled with the program they belong to. */
+  def judgeIssues(scored: EvalResult, dims: List[Dimension], program: String): ReviewResult =
+    val subBar = scored.scores.filter(s => s.score < dims.find(_.name == s.name).fold(2)(_.maxScore))
+    ReviewResult(
+      subBar.map(s => ReviewIssue(Severity.Critical, s"judge[$program]: ${s.name} scored ${s.score}", s.reasoning)),
+      s"judge:$program",
+    )
+
+  def isEmptyResponse(e: FlowError): Boolean = e match
+    case FlowError.Llm(message, _) => message.contains("empty response")
+    case _                         => false
+
+  /** Evaluate with a shrinking context ladder: an empty judge response that survives the in-run flaky
+    * retries is usually DETERMINISTIC (context overflow) — repeating the same prompt cannot succeed,
+    * so retry at half, then quarter context instead.
+    */
+  def judgeWithShrink(judge: Evaluator[Sample], sample: Sample)(using ctx: FlowContext): IO[FlowError, EvalResult] =
+    def capped(cap: Int): Sample =
+      sample.copy(context = sample.context.map(capText(_, cap)), response = capText(sample.response, cap))
+    def attempt(cap: Int, rest: List[Int]): IO[FlowError, EvalResult] =
+      judge
+        .evaluate(capped(cap))
+        .mapError(e => FlowError.Llm(e.message, Some(e)))
+        .catchSome {
+          case e if isEmptyResponse(e) && rest.nonEmpty =>
+            ctx.events.publish(
+              FlowEvent.Info(s"judge returned empty at cap $cap chars — shrinking to ${rest.head}: ${e.message}")
+            ) *> attempt(rest.head, rest.tail)
+        }
+    attempt(JudgeSourcesLimit, List(JudgeSourcesLimit / 2, JudgeSourcesLimit / 4))
+
+  /** Judge ONE program — resumably: its verdict persists in `gate/<NAME>.json`, fingerprinted over the
+    * source, spec, feature, and rubric it judged. Unchanged content reuses the stored verdict with NO
+    * LLM call, so a crash, quota death, or auto-resume re-entry re-judges only what actually changed.
+    * Delete a `gate/<NAME>.json` (or the whole `gate/` dir) to force a re-judge.
+    */
+  def judgeProgram(pack: Pack, judge: Evaluator[Sample], rel: String)(using ctx: FlowContext): IO[FlowError, (String, ReviewResult)] =
+    val name   = programName(rel)
+    val modDir = workDir.resolve(ModDir)
+    for
+      spec    <- readFileOr(modDir.resolve("specs").resolve(s"$name.md"), "")
+      feature <- readFileOr(modDir.resolve("features").resolve(s"${name.toLowerCase}.feature"), "")
+      source  <- readFileOr(workDir.resolve(rel), "")
+      rubric   = pack.judgeDimensions.map(d => s"${d.name} (0..${d.maxScore}): ${d.rubric}").mkString("\n")
+      result  <- ReviewCache.cached(
+                   modDir.resolve("gate").resolve(s"$name.json"),
+                   ReviewCache.fingerprint(source, spec, feature, rubric),
+                 ) {
+                   ctx.events.publish(FlowEvent.Info(s"judging $name")) *>
+                     judgeWithShrink(judge, Sample(response = s"$spec\n\n$feature", context = Some(source), query = Some(userPrompt)))
+                       .map(judgeIssues(_, pack.judgeDimensions, name))
+                 }
+    yield name -> result
+
+  /** One evaluation of the spec pack: indexes rebuilt, deterministic SpecChecks, then the per-program
+    * judge over the verdict cache — every program is consulted every round, but only programs whose
+    * files changed since their last verdict cost a judge call. An untouched dirty program keeps its
+    * stored findings ("you didn't change the files, the findings stand") instead of a fresh roll of
+    * the dice.
+    */
+  def gateEvaluate(
+    pack: Pack,
+    judge: Evaluator[Sample],
+    programs: List[String],
+  )(using ctx: FlowContext
+  ): IO[FlowError, ReviewResult] =
+    val modDir = workDir.resolve(ModDir)
+    for
+      _        <- rebuildIndexes(modDir)
+      trace    <- readFileOr(modDir.resolve("traceability.md"), "")
+      coverage <- SpecChecks.coverage(workDir, pack.coverage, trace)
+      features <- SpecChecks.features(modDir.resolve("features"))
+      docs     <- requiredDocs(modDir)
+      judged   <- ZIO.foreach(programs)(rel => judgeProgram(pack, judge, rel))
+    yield Reviewers.merge(coverage :: features :: docs :: judged.map(_._2))
+
+  /** `judge[ACCTXFR]: …` → `ACCTXFR` — the program a gate finding belongs to, when it names one. */
+  val JudgeIssueProgram: Regex = """judge\[([^\]]+)\]: .*""".r
+
+  def issueProgram(issue: ReviewIssue): Option[String] = issue.title match
+    case JudgeIssueProgram(name) => Some(name)
+    case _                       => None
+
+  def issueLines(issues: List[ReviewIssue]): String =
+    issues.map(i => s"- [${i.severity}] ${i.title}: ${i.description}").mkString("\n")
+
+  def programFixAsk(name: String, rel: String, issues: List[ReviewIssue]): String =
+    s"""The spec pack for ONE program did not clear its quality gate: $name (source: $rel).
+       |Fix these findings by editing ONLY this program's files — $ModDir/specs/$name.md,
+       |$ModDir/features/${name.toLowerCase}.feature, $ModDir/traceability/$name.md,
+       |$ModDir/mapping/$name.md — against the source at $rel. Then stop:
+       |${issueLines(issues)}""".stripMargin
+
+  def globalFixAsk(issues: List[ReviewIssue]): String =
+    s"""The spec pack did not clear its estate-wide quality gate. Fix these findings by editing the
+       |per-program files under $ModDir/ (specs/, features/, traceability/<PROGRAM>.md,
+       |mapping/<PROGRAM>.md). $ModDir/traceability.md and $ModDir/mapping.md are REGENERATED from the
+       |fragments — do not edit them directly. Fix the findings in place, then stop:
+       |${issueLines(issues)}""".stripMargin
+
+  /** Fix turns mirror the judge: one bounded turn per sub-bar program (fresh chat, own commit — a crash
+    * mid-round keeps the programs already fixed), plus a single residual turn for estate-wide findings
+    * (coverage gaps, malformed features, missing indexes). Editing a program's files changes its
+    * fingerprint, so exactly the programs touched here get re-judged next round.
+    */
+  def fixOnce(pack: Pack, system: String, programs: List[String])(result: ReviewResult)(using ctx: FlowContext): IO[FlowError, Unit] =
+    val recover: PartialFunction[FlowError, IO[FlowError, Unit]] =
+      case FlowError.Llm(_, Some(_: LlmError.TurnLimitError)) =>
+        ctx.events.publish(FlowEvent.Info("turn limit hit during a fix turn — re-evaluating what was written"))
+    val relOf            = programs.map(rel => programName(rel) -> rel).toMap
+    val (scoped, global) = result.issues.partition(i => issueProgram(i).exists(relOf.contains))
+    val byProgram        = scoped.groupBy(i => issueProgram(i).getOrElse("")).toList.sortBy(_._1)
+    def turn(ask: String, commitMsg: String): IO[FlowError, Unit] =
+      for
+        chat <- Chat.start(coder, system = Some(system))
+        _    <- chat.ask(ask).unit.catchSome(recover)
+        _    <- git.commitAll(commitMsg).unit
+      yield ()
+    for
+      _ <- ZIO.foreachDiscard(byProgram) { (name, issues) =>
+             ctx.events.publish(FlowEvent.Info(s"fixing $name — ${issues.size} finding(s)")) *>
+               turn(programFixAsk(name, relOf(name), issues), s"modernize(${pack.name}): gate fixes $name")
+           }
+      _ <- ZIO.when(global.nonEmpty)(
+             ctx.events.publish(FlowEvent.Info(s"fixing estate-wide findings — ${global.size}")) *>
+               turn(globalFixAsk(global), s"modernize(${pack.name}): gate fixes (estate-wide)")
+           )
+    yield ()
+
+  /** Clean pack → tell the human where to approve; dirty pack → halt with the committed draft. */
+  def announceOrHalt(result: ReviewResult)(using ctx: FlowContext): IO[FlowError, Unit] =
+    if result.isClean then
+      ctx.events.publish(
+        FlowEvent.Info(
+          s"spec pack ready — review $ModDir/README.md, set '${ApprovalGate.ApprovedMarker}', then run modernize-seed.sc"
+        )
+      )
+    else
+      fail(
+        s"extraction gate not cleared after $MaxRounds round(s) — spec pack committed as draft:\n" +
+          result.issues.map(i => s"- ${i.title}").mkString("\n")
+      )
+
+  def indexFor(pack: Pack, verdict: String): String =
+    s"""# Modernization spec pack — ${pack.name}
+       |
+       |Extracted by modernize-extract.sc. Gate verdict: $verdict.
+       |
+       |- specs/ — behavioural specs, one per program
+       |- features/ — BDD acceptance scenarios
+       |- traceability.md — source-unit → spec coverage matrix (generated from traceability/)
+       |- mapping.md — data & interface mapping (generated from mapping/)
+       |- rules.txt — every coverage unit, one per line (the rule universe modernize-verify.sc reports against)
+       |- gate/ — cached per-program judge verdicts (delete to force re-judging)
+       |- plan.md — proposed implementation tasks (parsed by modernize-seed.sc)
+       |
+       |Review everything, then flip the marker below and run modernize-seed.sc.""".stripMargin
+
+  def run(args: Array[String]): Unit =
+    flow(
+      args,
+      coder = coderCfg,
+      reasoning = Some(reasoningCfg),
+      defaultPrompt = Some("Extract the complete behavioural spec pack for this legacy estate"),
+    ):
+      val packDir = workspace.resolve(Env.getOrElse("LLM4ZIO_PACK", "packs/cobol-springboot"))
+      val modDir  = workDir.resolve(ModDir)
+
+      for
+        pack     <- stage("Pack")(Pack.load(packDir))
+        _        <- stage("Branch")(git.checkoutOrCreate("modernize/spec-pack"))
+        system    = List(
+                      pack.prompt("analysis"),
+                      pack.lessons.map(l => s"Lessons from previous modernization runs — apply them:\n$l"),
+                    ).flatten.mkString("\n\n")
+        judge     = Judge.of(reasoning, pack.judgeDimensions)
+        all      <- stage("Inventory")(
+                      SpecChecks.matchingFiles(workDir, pack.programs.orElse(pack.sources).getOrElse(""".*"""))
+                    )
+        programs <- Env.get("LLM4ZIO_WAVE").map(_.trim).filter(_.nonEmpty) match
+                      case None       => ZIO.succeed(all)
+                      case Some(wave) => // survey's wave plan scopes this run — and must be human-approved first
+                        for
+                          _     <- stage("Wave")(
+                                     ApprovalGate.gate(modDir.resolve("wave-plan.md"), Interaction.noninteractive)
+                                   )
+                          text  <- readFileOr(modDir.resolve("wave-plan.md"), "")
+                          names  = wavePrograms(text, wave).toSet
+                          scoped = all.filter(rel => names.contains(programName(rel)))
+                          _     <- ZIO.when(scoped.isEmpty)(
+                                     fail(s"wave '$wave' matches no programs in $ModDir/wave-plan.md")
+                                   )
+                        yield scoped
+        _        <- ZIO.when(programs.isEmpty)(
+                      fail(s"no source units matched the pack's programs/sources regex under $workDir")
+                    )
+        cards    <- Patterns
+                      .load(packDir.resolve("patterns"))
+                      .zipWith(Patterns.load(workspace.resolve("patterns")))(_ ++ _)
+        _        <- stage("Extract")(extractPrograms(pack, system, programs, cards))
+        // Commit the (ungated) draft: extraction is the expensive step, and a gate failure or crash must
+        // not cost it. The Gate/Commit stages amend the picture with the verdict afterwards.
+        _        <- stage("Draft")(
+                      rebuildIndexes(modDir) *> writeRules(pack, workDir, modDir) *>
+                        writeFile(
+                          modDir.resolve("seats.json"),
+                          seatNames.toList.sorted.map((k, v) => s"  \"$k\": \"$v\"").mkString("{\n", ",\n", "\n}\n"),
+                        ) *>
+                        git.commitAll(s"modernize(${pack.name}): spec pack draft (ungated)").unit
+                    )
+        result   <- stage("Gate")(fixLoop(gateEvaluate(pack, judge, programs), fixOnce(pack, system, programs), MaxRounds))
+        _        <- ZIO.when(result.isClean)(stage("Plan") {
+                      for
+                        specText <- gatherSpecPack(modDir)
+                        plan     <- Planner.from(
+                                      reasoning,
+                                      capText(specText, JudgeSourcesLimit),
+                                      Planner.defaultInstructions + "\n\n" + pack.prompt("plan").getOrElse(""),
+                                    )
+                        _        <- writeFile(modDir.resolve("plan.md"), plan.render)
+                      yield ()
+                    })
+        verdict   = if result.isClean then "PASSED — pending human approval" else s"DRAFT — ${result.issues.size} open issue(s)"
+        _        <- stage("Commit")(
+                      writeFile(modDir.resolve("README.md"), ApprovalGate.withDraftMarker(indexFor(pack, verdict))) *>
+                        git.commitAll(s"modernize(${pack.name}): spec pack ($verdict)").unit
+                    )
+        _        <- announceOrHalt(result)
+      yield ModDir

--- a/modules/llm4zio-modernize/src/main/scala/llm4zio/modernize/ImplementFlow.scala
+++ b/modules/llm4zio-modernize/src/main/scala/llm4zio/modernize/ImplementFlow.scala
@@ -1,0 +1,248 @@
+package llm4zio.modernize
+
+object ImplementFlow:
+
+  /** Legacy-modernization phase 3 of 5: implement the seeded plan, gated until green.
+    *
+    *   modernize-extract.sc → (human approves) → modernize-seed.sc → modernize-implement.sc
+    *     → modernize-verify.sc → modernize-review.sc
+    *
+    * The clean-room wall is ENFORCED here: the flow refuses to start if anything in the target
+    * workspace matches the pack's legacy `sources:` regex — the coder is driven by specs alone.
+    *
+    * Runs ROOTED AT THE TARGET REPO (`--repo <target>`), resuming the plan modernize-seed.sc
+    * committed at `docs/modernization/plan.md` (PlanStore — a crashed or halted run picks up at the
+    * first incomplete task; task completion is persisted into the committed plan file itself, so
+    * progress is auditable in git history).
+    *
+    * The sdd.sc harness, pack-parameterized:
+    *   - Task 1 encodes the seeded BDD scenarios as FAILING acceptance tests — gated on the pack's
+    *     `build` command, then required RED (green new tests encode nothing → the flow fails).
+    *   - Every later task implements toward green: `reviewAndFixLoop` runs the pack's `test`
+    *     command as the lint gate plus `Reviewers.minimal` and the PACK'S OWN LENSES (e.g.
+    *     cobol-fidelity: BigDecimal/HALF_UP, validation order, reason codes) on the flash reviewer.
+    *   - One commit per task; non-convergence halts with the plan persisted — fix or rerun.
+    *   - Final gate: the pack's `verify` command must be clean, then an LLM-as-a-Judge on
+    *     `reasoning` scores the WHOLE branch diff against the committed spec pack
+    *     (spec-compliance + scenario-coverage, full marks or the flow fails after a bounded
+    *     feedback round).
+    *   - Push + PR: Azure DevOps when configured, GitHub otherwise; a missing forge/remote
+    *     degrades to an Info event so the local demo still completes.
+    *
+    * Run:  scala-cli run modernize-implement.sc -- --repo ~/services/meridian-transfers
+    */
+
+  import zio.{ IO, ZIO }
+
+  import llm4zio.eval.*
+  import llm4zio.flow.*
+  import llm4zio.runner.*
+
+  val ProModel: String    = "gemini-2.5-pro"   // point these at whatever your `gemini` CLI offers
+  val FlashModel: String  = "gemini-3.5-flash"
+  val JudgeRounds: Int = 2
+  val ModDir: String      = "docs/modernization"
+
+  /** The enforced clean-room wall: refuse to run with legacy source inside the target workspace, so the
+    * coder provably works from the specs alone.
+    */
+  def assertWall(pack: Pack, root: java.nio.file.Path, events: FlowEvents): IO[FlowError, Unit] =
+    pack.sources match
+      case None        => events.publish(FlowEvent.Info("pack has no sources regex — wall check skipped"))
+      case Some(regex) =>
+        Wall.check(root, regex).flatMap {
+          case Wall.Result.Clean           =>
+            events.publish(FlowEvent.Info("clean-room wall: no legacy source in the target workspace"))
+          case Wall.Result.Breached(paths) =>
+            val shown = paths.take(10).mkString(", ")
+            val more  = if paths.size > 10 then s" (+${paths.size - 10} more)" else ""
+            ZIO.fail(FlowError.Aborted(
+              s"clean-room wall breached — legacy source inside the target workspace: $shown$more. " +
+                "The implementation must be driven by the specs alone; remove the files and rerun."
+            ))
+        }
+
+  val (coderCfg, reasoningCfg, reviewerCfg) =
+    Env.get("LLM4ZIO_CODER").map(_.trim.toLowerCase).filter(_.nonEmpty) match
+      case None | Some("gemini") =>
+        (gemini, gemini.withModel(ProModel).copy(readOnly = true), gemini.withModel(FlashModel).copy(readOnly = true))
+      case Some(_)               =>
+        val agent = Connectors.coderFromEnv()
+        (agent, agent.copy(readOnly = true), agent.copy(readOnly = true))
+
+  val complianceDims: List[Dimension] = List(
+    Dimension(
+      "spec-compliance",
+      "Does the implementation satisfy every rule in the committed specs — exact values, validation order, " +
+        "error paths — without weakening, deleting, or loosening any test or scenario?",
+    ),
+    Dimension(
+      "scenario-coverage",
+      "Is every BDD scenario in the seeded feature files exercised by an acceptance test in this diff?",
+    ),
+  )
+
+  def judgeFeedback(below: List[DimensionScore]): String =
+    val lines = below.map(d => s"- ${d.name} (${d.score}/2): ${d.reasoning}").mkString("\n")
+    s"""The final spec-compliance review scored the branch below the bar. Close these gaps without
+       |weakening any test, then stop:
+       |$lines""".stripMargin
+
+  /** Concatenate the committed specs + features — the judge's contract text. */
+  def gatherSpecs(root: java.nio.file.Path, specsDir: String): IO[FlowError, String] =
+    ZIO
+      .attemptBlocking {
+        import scala.jdk.CollectionConverters.*
+        val dir = root.resolve(specsDir)
+        if !java.nio.file.Files.isDirectory(dir) then ""
+        else
+          val stream = java.nio.file.Files.walk(dir)
+          try
+            stream
+              .iterator()
+              .asScala
+              .filter(java.nio.file.Files.isRegularFile(_))
+              .toList
+              .sortBy(_.toString)
+              .map(f => s"===== ${root.relativize(f)} =====\n${java.nio.file.Files.readString(f)}")
+              .mkString("\n\n")
+          finally stream.close()
+      }
+      .mapError(e => FlowError.Persistence("failed to read the committed specs", Some(e)))
+
+  /** Judge the branch diff against the committed specs; feed sub-bar reasoning back to the coder,
+    * re-verify, re-judge — bounded by `JudgeRounds`, failing the flow if the bar is never cleared.
+    */
+  def specComplianceLoop(
+    coderChat: Chat,
+    judge: Evaluator[Sample],
+    verGate: IO[FlowError, ReviewResult],
+    specText: String,
+    epicId: String,
+  )(using ctx: FlowContext
+  ): IO[FlowError, Unit] =
+    def round(n: Int): IO[FlowError, Unit] =
+      for
+        base   <- git.defaultBase
+        diff   <- git.diffVsBase(base)
+        result <- judge
+                    .evaluate(Sample(response = diff, context = Some(specText), query = Some(userPrompt)))
+                    .mapError(e => FlowError.Llm(e.message, Some(e)))
+        below   = result.scores.filter(_.score < 2)
+        _      <- if below.isEmpty then ctx.events.publish(FlowEvent.Info("spec-compliance judge: branch cleared the bar"))
+                  else if n >= JudgeRounds then
+                    fail(
+                      s"spec-compliance judge not cleared after $JudgeRounds round(s):\n" +
+                        below.map(d => s"- ${d.name} ${d.score}/2: ${d.reasoning}").mkString("\n")
+                    )
+                  else
+                    coderChat.ask(judgeFeedback(below)) *>
+                      verGate.flatMap(r =>
+                        ZIO.unless(r.isClean)(fail("verify gate broke while addressing judge feedback")).unit
+                      ) *>
+                      git.commitAll(s"$epicId: address spec-compliance feedback").unit *>
+                      round(n + 1)
+      yield ()
+    round(1)
+
+  def run(args: Array[String]): Unit =
+    flow(
+      args,
+      coder = coderCfg,
+      reasoning = Some(reasoningCfg),
+      reviewers = List(reviewerCfg),
+      defaultPrompt = Some("Implement the seeded modernization plan"),
+    ):
+      val packDir   = workspace.resolve(Env.getOrElse("LLM4ZIO_PACK", "packs/cobol-springboot"))
+      val planFile  = workDir.resolve(ModDir).resolve("plan.md")
+      val events    = summon[FlowEvents]
+      val reviewSvc = reviewers.headOption.getOrElse(reasoning)
+
+      for
+        pack     <- stage("Pack")(Pack.load(packDir))
+        _        <- stage("Wall")(assertWall(pack, workDir, events))
+        plan     <- PlanStore
+                      .load(planFile)
+                      .someOrFail(FlowError.Aborted(s"no plan at $planFile — run modernize-seed.sc first"))
+        buildGate = pack.gate("build").fold(ZIO.succeed(ReviewResult(Nil)))(Reviewers.lintCommand(_, workDir))
+        testGate  = pack.gate("test").fold(ZIO.succeed(ReviewResult(Nil)))(Reviewers.lintCommand(_, workDir))
+        verGate   = pack.gate("verify").orElse(pack.gate("test")).fold(ZIO.succeed(ReviewResult(Nil)))(
+                      Reviewers.lintCommand(_, workDir)
+                    )
+        _        <- stage("Branch")(git.checkoutOrCreate(plan.epicId))
+        cards    <- Patterns
+                      .load(packDir.resolve("patterns"))
+                      .zipWith(Patterns.load(workspace.resolve("patterns")))(_ ++ _)
+        specText <- gatherSpecs(workDir, pack.specsDir)
+        cited     = Patterns.tagged(specText) // extraction tagged the fragments; specs cite the ids
+        playbook  = cards.filter(c => cited.contains(c.id))
+        system    = List(
+                      pack.prompt("implement"),
+                      pack.lessons.map(l => s"Lessons from previous modernization runs — apply them:\n$l"),
+                      Option.when(playbook.nonEmpty)(
+                        "Pattern cards cited by the specs — the translation playbook (advisory, the specs win):\n\n" +
+                          playbook.map(c => s"### ${c.id}\n${c.body}").mkString("\n\n")
+                      ),
+                    ).flatten.mkString("\n\n")
+        coderChat <- Chat.start(coder, system = Some(system))
+        _         <- implementTaskLoop(planFile, plan) { task =>
+                       val testsTask = plan.tasks.headOption.contains(task)
+                       for
+                         _ <- coderChat.ask(plan.taskPrompt(task))
+                         _ <- reviewAndFixLoop(
+                                Reviewers.minimal ++ pack.lenses,
+                                reviewSvc,
+                                coderChat,
+                                task.title,
+                                git.diffAll,
+                                lint = Some(if testsTask then buildGate else testGate),
+                                parallelism = 1, // gemini free tier 429s under concurrent reviewers
+                              )
+                         _ <- ZIO.when(testsTask) {
+                                testGate.flatMap { r =>
+                                  ZIO.when(r.isClean)(
+                                    fail("the new acceptance tests pass before any implementation — they encode nothing")
+                                  )
+                                }
+                              }
+                         _ <- git.commitAll(s"${plan.epicId}: ${task.title}").unit
+                       yield ()
+                     }
+        _         <- stage("Verify") {
+                       verGate.flatMap { r =>
+                         if r.isClean then ZIO.unit
+                         else
+                           fail(
+                             s"verify gate failed:\n${r.issues.map(i => s"${i.title}\n${i.description}".strip).mkString("\n\n")}"
+                           )
+                       }
+                     }
+        specText  <- gatherSpecs(workDir, pack.specsDir)
+        _         <- stage("Judge")(
+                       specComplianceLoop(coderChat, Judge.of(reasoning, complianceDims), verGate, specText, plan.epicId)
+                     )
+        _         <- stage("Publish") {
+                       val push = git.push("origin", plan.epicId)
+                       val pr   = Ado.configFrom(sys.env) match
+                         case Right(_) =>
+                           Ado.withTool() { ado =>
+                             ado
+                               .createPr(
+                                 s"refs/heads/${plan.epicId}",
+                                 "refs/heads/main",
+                                 s"modernize: ${plan.epicId}",
+                                 s"Implements the approved spec pack. Plan: $ModDir/plan.md — all gates green.",
+                               )
+                               .flatMap(p => events.publish(FlowEvent.Info(s"ADO PR: ${p.webUrl}")))
+                           }
+                         case Left(_)  =>
+                           gh.createPr(
+                             plan.epicId,
+                             body = s"Implements the approved spec pack. Plan: $ModDir/plan.md — all gates green.",
+                             base = Some("main"),
+                           ).flatMap(p => events.publish(FlowEvent.Info(s"PR: ${p.url}")))
+                       (push *> pr).catchAll(e =>
+                         events.publish(FlowEvent.Info(s"publish skipped (no remote/forge configured): ${e.message}"))
+                       )
+                     }
+      yield plan.epicId

--- a/modules/llm4zio-modernize/src/main/scala/llm4zio/modernize/ImplementFlow.scala
+++ b/modules/llm4zio-modernize/src/main/scala/llm4zio/modernize/ImplementFlow.scala
@@ -4,32 +4,30 @@ object ImplementFlow:
 
   /** Legacy-modernization phase 3 of 5: implement the seeded plan, gated until green.
     *
-    *   modernize-extract.sc → (human approves) → modernize-seed.sc → modernize-implement.sc
-    *     → modernize-verify.sc → modernize-review.sc
+    * modernize-extract.sc → (human approves) → modernize-seed.sc → modernize-implement.sc → modernize-verify.sc →
+    * modernize-review.sc
     *
-    * The clean-room wall is ENFORCED here: the flow refuses to start if anything in the target
-    * workspace matches the pack's legacy `sources:` regex — the coder is driven by specs alone.
+    * The clean-room wall is ENFORCED here: the flow refuses to start if anything in the target workspace matches the
+    * pack's legacy `sources:` regex — the coder is driven by specs alone.
     *
-    * Runs ROOTED AT THE TARGET REPO (`--repo <target>`), resuming the plan modernize-seed.sc
-    * committed at `docs/modernization/plan.md` (PlanStore — a crashed or halted run picks up at the
-    * first incomplete task; task completion is persisted into the committed plan file itself, so
-    * progress is auditable in git history).
+    * Runs ROOTED AT THE TARGET REPO (`--repo <target>`), resuming the plan modernize-seed.sc committed at
+    * `docs/modernization/plan.md` (PlanStore — a crashed or halted run picks up at the first incomplete task; task
+    * completion is persisted into the committed plan file itself, so progress is auditable in git history).
     *
     * The sdd.sc harness, pack-parameterized:
-    *   - Task 1 encodes the seeded BDD scenarios as FAILING acceptance tests — gated on the pack's
-    *     `build` command, then required RED (green new tests encode nothing → the flow fails).
-    *   - Every later task implements toward green: `reviewAndFixLoop` runs the pack's `test`
-    *     command as the lint gate plus `Reviewers.minimal` and the PACK'S OWN LENSES (e.g.
-    *     cobol-fidelity: BigDecimal/HALF_UP, validation order, reason codes) on the flash reviewer.
+    *   - Task 1 encodes the seeded BDD scenarios as FAILING acceptance tests — gated on the pack's `build` command,
+    *     then required RED (green new tests encode nothing → the flow fails).
+    *   - Every later task implements toward green: `reviewAndFixLoop` runs the pack's `test` command as the lint gate
+    *     plus `Reviewers.minimal` and the PACK'S OWN LENSES (e.g. cobol-fidelity: BigDecimal/HALF_UP, validation order,
+    *     reason codes) on the flash reviewer.
     *   - One commit per task; non-convergence halts with the plan persisted — fix or rerun.
-    *   - Final gate: the pack's `verify` command must be clean, then an LLM-as-a-Judge on
-    *     `reasoning` scores the WHOLE branch diff against the committed spec pack
-    *     (spec-compliance + scenario-coverage, full marks or the flow fails after a bounded
-    *     feedback round).
-    *   - Push + PR: Azure DevOps when configured, GitHub otherwise; a missing forge/remote
-    *     degrades to an Info event so the local demo still completes.
+    *   - Final gate: the pack's `verify` command must be clean, then an LLM-as-a-Judge on `reasoning` scores the WHOLE
+    *     branch diff against the committed spec pack (spec-compliance + scenario-coverage, full marks or the flow fails
+    *     after a bounded feedback round).
+    *   - Push + PR: Azure DevOps when configured, GitHub otherwise; a missing forge/remote degrades to an Info event so
+    *     the local demo still completes.
     *
-    * Run:  scala-cli run modernize-implement.sc -- --repo ~/services/meridian-transfers
+    * Run: scala-cli run modernize-implement.sc -- --repo ~/services/meridian-transfers
     */
 
   import zio.{ IO, ZIO }
@@ -38,13 +36,13 @@ object ImplementFlow:
   import llm4zio.flow.*
   import llm4zio.runner.*
 
-  val ProModel: String    = "gemini-2.5-pro"   // point these at whatever your `gemini` CLI offers
-  val FlashModel: String  = "gemini-3.5-flash"
-  val JudgeRounds: Int = 2
-  val ModDir: String      = "docs/modernization"
+  val ProModel: String   = "gemini-2.5-pro" // point these at whatever your `gemini` CLI offers
+  val FlashModel: String = "gemini-3.5-flash"
+  val JudgeRounds: Int   = 2
+  val ModDir: String     = "docs/modernization"
 
-  /** The enforced clean-room wall: refuse to run with legacy source inside the target workspace, so the
-    * coder provably works from the specs alone.
+  /** The enforced clean-room wall: refuse to run with legacy source inside the target workspace, so the coder provably
+    * works from the specs alone.
     */
   def assertWall(pack: Pack, root: java.nio.file.Path, events: FlowEvents): IO[FlowError, Unit] =
     pack.sources match
@@ -110,8 +108,8 @@ object ImplementFlow:
       }
       .mapError(e => FlowError.Persistence("failed to read the committed specs", Some(e)))
 
-  /** Judge the branch diff against the committed specs; feed sub-bar reasoning back to the coder,
-    * re-verify, re-judge — bounded by `JudgeRounds`, failing the flow if the bar is never cleared.
+  /** Judge the branch diff against the committed specs; feed sub-bar reasoning back to the coder, re-verify, re-judge —
+    * bounded by `JudgeRounds`, failing the flow if the bar is never cleared.
     */
   def specComplianceLoop(
     coderChat: Chat,
@@ -159,31 +157,31 @@ object ImplementFlow:
       val reviewSvc = reviewers.headOption.getOrElse(reasoning)
 
       for
-        pack     <- stage("Pack")(Pack.load(packDir))
-        _        <- stage("Wall")(assertWall(pack, workDir, events))
-        plan     <- PlanStore
-                      .load(planFile)
-                      .someOrFail(FlowError.Aborted(s"no plan at $planFile — run modernize-seed.sc first"))
-        buildGate = pack.gate("build").fold(ZIO.succeed(ReviewResult(Nil)))(Reviewers.lintCommand(_, workDir))
-        testGate  = pack.gate("test").fold(ZIO.succeed(ReviewResult(Nil)))(Reviewers.lintCommand(_, workDir))
-        verGate   = pack.gate("verify").orElse(pack.gate("test")).fold(ZIO.succeed(ReviewResult(Nil)))(
-                      Reviewers.lintCommand(_, workDir)
-                    )
-        _        <- stage("Branch")(git.checkoutOrCreate(plan.epicId))
-        cards    <- Patterns
-                      .load(packDir.resolve("patterns"))
-                      .zipWith(Patterns.load(workspace.resolve("patterns")))(_ ++ _)
-        specText <- gatherSpecs(workDir, pack.specsDir)
-        cited     = Patterns.tagged(specText) // extraction tagged the fragments; specs cite the ids
-        playbook  = cards.filter(c => cited.contains(c.id))
-        system    = List(
-                      pack.prompt("implement"),
-                      pack.lessons.map(l => s"Lessons from previous modernization runs — apply them:\n$l"),
-                      Option.when(playbook.nonEmpty)(
-                        "Pattern cards cited by the specs — the translation playbook (advisory, the specs win):\n\n" +
-                          playbook.map(c => s"### ${c.id}\n${c.body}").mkString("\n\n")
-                      ),
-                    ).flatten.mkString("\n\n")
+        pack      <- stage("Pack")(Pack.load(packDir))
+        _         <- stage("Wall")(assertWall(pack, workDir, events))
+        plan      <- PlanStore
+                       .load(planFile)
+                       .someOrFail(FlowError.Aborted(s"no plan at $planFile — run modernize-seed.sc first"))
+        buildGate  = pack.gate("build").fold(ZIO.succeed(ReviewResult(Nil)))(Reviewers.lintCommand(_, workDir))
+        testGate   = pack.gate("test").fold(ZIO.succeed(ReviewResult(Nil)))(Reviewers.lintCommand(_, workDir))
+        verGate    = pack.gate("verify").orElse(pack.gate("test")).fold(ZIO.succeed(ReviewResult(Nil)))(
+                       Reviewers.lintCommand(_, workDir)
+                     )
+        _         <- stage("Branch")(git.checkoutOrCreate(plan.epicId))
+        cards     <- Patterns
+                       .load(packDir.resolve("patterns"))
+                       .zipWith(Patterns.load(workspace.resolve("patterns")))(_ ++ _)
+        specText  <- gatherSpecs(workDir, pack.specsDir)
+        cited      = Patterns.tagged(specText) // extraction tagged the fragments; specs cite the ids
+        playbook   = cards.filter(c => cited.contains(c.id))
+        system     = List(
+                       pack.prompt("implement"),
+                       pack.lessons.map(l => s"Lessons from previous modernization runs — apply them:\n$l"),
+                       Option.when(playbook.nonEmpty)(
+                         "Pattern cards cited by the specs — the translation playbook (advisory, the specs win):\n\n" +
+                           playbook.map(c => s"### ${c.id}\n${c.body}").mkString("\n\n")
+                       ),
+                     ).flatten.mkString("\n\n")
         coderChat <- Chat.start(coder, system = Some(system))
         _         <- implementTaskLoop(planFile, plan) { task =>
                        val testsTask = plan.tasks.headOption.contains(task)
@@ -208,15 +206,16 @@ object ImplementFlow:
                          _ <- git.commitAll(s"${plan.epicId}: ${task.title}").unit
                        yield ()
                      }
-        _         <- stage("Verify") {
-                       verGate.flatMap { r =>
-                         if r.isClean then ZIO.unit
-                         else
-                           fail(
-                             s"verify gate failed:\n${r.issues.map(i => s"${i.title}\n${i.description}".strip).mkString("\n\n")}"
-                           )
-                       }
-                     }
+        _         <-
+          stage("Verify") {
+            verGate.flatMap { r =>
+              if r.isClean then ZIO.unit
+              else
+                fail(
+                  s"verify gate failed:\n${r.issues.map(i => s"${i.title}\n${i.description}".strip).mkString("\n\n")}"
+                )
+            }
+          }
         specText  <- gatherSpecs(workDir, pack.specsDir)
         _         <- stage("Judge")(
                        specComplianceLoop(coderChat, Judge.of(reasoning, complianceDims), verGate, specText, plan.epicId)

--- a/modules/llm4zio-modernize/src/main/scala/llm4zio/modernize/Main.scala
+++ b/modules/llm4zio-modernize/src/main/scala/llm4zio/modernize/Main.scala
@@ -61,5 +61,5 @@ object Main:
         loadConf()
         phases(cmd)(rest.toArray)
       case _                                   =>
-        println(usage)
+        System.err.println(usage)
         sys.exit(2)

--- a/modules/llm4zio-modernize/src/main/scala/llm4zio/modernize/Main.scala
+++ b/modules/llm4zio-modernize/src/main/scala/llm4zio/modernize/Main.scala
@@ -1,0 +1,65 @@
+package llm4zio.modernize
+
+import java.nio.file.{ Files, Paths }
+
+import scala.jdk.CollectionConverters.*
+
+/** Environment for the modernization flows: real env vars win, `modernize.conf` (loaded into system
+  * properties by [[Main]]) fills the gaps — packs stay estate knowledge, the conf is deployment choices
+  * (seats, models, endpoints), different owners, different repos.
+  */
+object Env:
+  def get(name: String): Option[String]                     = sys.env.get(name).orElse(sys.props.get(s"llm4zio.$name"))
+  def getOrElse(name: String, fallback: => String): String  = get(name).getOrElse(fallback)
+
+/** The modernization pipeline as a product: six flows behind one subcommand main, configured entirely by
+  * the pack + env/`modernize.conf` — the operator never edits Scala. The `.sc` examples remain the
+  * authoring surface; this is the `cs launch` / OCI surface.
+  */
+object Main:
+
+  private val phases: Map[String, Array[String] => Unit] = Map(
+    "survey"    -> SurveyFlow.run,
+    "extract"   -> ExtractFlow.run,
+    "seed"      -> SeedFlow.run,
+    "implement" -> ImplementFlow.run,
+    "verify"    -> VerifyFlow.run,
+    "review"    -> ReviewFlow.run,
+  )
+
+  private val usage =
+    """usage: llm4zio-modernize <survey|extract|seed|implement|verify|review> -- --repo <dir> [args]
+      |
+      |  survey     inventory + dependency graph + triage + human-gated wave plan   (legacy repo)
+      |  extract    judged spec pack, per program, resumable                        (legacy repo)
+      |  seed       scaffold + specs + plan + provenance manifest (deterministic)   (target repo)
+      |  implement  plan execution, RED-first tests, gated until green              (target repo)
+      |  verify     equivalence proof: vectors → replay → per-rule report           (target repo)
+      |  review     fix specs + plan increment + lessons back into the pack         (target repo)
+      |
+      |Config: env vars first (LLM4ZIO_PACK, LLM4ZIO_CODER, LLM4ZIO_WAVE, …), then ./modernize.conf
+      |(KEY=value lines) for whatever env leaves unset. Packs are estate knowledge; the conf is
+      |deployment choices. See docs/pilot-playbook.md.""".stripMargin
+
+  /** `./modernize.conf` (KEY=value, `#` comments) → system properties, so [[Env]] finds them after env. */
+  private def loadConf(): Unit =
+    val conf = Paths.get("modernize.conf")
+    if Files.exists(conf) then
+      Files
+        .readAllLines(conf)
+        .asScala
+        .map(_.trim)
+        .filter(l => l.nonEmpty && !l.startsWith("#") && l.contains("="))
+        .foreach { line =>
+          val (k, v) = line.span(_ != '=')
+          sys.props.update(s"llm4zio.${k.trim}", v.drop(1).trim)
+        }
+
+  def main(args: Array[String]): Unit =
+    args.toList match
+      case cmd :: rest if phases.contains(cmd) =>
+        loadConf()
+        phases(cmd)(rest.toArray)
+      case _                                   =>
+        println(usage)
+        sys.exit(2)

--- a/modules/llm4zio-modernize/src/main/scala/llm4zio/modernize/Main.scala
+++ b/modules/llm4zio-modernize/src/main/scala/llm4zio/modernize/Main.scala
@@ -4,17 +4,17 @@ import java.nio.file.{ Files, Paths }
 
 import scala.jdk.CollectionConverters.*
 
-/** Environment for the modernization flows: real env vars win, `modernize.conf` (loaded into system
-  * properties by [[Main]]) fills the gaps — packs stay estate knowledge, the conf is deployment choices
-  * (seats, models, endpoints), different owners, different repos.
+/** Environment for the modernization flows: real env vars win, `modernize.conf` (loaded into system properties by
+  * [[Main]]) fills the gaps — packs stay estate knowledge, the conf is deployment choices (seats, models, endpoints),
+  * different owners, different repos.
   */
 object Env:
-  def get(name: String): Option[String]                     = sys.env.get(name).orElse(sys.props.get(s"llm4zio.$name"))
-  def getOrElse(name: String, fallback: => String): String  = get(name).getOrElse(fallback)
+  def get(name: String): Option[String]                    = sys.env.get(name).orElse(sys.props.get(s"llm4zio.$name"))
+  def getOrElse(name: String, fallback: => String): String = get(name).getOrElse(fallback)
 
-/** The modernization pipeline as a product: six flows behind one subcommand main, configured entirely by
-  * the pack + env/`modernize.conf` — the operator never edits Scala. The `.sc` examples remain the
-  * authoring surface; this is the `cs launch` / OCI surface.
+/** The modernization pipeline as a product: six flows behind one subcommand main, configured entirely by the pack +
+  * env/`modernize.conf` — the operator never edits Scala. The `.sc` examples remain the authoring surface; this is the
+  * `cs launch` / OCI surface.
   */
 object Main:
 
@@ -61,5 +61,5 @@ object Main:
         loadConf()
         phases(cmd)(rest.toArray)
       case _                                   =>
-        System.err.println(usage)
+        System.err.print(usage + "\n")
         sys.exit(2)

--- a/modules/llm4zio-modernize/src/main/scala/llm4zio/modernize/ReviewFlow.scala
+++ b/modules/llm4zio-modernize/src/main/scala/llm4zio/modernize/ReviewFlow.scala
@@ -1,0 +1,242 @@
+package llm4zio.modernize
+
+object ReviewFlow:
+
+  /** Legacy-modernization phase 5 of 5: review the delivered increment, produce fix specs, and
+    * feed lessons back into the pack.
+    *
+    *   modernize-extract.sc → (human approves) → modernize-seed.sc → modernize-implement.sc
+    *     → modernize-verify.sc → modernize-review.sc
+    *
+    * Runs ROOTED AT THE TARGET REPO (`--repo <target>`) on the implementation branch. This flow
+    * FINDS and ROUTES — it does not fix:
+    *
+    *   1. The full reviewer roster (`Reviewers.all`) PLUS the pack's own lenses read the branch
+    *      diff against the committed spec pack; an advisory judge quantifies spec compliance.
+    *   2. `reasoning` distills the findings into three routed outputs:
+    *      - FIX specs (implementation violates the spec) → documents under `docs/specs/fixes/`
+    *        + appended as new tasks to `docs/modernization/plan.md` — rerunning
+    *        modernize-implement.sc picks them up (the loop the gates promised).
+    *      - IMPROVEMENTS (compliant but worth follow-up) → documents under `docs/specs/fixes/`.
+    *      - LESSONS (generalizable to future runs) → `Pack.appendLesson` into the PACK's
+    *        lessons.md — extract.sc and implement.sc inject lessons into their briefs, so the
+    *        next modernization of this estate kind starts smarter. Commit the pack change like
+    *        any other reviewed edit.
+    *   3. Azure DevOps (optional): one work item per fix spec when ADO env vars are present.
+    *
+    * Run:  scala-cli run modernize-review.sc -- --repo ~/services/meridian-transfers
+    */
+
+  import java.nio.charset.StandardCharsets
+  import java.nio.file.{ Files, Path }
+
+  import scala.jdk.CollectionConverters.*
+
+  import zio.json.JsonCodec
+  import zio.{ IO, ZIO }
+
+  import llm4zio.core.SchemaDerivation
+  import llm4zio.eval.*
+  import llm4zio.flow.*
+  import llm4zio.runner.*
+
+  val ProModel: String   = "gemini-2.5-pro"   // point these at whatever your `gemini` CLI offers
+  val FlashModel: String = "gemini-3.5-flash"
+  val ModDir: String     = "docs/modernization"
+
+  /** The enforced clean-room wall: refuse to run with legacy source inside the target workspace. */
+  def assertWall(pack: Pack, root: Path, events: FlowEvents): IO[FlowError, Unit] =
+    pack.sources match
+      case None        => events.publish(FlowEvent.Info("pack has no sources regex — wall check skipped"))
+      case Some(regex) =>
+        Wall.check(root, regex).flatMap {
+          case Wall.Result.Clean           =>
+            events.publish(FlowEvent.Info("clean-room wall: no legacy source in the target workspace"))
+          case Wall.Result.Breached(paths) =>
+            val shown = paths.take(10).mkString(", ")
+            val more  = if paths.size > 10 then s" (+${paths.size - 10} more)" else ""
+            ZIO.fail(FlowError.Aborted(
+              s"clean-room wall breached — legacy source inside the target workspace: $shown$more. " +
+                "The review must judge spec-driven work only; remove the files and rerun."
+            ))
+        }
+
+  val (coderCfg, reasoningCfg, reviewerCfg) =
+    Env.get("LLM4ZIO_CODER").map(_.trim.toLowerCase).filter(_.nonEmpty) match
+      case None | Some("gemini") =>
+        (gemini, gemini.withModel(ProModel).copy(readOnly = true), gemini.withModel(FlashModel).copy(readOnly = true))
+      case Some(_)               =>
+        val agent = Connectors.coderFromEnv()
+        (agent, agent.copy(readOnly = true), agent.copy(readOnly = true))
+
+  /** One routed finding: a spec document plus the plan task that would address it. */
+  case class FixSpec(title: String, spec: String, taskTitle: String, taskDescription: String) derives JsonCodec
+
+  /** The distilled review: what must be fixed, what could be improved, what generalizes. */
+  case class ReviewOutcome(fixes: List[FixSpec], improvements: List[FixSpec], lessons: List[String]) derives JsonCodec
+
+  val complianceDims: List[Dimension] = List(
+    Dimension(
+      "spec-compliance",
+      "Does the implementation satisfy every rule in the committed specs — exact values, validation order, " +
+        "error paths — without weakening, deleting, or loosening any test or scenario?",
+    ),
+    Dimension(
+      "scenario-coverage",
+      "Is every BDD scenario in the seeded feature files exercised by an acceptance test on this branch?",
+    ),
+  )
+
+  def writeFile(path: Path, content: String): IO[FlowError, Unit] =
+    ZIO
+      .attemptBlocking {
+        Option(path.getParent).foreach(Files.createDirectories(_))
+        Files.write(path, content.getBytes(StandardCharsets.UTF_8))
+        ()
+      }
+      .mapError(e => FlowError.Persistence(s"failed to write $path", Some(e)))
+
+  def gatherDir(root: Path, dir: Path): IO[FlowError, String] =
+    ZIO
+      .attemptBlocking {
+        if !Files.isDirectory(dir) then ""
+        else
+          val stream = Files.walk(dir)
+          try
+            stream
+              .iterator()
+              .asScala
+              .filter(Files.isRegularFile(_))
+              .toList
+              .sortBy(_.toString)
+              .map(f => s"===== ${root.relativize(f)} =====\n${Files.readString(f)}")
+              .mkString("\n\n")
+          finally stream.close()
+      }
+      .mapError(e => FlowError.Persistence(s"failed to read $dir", Some(e)))
+
+  def slug(title: String): String =
+    title.toLowerCase.replaceAll("[^a-z0-9]+", "-").stripPrefix("-").stripSuffix("-").take(60)
+
+  def distillPrompt(packReviewPrompt: String, findings: ReviewResult, scored: EvalResult, diff: String): String =
+    val findingLines = findings.issues.map(i => s"- [${i.severity}] ${i.title}: ${i.description}").mkString("\n")
+    val scoreLines   = scored.scores.map(s => s"- ${s.name}: ${s.score}/2 — ${s.reasoning}").mkString("\n")
+    s"""$packReviewPrompt
+       |
+       |Below are the raw reviewer findings and judge scores for a modernization increment.
+       |Distill them:
+       |- "fixes": findings where the implementation VIOLATES the committed specs. Each gets a
+       |  short spec document (Markdown: what is wrong, the spec rule it violates, the expected
+       |  behaviour) and a plan task (title + description naming the spec rules/scenarios).
+       |- "improvements": worthwhile follow-ups that do NOT violate the specs.
+       |- "lessons": rules of thumb that would help FUTURE modernizations of this kind — phrased
+       |  generally (no file paths from this repo), one sentence each. Only include lessons that
+       |  generalize; an empty list is a fine answer.
+       |
+       |Reviewer findings:
+       |$findingLines
+       |
+       |Judge scores:
+       |$scoreLines
+       |
+       |Diff under review:
+       |$diff""".stripMargin
+
+  def run(args: Array[String]): Unit =
+    flow(
+      args,
+      coder = coderCfg,
+      reasoning = Some(reasoningCfg),
+      reviewers = List(reviewerCfg),
+      defaultPrompt = Some("Review the modernization increment against its spec pack"),
+    ):
+      val packDir   = workspace.resolve(Env.getOrElse("LLM4ZIO_PACK", "packs/cobol-springboot"))
+      val planFile  = workDir.resolve(ModDir).resolve("plan.md")
+      val events    = summon[FlowEvents]
+      val reviewSvc = reviewers.headOption.getOrElse(reasoning)
+
+      for
+        pack     <- stage("Pack")(Pack.load(packDir))
+        _        <- stage("Wall")(assertWall(pack, workDir, events))
+        base     <- git.defaultBase
+        diff     <- git.diffVsBase(base)
+        _        <- ZIO.when(diff.isBlank)(
+                      ZIO.fail(FlowError.Aborted(s"nothing to review: no diff vs $base on this branch"))
+                    )
+        files    <- git.changedFilesVsBase(base)
+        specText <- gatherDir(workDir, workDir.resolve(pack.specsDir))
+        findings <- stage("Review") {
+                      val roster = (Reviewers.all ++ pack.lenses).filter(_.matches(files))
+                      ZIO
+                        .foreach(roster) { r => // sequential: gemini free tier 429s under concurrent reviewers
+                          r.asService(reviewSvc)
+                            .executeStructured[ReviewResult](
+                              Reviewers.reviewPrompt(s"modernization increment vs committed specs\n\n$specText", diff),
+                              Reviewers.schema,
+                            )
+                            .mapError(e => FlowError.Llm(e.message, Some(e)))
+                        }
+                        .map(Reviewers.merge)
+                    }
+        scored   <- stage("Judge") {
+                      Judge
+                        .of(reasoning, complianceDims)
+                        .evaluate(Sample(response = diff, context = Some(specText), query = Some(userPrompt)))
+                        .mapError(e => FlowError.Llm(e.message, Some(e)))
+                    }
+        outcome  <- stage("Distill") {
+                      reasoning
+                        .executeStructured[ReviewOutcome](
+                          distillPrompt(pack.prompt("review").getOrElse(""), findings, scored, diff),
+                          SchemaDerivation.derive[ReviewOutcome],
+                        )
+                        .mapError(e => FlowError.Llm(e.message, Some(e)))
+                    }
+        _        <- stage("Fix specs") {
+                      val all = outcome.fixes.map(("fix", _)) ++ outcome.improvements.map(("improvement", _))
+                      ZIO.foreachDiscard(all) { (kind, f) =>
+                        writeFile(
+                          workDir.resolve(pack.specsDir).resolve("fixes").resolve(s"$kind-${slug(f.title)}.md"),
+                          s"# ${f.title}\n\n${f.spec}\n",
+                        )
+                      } *> {
+                        if outcome.fixes.isEmpty then events.publish(FlowEvent.Info("no spec violations — no plan increment"))
+                        else
+                          PlanStore
+                            .load(planFile)
+                            .someOrFail(FlowError.Aborted(s"no plan at $planFile — run modernize-seed.sc first"))
+                            .flatMap { plan =>
+                              val increment = outcome.fixes.map(f => Task(f.taskTitle, f.taskDescription))
+                              PlanStore.save(planFile, plan.copy(tasks = plan.tasks ++ increment)) *>
+                                events.publish(FlowEvent.Info(
+                                  s"${increment.size} fix task(s) appended — rerun modernize-implement.sc"
+                                ))
+                            }
+                      }
+                    }
+        _        <- stage("Lessons") {
+                      if outcome.lessons.isEmpty then events.publish(FlowEvent.Info("no generalizable lessons this round"))
+                      else
+                        ZIO.foreachDiscard(outcome.lessons)(Pack.appendLesson(pack.dir, _)) *>
+                          events.publish(FlowEvent.Info(
+                            s"${outcome.lessons.size} lesson(s) appended to ${pack.dir.resolve("lessons.md")} — " +
+                              "review and commit the pack change"
+                          ))
+                    }
+        _        <- stage("Commit")(
+                      git.commitAll(s"modernize(${pack.name}): review — ${outcome.fixes.size} fix(es), " +
+                        s"${outcome.improvements.size} improvement(s)").unit
+                    )
+        _        <- stage("Boards") {
+                      Ado.configFrom(sys.env) match
+                        case Left(_)  => events.publish(FlowEvent.Info("Azure DevOps not configured — skipping work items"))
+                        case Right(_) =>
+                          Ado.withTool() { ado =>
+                            ZIO.foreachDiscard(outcome.fixes) { f =>
+                              ado
+                                .createWorkItem("Task", f.taskTitle, Map("System.Description" -> f.taskDescription))
+                                .flatMap(id => events.publish(FlowEvent.Info(s"work item $id: ${f.taskTitle}")))
+                            }
+                          }
+                    }
+      yield s"fixes=${outcome.fixes.size} improvements=${outcome.improvements.size} lessons=${outcome.lessons.size}"

--- a/modules/llm4zio-modernize/src/main/scala/llm4zio/modernize/ReviewFlow.scala
+++ b/modules/llm4zio-modernize/src/main/scala/llm4zio/modernize/ReviewFlow.scala
@@ -2,29 +2,28 @@ package llm4zio.modernize
 
 object ReviewFlow:
 
-  /** Legacy-modernization phase 5 of 5: review the delivered increment, produce fix specs, and
-    * feed lessons back into the pack.
+  /** Legacy-modernization phase 5 of 5: review the delivered increment, produce fix specs, and feed lessons back into
+    * the pack.
     *
-    *   modernize-extract.sc → (human approves) → modernize-seed.sc → modernize-implement.sc
-    *     → modernize-verify.sc → modernize-review.sc
+    * modernize-extract.sc → (human approves) → modernize-seed.sc → modernize-implement.sc → modernize-verify.sc →
+    * modernize-review.sc
     *
-    * Runs ROOTED AT THE TARGET REPO (`--repo <target>`) on the implementation branch. This flow
-    * FINDS and ROUTES — it does not fix:
+    * Runs ROOTED AT THE TARGET REPO (`--repo <target>`) on the implementation branch. This flow FINDS and ROUTES — it
+    * does not fix:
     *
-    *   1. The full reviewer roster (`Reviewers.all`) PLUS the pack's own lenses read the branch
-    *      diff against the committed spec pack; an advisory judge quantifies spec compliance.
+    *   1. The full reviewer roster (`Reviewers.all`) PLUS the pack's own lenses read the branch diff against the
+    *      committed spec pack; an advisory judge quantifies spec compliance.
     *   2. `reasoning` distills the findings into three routed outputs:
-    *      - FIX specs (implementation violates the spec) → documents under `docs/specs/fixes/`
-    *        + appended as new tasks to `docs/modernization/plan.md` — rerunning
-    *        modernize-implement.sc picks them up (the loop the gates promised).
+    *      - FIX specs (implementation violates the spec) → documents under `docs/specs/fixes/` + appended as new tasks
+    *        to `docs/modernization/plan.md` — rerunning modernize-implement.sc picks them up (the loop the gates
+    *        promised).
     *      - IMPROVEMENTS (compliant but worth follow-up) → documents under `docs/specs/fixes/`.
-    *      - LESSONS (generalizable to future runs) → `Pack.appendLesson` into the PACK's
-    *        lessons.md — extract.sc and implement.sc inject lessons into their briefs, so the
-    *        next modernization of this estate kind starts smarter. Commit the pack change like
-    *        any other reviewed edit.
+    *      - LESSONS (generalizable to future runs) → `Pack.appendLesson` into the PACK's lessons.md — extract.sc and
+    *        implement.sc inject lessons into their briefs, so the next modernization of this estate kind starts
+    *        smarter. Commit the pack change like any other reviewed edit.
     *   3. Azure DevOps (optional): one work item per fix spec when ADO env vars are present.
     *
-    * Run:  scala-cli run modernize-review.sc -- --repo ~/services/meridian-transfers
+    * Run: scala-cli run modernize-review.sc -- --repo ~/services/meridian-transfers
     */
 
   import java.nio.charset.StandardCharsets
@@ -40,7 +39,7 @@ object ReviewFlow:
   import llm4zio.flow.*
   import llm4zio.runner.*
 
-  val ProModel: String   = "gemini-2.5-pro"   // point these at whatever your `gemini` CLI offers
+  val ProModel: String   = "gemini-2.5-pro" // point these at whatever your `gemini` CLI offers
   val FlashModel: String = "gemini-3.5-flash"
   val ModDir: String     = "docs/modernization"
 

--- a/modules/llm4zio-modernize/src/main/scala/llm4zio/modernize/SeedFlow.scala
+++ b/modules/llm4zio-modernize/src/main/scala/llm4zio/modernize/SeedFlow.scala
@@ -4,32 +4,32 @@ object SeedFlow:
 
   /** Legacy-modernization phase 2 of 5: seed the target repo from the APPROVED spec pack.
     *
-    *   modernize-extract.sc → (human approves) → modernize-seed.sc → modernize-implement.sc
-    *     → modernize-verify.sc → modernize-review.sc
+    * modernize-extract.sc → (human approves) → modernize-seed.sc → modernize-implement.sc → modernize-verify.sc →
+    * modernize-review.sc
     *
-    * Runs ROOTED AT THE TARGET REPO (`--repo <target>`), reading the spec pack out of the legacy
-    * repo (`LLM4ZIO_LEGACY_REPO`). This phase is deliberately deterministic — no LLM calls:
+    * Runs ROOTED AT THE TARGET REPO (`--repo <target>`), reading the spec pack out of the legacy repo
+    * (`LLM4ZIO_LEGACY_REPO`). This phase is deliberately deterministic — no LLM calls:
     *
-    *   1. `ApprovalGate.gate` REFUSES to run until a human has flipped `- [x] Approved` in the
-    *      legacy repo's `docs/modernization/README.md` (extract.sc writes it unchecked).
-    *   2. If the target repo is empty, the pack's scaffold is copied in (the bank-provided
-    *      starter); an existing repo is used as-is.
-    *   3. Specs / traceability / mapping land in the pack's `specs-dir`; .feature files land in
-    *      the pack's `features-dir` (for cobol-springboot: src/test/resources/features, where the
-    *      acceptance tests will read them).
-    *   4. The proposed plan is materialized at `docs/modernization/plan.md` — extract.sc wrote it
-    *      in the canonical `Plan.render` Markdown, so this phase re-parses it as a hard validation
-    *      and modernize-implement.sc resumes it with `PlanStore`.
-    *   5. The PROVENANCE MANIFEST (`docs/modernization/provenance.json`) is written and committed:
-    *      the clean-room receipt — spec-pack file hashes (plain sha256, `shasum`-checkable), gate
-    *      verdict digests, pack, llm4zio version, and the approver (`LLM4ZIO_APPROVER`, when set).
-    *      modernize-verify.sc appends the equivalence-report hash to it later.
-    *   6. Azure DevOps (optional): when ADO env vars are present (SYSTEM_COLLECTIONURI /
-    *      LLM4ZIO_ADO_* + PAT), one Task work item is created per plan task, carrying the task
-    *      description as acceptance criteria. Absent config = skipped with an Info event.
+    *   1. `ApprovalGate.gate` REFUSES to run until a human has flipped `- [x] Approved` in the legacy repo's
+    *      `docs/modernization/README.md` (extract.sc writes it unchecked).
+    *   2. If the target repo is empty, the pack's scaffold is copied in (the bank-provided starter); an existing repo
+    *      is used as-is.
+    *   3. Specs / traceability / mapping land in the pack's `specs-dir`; .feature files land in the pack's
+    *      `features-dir` (for cobol-springboot: src/test/resources/features, where the acceptance tests will read
+    *      them).
+    *   4. The proposed plan is materialized at `docs/modernization/plan.md` — extract.sc wrote it in the canonical
+    *      `Plan.render` Markdown, so this phase re-parses it as a hard validation and modernize-implement.sc resumes it
+    *      with `PlanStore`.
+    *   5. The PROVENANCE MANIFEST (`docs/modernization/provenance.json`) is written and committed: the clean-room
+    *      receipt — spec-pack file hashes (plain sha256, `shasum`-checkable), gate verdict digests, pack, llm4zio
+    *      version, and the approver (`LLM4ZIO_APPROVER`, when set). modernize-verify.sc appends the equivalence-report
+    *      hash to it later.
+    *   6. Azure DevOps (optional): when ADO env vars are present (SYSTEM_COLLECTIONURI / LLM4ZIO_ADO_* + PAT), one Task
+    *      work item is created per plan task, carrying the task description as acceptance criteria. Absent config =
+    *      skipped with an Info event.
     *
-    * Run:  LLM4ZIO_LEGACY_REPO=~/estates/meridian-legacy \
-    *       scala-cli run modernize-seed.sc -- --repo ~/services/meridian-transfers
+    * Run: LLM4ZIO_LEGACY_REPO=~/estates/meridian-legacy \ scala-cli run modernize-seed.sc -- --repo
+    * ~/services/meridian-transfers
     */
 
   import java.nio.charset.StandardCharsets
@@ -105,99 +105,100 @@ object SeedFlow:
       val events     = summon[FlowEvents]
 
       for
-        pack     <- stage("Pack")(Pack.load(packDir))
-        legacy   <- ZIO
-                      .fromOption(legacyRepo)
-                      .orElseFail(FlowError.Aborted("set LLM4ZIO_LEGACY_REPO to the legacy repo holding the spec pack"))
-        specPack  = legacy.resolve(ModDir)
-        _        <- stage("Approval")(ApprovalGate.gate(specPack.resolve("README.md"), Interaction.noninteractive))
-        _        <- stage("Scaffold") {
-                      nonGitEntries(workDir).flatMap {
-                        case Nil =>
-                          pack.scaffold match
-                            case Some(rel) =>
-                              val scaffold = pack.dir.resolve(rel).normalize
-                              copyTree(scaffold, workDir).flatMap(n =>
-                                events.publish(FlowEvent.Info(s"scaffolded $n file(s) from $scaffold"))
-                              )
-                            case None      =>
-                              ZIO.fail(FlowError.Aborted(s"target repo is empty and pack '${pack.name}' has no scaffold"))
-                        case _   => events.publish(FlowEvent.Info("target repo is not empty — using it as-is"))
-                      }
-                    }
-        seeded   <- stage("Seed") {
-                      for
-                        n1 <- copyTree(specPack.resolve("specs"), workDir.resolve(pack.specsDir))
-                        n2 <- copyTree(specPack.resolve("features"), workDir.resolve(pack.featuresDir))
-                        _  <- ZIO.foreachDiscard(List("traceability.md", "mapping.md", "rules.txt")) { f =>
-                                copyFile(specPack.resolve(f), workDir.resolve(pack.specsDir).resolve(f))
-                              }
-                      yield n1 + n2
-                    }
-        plan     <- stage("Plan") {
-                      for
-                        text   <- ZIO
-                                    .attemptBlocking(Files.readString(specPack.resolve("plan.md")))
-                                    .mapError(e =>
-                                      FlowError.Persistence("spec pack has no plan.md — did extract.sc pass its gate?", Some(e))
+        pack    <- stage("Pack")(Pack.load(packDir))
+        legacy  <- ZIO
+                     .fromOption(legacyRepo)
+                     .orElseFail(FlowError.Aborted("set LLM4ZIO_LEGACY_REPO to the legacy repo holding the spec pack"))
+        specPack = legacy.resolve(ModDir)
+        _       <- stage("Approval")(ApprovalGate.gate(specPack.resolve("README.md"), Interaction.noninteractive))
+        _       <- stage("Scaffold") {
+                     nonGitEntries(workDir).flatMap {
+                       case Nil =>
+                         pack.scaffold match
+                           case Some(rel) =>
+                             val scaffold = pack.dir.resolve(rel).normalize
+                             copyTree(scaffold, workDir).flatMap(n =>
+                               events.publish(FlowEvent.Info(s"scaffolded $n file(s) from $scaffold"))
+                             )
+                           case None      =>
+                             ZIO.fail(FlowError.Aborted(s"target repo is empty and pack '${pack.name}' has no scaffold"))
+                       case _   => events.publish(FlowEvent.Info("target repo is not empty — using it as-is"))
+                     }
+                   }
+        seeded  <- stage("Seed") {
+                     for
+                       n1 <- copyTree(specPack.resolve("specs"), workDir.resolve(pack.specsDir))
+                       n2 <- copyTree(specPack.resolve("features"), workDir.resolve(pack.featuresDir))
+                       _  <- ZIO.foreachDiscard(List("traceability.md", "mapping.md", "rules.txt")) { f =>
+                               copyFile(specPack.resolve(f), workDir.resolve(pack.specsDir).resolve(f))
+                             }
+                     yield n1 + n2
+                   }
+        plan    <- stage("Plan") {
+                     for
+                       text   <-
+                         ZIO
+                           .attemptBlocking(Files.readString(specPack.resolve("plan.md")))
+                           .mapError(e =>
+                             FlowError.Persistence("spec pack has no plan.md — did extract.sc pass its gate?", Some(e))
+                           )
+                       parsed <- ZIO.fromEither(Plan.parse(text)).mapError(FlowError.PlanParse(_))
+                       _      <- writeFile(workDir.resolve(ModDir).resolve("plan.md"), parsed.render)
+                     yield parsed
+                   }
+        _       <- stage("Provenance") {
+                     for
+                       specFiles <- SpecChecks.matchingFiles(workDir.resolve(pack.specsDir), """.*\.md""")
+                       hashes    <- Provenance.hashFiles(workDir, specFiles.map(f => s"${pack.specsDir}/$f"))
+                       gateFiles <- SpecChecks
+                                      .matchingFiles(specPack.resolve("gate"), """.*\.json""")
+                                      .orElseSucceed(Nil) // pre-3.13 spec packs have no gate/ directory
+                       verdicts  <- Provenance.hashFiles(specPack.resolve("gate"), gateFiles)
+                       seats     <- ZIO
+                                      .attemptBlocking(Files.readString(specPack.resolve("seats.json")))
+                                      .map(_.fromJson[Map[String, String]].getOrElse(Map.empty))
+                                      .orElseSucceed(Map.empty) // pre-3.23 spec packs have no seats sidecar
+                       now       <- zio.Clock.instant
+                       _         <- Provenance.write(
+                                      workDir.resolve(ModDir).resolve("provenance.json"),
+                                      Provenance(
+                                        schema = 1,
+                                        pack = pack.name,
+                                        llm4zioVersion = Llm4zioVersion,
+                                        createdAt = now.toString,
+                                        approvedBy = Env.get("LLM4ZIO_APPROVER"),
+                                        seats = seats,
+                                        specs = hashes,
+                                        gateVerdicts = verdicts.map((f, h) => f.stripSuffix(".json") -> h),
+                                        equivalenceReport = None,
+                                        fixSpecs = Nil,
+                                      ),
                                     )
-                        parsed <- ZIO.fromEither(Plan.parse(text)).mapError(FlowError.PlanParse(_))
-                        _      <- writeFile(workDir.resolve(ModDir).resolve("plan.md"), parsed.render)
-                      yield parsed
-                    }
-        _        <- stage("Provenance") {
-                      for
-                        specFiles <- SpecChecks.matchingFiles(workDir.resolve(pack.specsDir), """.*\.md""")
-                        hashes    <- Provenance.hashFiles(workDir, specFiles.map(f => s"${pack.specsDir}/$f"))
-                        gateFiles <- SpecChecks
-                                       .matchingFiles(specPack.resolve("gate"), """.*\.json""")
-                                       .orElseSucceed(Nil) // pre-3.13 spec packs have no gate/ directory
-                        verdicts  <- Provenance.hashFiles(specPack.resolve("gate"), gateFiles)
-                        seats     <- ZIO
-                                       .attemptBlocking(Files.readString(specPack.resolve("seats.json")))
-                                       .map(_.fromJson[Map[String, String]].getOrElse(Map.empty))
-                                       .orElseSucceed(Map.empty) // pre-3.23 spec packs have no seats sidecar
-                        now       <- zio.Clock.instant
-                        _         <- Provenance.write(
-                                       workDir.resolve(ModDir).resolve("provenance.json"),
-                                       Provenance(
-                                         schema = 1,
-                                         pack = pack.name,
-                                         llm4zioVersion = Llm4zioVersion,
-                                         createdAt = now.toString,
-                                         approvedBy = Env.get("LLM4ZIO_APPROVER"),
-                                         seats = seats,
-                                         specs = hashes,
-                                         gateVerdicts = verdicts.map((f, h) => f.stripSuffix(".json") -> h),
-                                         equivalenceReport = None,
-                                         fixSpecs = Nil,
-                                       ),
-                                     )
-                      yield ()
-                    }
-        _        <- stage("Commit")(
-                      git.commitAll(s"modernize(${pack.name}): seed specs, features, plan, and provenance " +
-                        s"($seeded file(s))").unit
-                    )
-        _        <- stage("Boards") {
-                      Ado.configFrom(sys.env) match
-                        case Left(_)  =>
-                          events.publish(FlowEvent.Info("Azure DevOps not configured — skipping work items"))
-                        case Right(_) =>
-                          Ado.withTool() { ado =>
-                            ZIO.foreachDiscard(plan.tasks) { task =>
-                              ado
-                                .createWorkItem(
-                                  "Task",
-                                  s"${plan.epicId}: ${task.title}",
-                                  Map(
-                                    "System.Description"                        -> task.description,
-                                    "Microsoft.VSTS.Common.AcceptanceCriteria" -> task.description,
-                                  ),
-                                )
-                                .flatMap(id => events.publish(FlowEvent.Info(s"work item $id: ${task.title}")))
-                            }
-                          }
-                    }
-        _        <- events.publish(FlowEvent.Info("target seeded — run modernize-implement.sc with the same --repo"))
+                     yield ()
+                   }
+        _       <- stage("Commit")(
+                     git.commitAll(s"modernize(${pack.name}): seed specs, features, plan, and provenance " +
+                       s"($seeded file(s))").unit
+                   )
+        _       <- stage("Boards") {
+                     Ado.configFrom(sys.env) match
+                       case Left(_)  =>
+                         events.publish(FlowEvent.Info("Azure DevOps not configured — skipping work items"))
+                       case Right(_) =>
+                         Ado.withTool() { ado =>
+                           ZIO.foreachDiscard(plan.tasks) { task =>
+                             ado
+                               .createWorkItem(
+                                 "Task",
+                                 s"${plan.epicId}: ${task.title}",
+                                 Map(
+                                   "System.Description"                       -> task.description,
+                                   "Microsoft.VSTS.Common.AcceptanceCriteria" -> task.description,
+                                 ),
+                               )
+                               .flatMap(id => events.publish(FlowEvent.Info(s"work item $id: ${task.title}")))
+                           }
+                         }
+                   }
+        _       <- events.publish(FlowEvent.Info("target seeded — run modernize-implement.sc with the same --repo"))
       yield plan.epicId

--- a/modules/llm4zio-modernize/src/main/scala/llm4zio/modernize/SeedFlow.scala
+++ b/modules/llm4zio-modernize/src/main/scala/llm4zio/modernize/SeedFlow.scala
@@ -1,0 +1,203 @@
+package llm4zio.modernize
+
+object SeedFlow:
+
+  /** Legacy-modernization phase 2 of 5: seed the target repo from the APPROVED spec pack.
+    *
+    *   modernize-extract.sc → (human approves) → modernize-seed.sc → modernize-implement.sc
+    *     → modernize-verify.sc → modernize-review.sc
+    *
+    * Runs ROOTED AT THE TARGET REPO (`--repo <target>`), reading the spec pack out of the legacy
+    * repo (`LLM4ZIO_LEGACY_REPO`). This phase is deliberately deterministic — no LLM calls:
+    *
+    *   1. `ApprovalGate.gate` REFUSES to run until a human has flipped `- [x] Approved` in the
+    *      legacy repo's `docs/modernization/README.md` (extract.sc writes it unchecked).
+    *   2. If the target repo is empty, the pack's scaffold is copied in (the bank-provided
+    *      starter); an existing repo is used as-is.
+    *   3. Specs / traceability / mapping land in the pack's `specs-dir`; .feature files land in
+    *      the pack's `features-dir` (for cobol-springboot: src/test/resources/features, where the
+    *      acceptance tests will read them).
+    *   4. The proposed plan is materialized at `docs/modernization/plan.md` — extract.sc wrote it
+    *      in the canonical `Plan.render` Markdown, so this phase re-parses it as a hard validation
+    *      and modernize-implement.sc resumes it with `PlanStore`.
+    *   5. The PROVENANCE MANIFEST (`docs/modernization/provenance.json`) is written and committed:
+    *      the clean-room receipt — spec-pack file hashes (plain sha256, `shasum`-checkable), gate
+    *      verdict digests, pack, llm4zio version, and the approver (`LLM4ZIO_APPROVER`, when set).
+    *      modernize-verify.sc appends the equivalence-report hash to it later.
+    *   6. Azure DevOps (optional): when ADO env vars are present (SYSTEM_COLLECTIONURI /
+    *      LLM4ZIO_ADO_* + PAT), one Task work item is created per plan task, carrying the task
+    *      description as acceptance criteria. Absent config = skipped with an Info event.
+    *
+    * Run:  LLM4ZIO_LEGACY_REPO=~/estates/meridian-legacy \
+    *       scala-cli run modernize-seed.sc -- --repo ~/services/meridian-transfers
+    */
+
+  import java.nio.charset.StandardCharsets
+  import java.nio.file.{ Files, Path }
+
+  import scala.jdk.CollectionConverters.*
+
+  import zio.json.*
+  import zio.{ IO, ZIO }
+
+  import llm4zio.flow.*
+  import llm4zio.runner.*
+
+  val ModDir: String         = "docs/modernization"
+  val Llm4zioVersion: String = "3.26.0" // keep in step with the `using dep` header pin
+
+  def writeFile(path: Path, content: String): IO[FlowError, Unit] =
+    ZIO
+      .attemptBlocking {
+        Option(path.getParent).foreach(Files.createDirectories(_))
+        Files.write(path, content.getBytes(StandardCharsets.UTF_8))
+        ()
+      }
+      .mapError(e => FlowError.Persistence(s"failed to write $path", Some(e)))
+
+  /** Copy a directory tree, skipping build/VCS litter. */
+  def copyTree(src: Path, dst: Path, skip: Set[String] = Set(".git", "target", "node_modules")): IO[FlowError, Int] =
+    ZIO
+      .attemptBlocking {
+        val stream = Files.walk(src)
+        val files  =
+          try stream.iterator().asScala.filter(Files.isRegularFile(_)).toList
+          finally stream.close()
+        val kept   = files.filterNot(f => src.relativize(f).iterator().asScala.exists(p => skip(p.toString)))
+        kept.foreach { f =>
+          val to = dst.resolve(src.relativize(f).toString)
+          Option(to.getParent).foreach(Files.createDirectories(_))
+          Files.copy(f, to, java.nio.file.StandardCopyOption.REPLACE_EXISTING)
+        }
+        kept.size
+      }
+      .mapError(e => FlowError.Persistence(s"failed to copy $src -> $dst", Some(e)))
+
+  /** Copy one file if it exists, creating parent directories; false when the source is absent. */
+  def copyFile(src: Path, dst: Path): IO[FlowError, Boolean] =
+    ZIO
+      .attemptBlocking {
+        if !Files.exists(src) then false
+        else
+          Option(dst.getParent).foreach(Files.createDirectories(_))
+          Files.copy(src, dst, java.nio.file.StandardCopyOption.REPLACE_EXISTING)
+          true
+      }
+      .mapError(e => FlowError.Persistence(s"failed to copy $src -> $dst", Some(e)))
+
+  /** Files directly under `dir`, `.git` aside — empty means "fresh repo, scaffold me". */
+  def nonGitEntries(dir: Path): IO[FlowError, List[Path]] =
+    ZIO
+      .attemptBlocking {
+        val stream = Files.list(dir)
+        try stream.iterator().asScala.filterNot(_.getFileName.toString == ".git").toList
+        finally stream.close()
+      }
+      .mapError(e => FlowError.Persistence(s"failed to list $dir", Some(e)))
+
+  def run(args: Array[String]): Unit =
+    flow(
+      args,
+      defaultPrompt = Some("Seed the target repository from the approved spec pack"),
+    ):
+      val packDir    = workspace.resolve(Env.getOrElse("LLM4ZIO_PACK", "packs/cobol-springboot"))
+      val legacyRepo = Env.get("LLM4ZIO_LEGACY_REPO").map(p => workspace.resolve(p).normalize)
+      val events     = summon[FlowEvents]
+
+      for
+        pack     <- stage("Pack")(Pack.load(packDir))
+        legacy   <- ZIO
+                      .fromOption(legacyRepo)
+                      .orElseFail(FlowError.Aborted("set LLM4ZIO_LEGACY_REPO to the legacy repo holding the spec pack"))
+        specPack  = legacy.resolve(ModDir)
+        _        <- stage("Approval")(ApprovalGate.gate(specPack.resolve("README.md"), Interaction.noninteractive))
+        _        <- stage("Scaffold") {
+                      nonGitEntries(workDir).flatMap {
+                        case Nil =>
+                          pack.scaffold match
+                            case Some(rel) =>
+                              val scaffold = pack.dir.resolve(rel).normalize
+                              copyTree(scaffold, workDir).flatMap(n =>
+                                events.publish(FlowEvent.Info(s"scaffolded $n file(s) from $scaffold"))
+                              )
+                            case None      =>
+                              ZIO.fail(FlowError.Aborted(s"target repo is empty and pack '${pack.name}' has no scaffold"))
+                        case _   => events.publish(FlowEvent.Info("target repo is not empty — using it as-is"))
+                      }
+                    }
+        seeded   <- stage("Seed") {
+                      for
+                        n1 <- copyTree(specPack.resolve("specs"), workDir.resolve(pack.specsDir))
+                        n2 <- copyTree(specPack.resolve("features"), workDir.resolve(pack.featuresDir))
+                        _  <- ZIO.foreachDiscard(List("traceability.md", "mapping.md", "rules.txt")) { f =>
+                                copyFile(specPack.resolve(f), workDir.resolve(pack.specsDir).resolve(f))
+                              }
+                      yield n1 + n2
+                    }
+        plan     <- stage("Plan") {
+                      for
+                        text   <- ZIO
+                                    .attemptBlocking(Files.readString(specPack.resolve("plan.md")))
+                                    .mapError(e =>
+                                      FlowError.Persistence("spec pack has no plan.md — did extract.sc pass its gate?", Some(e))
+                                    )
+                        parsed <- ZIO.fromEither(Plan.parse(text)).mapError(FlowError.PlanParse(_))
+                        _      <- writeFile(workDir.resolve(ModDir).resolve("plan.md"), parsed.render)
+                      yield parsed
+                    }
+        _        <- stage("Provenance") {
+                      for
+                        specFiles <- SpecChecks.matchingFiles(workDir.resolve(pack.specsDir), """.*\.md""")
+                        hashes    <- Provenance.hashFiles(workDir, specFiles.map(f => s"${pack.specsDir}/$f"))
+                        gateFiles <- SpecChecks
+                                       .matchingFiles(specPack.resolve("gate"), """.*\.json""")
+                                       .orElseSucceed(Nil) // pre-3.13 spec packs have no gate/ directory
+                        verdicts  <- Provenance.hashFiles(specPack.resolve("gate"), gateFiles)
+                        seats     <- ZIO
+                                       .attemptBlocking(Files.readString(specPack.resolve("seats.json")))
+                                       .map(_.fromJson[Map[String, String]].getOrElse(Map.empty))
+                                       .orElseSucceed(Map.empty) // pre-3.23 spec packs have no seats sidecar
+                        now       <- zio.Clock.instant
+                        _         <- Provenance.write(
+                                       workDir.resolve(ModDir).resolve("provenance.json"),
+                                       Provenance(
+                                         schema = 1,
+                                         pack = pack.name,
+                                         llm4zioVersion = Llm4zioVersion,
+                                         createdAt = now.toString,
+                                         approvedBy = Env.get("LLM4ZIO_APPROVER"),
+                                         seats = seats,
+                                         specs = hashes,
+                                         gateVerdicts = verdicts.map((f, h) => f.stripSuffix(".json") -> h),
+                                         equivalenceReport = None,
+                                         fixSpecs = Nil,
+                                       ),
+                                     )
+                      yield ()
+                    }
+        _        <- stage("Commit")(
+                      git.commitAll(s"modernize(${pack.name}): seed specs, features, plan, and provenance " +
+                        s"($seeded file(s))").unit
+                    )
+        _        <- stage("Boards") {
+                      Ado.configFrom(sys.env) match
+                        case Left(_)  =>
+                          events.publish(FlowEvent.Info("Azure DevOps not configured — skipping work items"))
+                        case Right(_) =>
+                          Ado.withTool() { ado =>
+                            ZIO.foreachDiscard(plan.tasks) { task =>
+                              ado
+                                .createWorkItem(
+                                  "Task",
+                                  s"${plan.epicId}: ${task.title}",
+                                  Map(
+                                    "System.Description"                        -> task.description,
+                                    "Microsoft.VSTS.Common.AcceptanceCriteria" -> task.description,
+                                  ),
+                                )
+                                .flatMap(id => events.publish(FlowEvent.Info(s"work item $id: ${task.title}")))
+                            }
+                          }
+                    }
+        _        <- events.publish(FlowEvent.Info("target seeded — run modernize-implement.sc with the same --repo"))
+      yield plan.epicId

--- a/modules/llm4zio-modernize/src/main/scala/llm4zio/modernize/SurveyFlow.scala
+++ b/modules/llm4zio-modernize/src/main/scala/llm4zio/modernize/SurveyFlow.scala
@@ -1,0 +1,193 @@
+package llm4zio.modernize
+
+object SurveyFlow:
+
+  /** Legacy-modernization phase 0 of 5: survey the estate — inventory, dependency graph, triage,
+    * and a human-approved wave plan with a cost projection.
+    *
+    *   modernize-survey.sc → (human approves waves) → modernize-extract.sc → … → modernize-review.sc
+    *
+    * Runs ROOTED AT THE LEGACY REPO (`--repo <legacy>`). Banks stall before extraction because
+    * nobody can answer "what do we have, what depends on what, in what order do we migrate" —
+    * this phase answers all three, deterministic-first:
+    *
+    *   1. GRAPH (deterministic, `flow.Survey` — no LLM): one node per file matching the pack's
+    *      `sources:` regex (size = lines + coverage units), one edge per `## Survey:` rule match
+    *      (CALL / COPY / EXEC PGM=…). Written as `docs/modernization/inventory.md` (auditable
+    *      Markdown) + `graph.json` (machine-readable), committed.
+    *   2. TRIAGE (LLM, bounded to the graph): `reasoning` classifies each unit
+    *      rewrite | retire | wrap (wrap = keep and front with an API — classified here,
+    *      implementing wraps is out of scope), resolves what the regexes could not (dynamic CALL
+    *      variables), and proposes dependency-coherent WAVES.
+    *   3. WAVE PLAN (human-gated): `docs/modernization/wave-plan.md` carries the waves, the
+    *      per-unit dispositions, and — when `bench-results.jsonl` exists next to the scripts — a
+    *      per-wave cost/duration projection from real measured runs (`bench-report --project`).
+    *      The plan gets an UNCHECKED approval marker: a person reviews, flips it, and only then
+    *      does extraction start. Scope extraction to one wave with LLM4ZIO_WAVE=<name>.
+    *
+    * Run:  scala-cli run modernize-survey.sc -- --repo ~/estates/meridian-legacy
+    */
+
+  import java.nio.charset.StandardCharsets
+  import java.nio.file.{ Files, Path }
+
+  import zio.json.*
+  import zio.{ IO, ZIO }
+
+  import llm4zio.core.SchemaDerivation
+  import llm4zio.flow.*
+  import llm4zio.runner.*
+
+  val ProModel: String = "gemini-2.5-pro" // point these at whatever your `gemini` CLI offers
+  val ModDir: String   = "docs/modernization"
+
+  val (coderCfg, reasoningCfg) =
+    Env.get("LLM4ZIO_CODER").map(_.trim.toLowerCase).filter(_.nonEmpty) match
+      case None | Some("gemini") => (gemini, gemini.withModel(ProModel).copy(readOnly = true))
+      case Some(_)               =>
+        val agent = Connectors.coderFromEnv()
+        (agent, agent.copy(readOnly = true))
+
+  /** One unit's disposition: rewrite (full modernization), retire (dead — decommission), or wrap
+    * (keep on the mainframe, front with an API; implementing the wrap is out of scope here).
+    */
+  case class NodeTriage(name: String, disposition: String, rationale: String) derives JsonCodec
+
+  case class WaveSlice(name: String, programs: List[String], rationale: String) derives JsonCodec
+
+  case class SurveyOutcome(triage: List[NodeTriage], waves: List[WaveSlice], notes: List[String]) derives JsonCodec
+
+  def writeFile(path: Path, content: String): IO[FlowError, Unit] =
+    ZIO
+      .attemptBlocking {
+        Option(path.getParent).foreach(Files.createDirectories(_))
+        Files.write(path, content.getBytes(StandardCharsets.UTF_8))
+        ()
+      }
+      .mapError(e => FlowError.Persistence(s"failed to write $path", Some(e)))
+
+  def triagePrompt(graph: SurveyGraph, inventory: String): String =
+    s"""You are triaging a legacy estate for modernization. Below are its deterministic
+       |inventory and dependency graph (regex-derived from the source — trust them).
+       |
+       |Produce:
+       |- "triage": for EVERY unit in the inventory, a disposition:
+       |  - "rewrite": actively used business logic to modernize;
+       |  - "retire": unreferenced/dead — candidate for decommissioning, with the evidence;
+       |  - "wrap": keep on the legacy platform and front with an API (shared utilities other
+       |    estates still call, or units out of this program's scope).
+       |  Rationale in one sentence, grounded in the graph (degrees, callers, size).
+       |- "waves": dependency-coherent migration slices for the REWRITE units: a wave's programs
+       |  should depend only on already-migrated or same-wave units where possible; leaves and
+       |  low-fan-in units first; name each wave (wave-1, wave-2, …) and give the ordering
+       |  rationale.
+       |- "notes": anything the graph could not resolve — dynamic CALL variables, cycles worth a
+       |  human look. Empty if none.
+       |
+       |Inventory:
+       |$inventory
+       |
+       |Graph (JSON):
+       |${graph.toJson}""".stripMargin
+
+  def renderWavePlan(outcome: SurveyOutcome, graph: SurveyGraph, projection: Option[String]): String =
+    val triageRows = outcome.triage
+      .sortBy(_.name)
+      .map(t => s"| ${t.name} | ${t.disposition} | ${t.rationale} |")
+    val waveSecs   = outcome.waves.map { w =>
+      (s"## Wave: ${w.name}" ::
+        "" ::
+        s"${w.rationale}" ::
+        "" ::
+        w.programs.map(p => s"- $p")).mkString("\n") + "\n"
+    }
+    val notes      =
+      if outcome.notes.isEmpty then Nil
+      else "## Needs a human look" :: "" :: outcome.notes.map(n => s"- $n") ::: List("")
+    (List(
+      "# Modernization wave plan",
+      "",
+      s"${graph.nodes.size} unit(s) surveyed, ${outcome.waves.size} wave(s) proposed.",
+      "Scope extraction to one wave with `LLM4ZIO_WAVE=<name>` once this plan is approved.",
+      "",
+      "| Unit | Disposition | Rationale |",
+      "| ---- | ----------- | --------- |",
+    ) ++ triageRows ++ List("") ++ waveSecs ++ notes ++ projection.toList).mkString("\n") + "\n"
+
+  def run(args: Array[String]): Unit =
+    flow(
+      args,
+      coder = coderCfg,
+      reasoning = Some(reasoningCfg),
+      defaultPrompt = Some("Survey the legacy estate and propose a migration wave plan"),
+    ):
+      val packDir = workspace.resolve(Env.getOrElse("LLM4ZIO_PACK", "packs/cobol-springboot"))
+      val modDir  = workDir.resolve(ModDir)
+      val events  = summon[FlowEvents]
+
+      for
+        pack      <- stage("Pack")(Pack.load(packDir))
+        _         <- ZIO.when(pack.survey.isEmpty)(
+                       ZIO.fail(FlowError.Aborted(
+                         s"pack '${pack.name}' has no '## Survey:' sections — add the dependency-edge regexes " +
+                           "(CALL/COPY/EXEC PGM…) the graph should be built from"
+                       ))
+                     )
+        graph     <- stage("Graph") {
+                       for
+                         g <- Survey.graph(
+                                workDir,
+                                sources = pack.sources.getOrElse(""".*"""),
+                                units = pack.coverage,
+                                edges = pack.survey,
+                              )
+                         _ <- writeFile(modDir.resolve("inventory.md"), Survey.renderInventory(g))
+                         _ <- writeFile(modDir.resolve("graph.json"), g.toJsonPretty)
+                         _ <- events.publish(FlowEvent.Info(s"${g.nodes.size} unit(s), ${g.edges.size} edge(s)"))
+                       yield g
+                     }
+        outcome   <- stage("Triage") {
+                       reasoning
+                         .executeStructured[SurveyOutcome](
+                           triagePrompt(graph, Survey.renderInventory(graph)),
+                           SchemaDerivation.derive[SurveyOutcome],
+                         )
+                         .mapError(e => FlowError.Llm(e.message, Some(e)))
+                     }
+        projection <- stage("Projection") {
+                        val bench = workspace.resolve("bench-results.jsonl")
+                        ZIO
+                          .attemptBlocking(Files.exists(bench))
+                          .orDie
+                          .flatMap {
+                            case false =>
+                              events
+                                .publish(FlowEvent.Info(
+                                  "no bench-results.jsonl next to the scripts — wave plan ships without cost projection " +
+                                    "(run modernize-bench.sc to measure, then rerun the survey)"
+                                ))
+                                .as(None)
+                            case true  =>
+                              BenchReport.load(List(bench)).map { records =>
+                                val first = outcome.waves.headOption.map(_.programs.size).getOrElse(0)
+                                Some(
+                                  s"## Cost projection (wave-1, $first program(s), from measured runs)\n\n" +
+                                    BenchReport.render(records, projectPrograms = Some(first)) +
+                                    "\n\nOther waves: `scala-cli run bench-report.sc -- bench-results.jsonl --project <n>`.\n"
+                                )
+                              }
+                          }
+                      }
+        planMd     = renderWavePlan(outcome, graph, projection)
+        _         <- stage("Wave plan")(
+                       writeFile(modDir.resolve("wave-plan.md"), ApprovalGate.withDraftMarker(planMd))
+                     )
+        _         <- stage("Commit")(
+                       git.commitAll(s"modernize(${pack.name}): survey — ${graph.nodes.size} unit(s), " +
+                         s"${outcome.waves.size} wave(s) proposed").unit
+                     )
+        _         <- events.publish(FlowEvent.Info(
+                       s"review $ModDir/wave-plan.md, flip '- [x] Approved', then run modernize-extract.sc " +
+                         "(LLM4ZIO_WAVE=<name> scopes it to one wave)"
+                     ))
+      yield s"units=${graph.nodes.size} waves=${outcome.waves.size}"

--- a/modules/llm4zio-modernize/src/main/scala/llm4zio/modernize/SurveyFlow.scala
+++ b/modules/llm4zio-modernize/src/main/scala/llm4zio/modernize/SurveyFlow.scala
@@ -2,30 +2,27 @@ package llm4zio.modernize
 
 object SurveyFlow:
 
-  /** Legacy-modernization phase 0 of 5: survey the estate — inventory, dependency graph, triage,
-    * and a human-approved wave plan with a cost projection.
+  /** Legacy-modernization phase 0 of 5: survey the estate — inventory, dependency graph, triage, and a human-approved
+    * wave plan with a cost projection.
     *
-    *   modernize-survey.sc → (human approves waves) → modernize-extract.sc → … → modernize-review.sc
+    * modernize-survey.sc → (human approves waves) → modernize-extract.sc → … → modernize-review.sc
     *
-    * Runs ROOTED AT THE LEGACY REPO (`--repo <legacy>`). Banks stall before extraction because
-    * nobody can answer "what do we have, what depends on what, in what order do we migrate" —
-    * this phase answers all three, deterministic-first:
+    * Runs ROOTED AT THE LEGACY REPO (`--repo <legacy>`). Banks stall before extraction because nobody can answer "what
+    * do we have, what depends on what, in what order do we migrate" — this phase answers all three,
+    * deterministic-first:
     *
-    *   1. GRAPH (deterministic, `flow.Survey` — no LLM): one node per file matching the pack's
-    *      `sources:` regex (size = lines + coverage units), one edge per `## Survey:` rule match
-    *      (CALL / COPY / EXEC PGM=…). Written as `docs/modernization/inventory.md` (auditable
-    *      Markdown) + `graph.json` (machine-readable), committed.
-    *   2. TRIAGE (LLM, bounded to the graph): `reasoning` classifies each unit
-    *      rewrite | retire | wrap (wrap = keep and front with an API — classified here,
-    *      implementing wraps is out of scope), resolves what the regexes could not (dynamic CALL
-    *      variables), and proposes dependency-coherent WAVES.
-    *   3. WAVE PLAN (human-gated): `docs/modernization/wave-plan.md` carries the waves, the
-    *      per-unit dispositions, and — when `bench-results.jsonl` exists next to the scripts — a
-    *      per-wave cost/duration projection from real measured runs (`bench-report --project`).
-    *      The plan gets an UNCHECKED approval marker: a person reviews, flips it, and only then
-    *      does extraction start. Scope extraction to one wave with LLM4ZIO_WAVE=<name>.
+    *   1. GRAPH (deterministic, `flow.Survey` — no LLM): one node per file matching the pack's `sources:` regex (size =
+    *      lines + coverage units), one edge per `## Survey:` rule match (CALL / COPY / EXEC PGM=…). Written as
+    *      `docs/modernization/inventory.md` (auditable Markdown) + `graph.json` (machine-readable), committed.
+    *   2. TRIAGE (LLM, bounded to the graph): `reasoning` classifies each unit rewrite | retire | wrap (wrap = keep and
+    *      front with an API — classified here, implementing wraps is out of scope), resolves what the regexes could not
+    *      (dynamic CALL variables), and proposes dependency-coherent WAVES.
+    *   3. WAVE PLAN (human-gated): `docs/modernization/wave-plan.md` carries the waves, the per-unit dispositions, and
+    *      — when `bench-results.jsonl` exists next to the scripts — a per-wave cost/duration projection from real
+    *      measured runs (`bench-report --project`). The plan gets an UNCHECKED approval marker: a person reviews, flips
+    *      it, and only then does extraction start. Scope extraction to one wave with LLM4ZIO_WAVE=<name>.
     *
-    * Run:  scala-cli run modernize-survey.sc -- --repo ~/estates/meridian-legacy
+    * Run: scala-cli run modernize-survey.sc -- --repo ~/estates/meridian-legacy
     */
 
   import java.nio.charset.StandardCharsets
@@ -48,8 +45,8 @@ object SurveyFlow:
         val agent = Connectors.coderFromEnv()
         (agent, agent.copy(readOnly = true))
 
-  /** One unit's disposition: rewrite (full modernization), retire (dead — decommission), or wrap
-    * (keep on the mainframe, front with an API; implementing the wrap is out of scope here).
+  /** One unit's disposition: rewrite (full modernization), retire (dead — decommission), or wrap (keep on the
+    * mainframe, front with an API; implementing the wrap is out of scope here).
     */
   case class NodeTriage(name: String, disposition: String, rationale: String) derives JsonCodec
 
@@ -126,34 +123,34 @@ object SurveyFlow:
       val events  = summon[FlowEvents]
 
       for
-        pack      <- stage("Pack")(Pack.load(packDir))
-        _         <- ZIO.when(pack.survey.isEmpty)(
-                       ZIO.fail(FlowError.Aborted(
-                         s"pack '${pack.name}' has no '## Survey:' sections — add the dependency-edge regexes " +
-                           "(CALL/COPY/EXEC PGM…) the graph should be built from"
-                       ))
-                     )
-        graph     <- stage("Graph") {
-                       for
-                         g <- Survey.graph(
-                                workDir,
-                                sources = pack.sources.getOrElse(""".*"""),
-                                units = pack.coverage,
-                                edges = pack.survey,
-                              )
-                         _ <- writeFile(modDir.resolve("inventory.md"), Survey.renderInventory(g))
-                         _ <- writeFile(modDir.resolve("graph.json"), g.toJsonPretty)
-                         _ <- events.publish(FlowEvent.Info(s"${g.nodes.size} unit(s), ${g.edges.size} edge(s)"))
-                       yield g
-                     }
-        outcome   <- stage("Triage") {
-                       reasoning
-                         .executeStructured[SurveyOutcome](
-                           triagePrompt(graph, Survey.renderInventory(graph)),
-                           SchemaDerivation.derive[SurveyOutcome],
-                         )
-                         .mapError(e => FlowError.Llm(e.message, Some(e)))
-                     }
+        pack       <- stage("Pack")(Pack.load(packDir))
+        _          <- ZIO.when(pack.survey.isEmpty)(
+                        ZIO.fail(FlowError.Aborted(
+                          s"pack '${pack.name}' has no '## Survey:' sections — add the dependency-edge regexes " +
+                            "(CALL/COPY/EXEC PGM…) the graph should be built from"
+                        ))
+                      )
+        graph      <- stage("Graph") {
+                        for
+                          g <- Survey.graph(
+                                 workDir,
+                                 sources = pack.sources.getOrElse(""".*"""),
+                                 units = pack.coverage,
+                                 edges = pack.survey,
+                               )
+                          _ <- writeFile(modDir.resolve("inventory.md"), Survey.renderInventory(g))
+                          _ <- writeFile(modDir.resolve("graph.json"), g.toJsonPretty)
+                          _ <- events.publish(FlowEvent.Info(s"${g.nodes.size} unit(s), ${g.edges.size} edge(s)"))
+                        yield g
+                      }
+        outcome    <- stage("Triage") {
+                        reasoning
+                          .executeStructured[SurveyOutcome](
+                            triagePrompt(graph, Survey.renderInventory(graph)),
+                            SchemaDerivation.derive[SurveyOutcome],
+                          )
+                          .mapError(e => FlowError.Llm(e.message, Some(e)))
+                      }
         projection <- stage("Projection") {
                         val bench = workspace.resolve("bench-results.jsonl")
                         ZIO
@@ -178,16 +175,16 @@ object SurveyFlow:
                               }
                           }
                       }
-        planMd     = renderWavePlan(outcome, graph, projection)
-        _         <- stage("Wave plan")(
-                       writeFile(modDir.resolve("wave-plan.md"), ApprovalGate.withDraftMarker(planMd))
-                     )
-        _         <- stage("Commit")(
-                       git.commitAll(s"modernize(${pack.name}): survey — ${graph.nodes.size} unit(s), " +
-                         s"${outcome.waves.size} wave(s) proposed").unit
-                     )
-        _         <- events.publish(FlowEvent.Info(
-                       s"review $ModDir/wave-plan.md, flip '- [x] Approved', then run modernize-extract.sc " +
-                         "(LLM4ZIO_WAVE=<name> scopes it to one wave)"
-                     ))
+        planMd      = renderWavePlan(outcome, graph, projection)
+        _          <- stage("Wave plan")(
+                        writeFile(modDir.resolve("wave-plan.md"), ApprovalGate.withDraftMarker(planMd))
+                      )
+        _          <- stage("Commit")(
+                        git.commitAll(s"modernize(${pack.name}): survey — ${graph.nodes.size} unit(s), " +
+                          s"${outcome.waves.size} wave(s) proposed").unit
+                      )
+        _          <- events.publish(FlowEvent.Info(
+                        s"review $ModDir/wave-plan.md, flip '- [x] Approved', then run modernize-extract.sc " +
+                          "(LLM4ZIO_WAVE=<name> scopes it to one wave)"
+                      ))
       yield s"units=${graph.nodes.size} waves=${outcome.waves.size}"

--- a/modules/llm4zio-modernize/src/main/scala/llm4zio/modernize/VerifyFlow.scala
+++ b/modules/llm4zio-modernize/src/main/scala/llm4zio/modernize/VerifyFlow.scala
@@ -2,37 +2,36 @@ package llm4zio.modernize
 
 object VerifyFlow:
 
-  /** Legacy-modernization phase 4 of 5: prove the implementation equivalent to its specs — per rule,
-    * with a deterministic diff, and an auditor-facing report.
+  /** Legacy-modernization phase 4 of 5: prove the implementation equivalent to its specs — per rule, with a
+    * deterministic diff, and an auditor-facing report.
     *
-    *   modernize-extract.sc → (human approves) → modernize-seed.sc → modernize-implement.sc
-    *     → modernize-verify.sc → modernize-review.sc
+    * modernize-extract.sc → (human approves) → modernize-seed.sc → modernize-implement.sc → modernize-verify.sc →
+    * modernize-review.sc
     *
-    * Runs ROOTED AT THE TARGET REPO (`--repo <target>`) on the implementation branch, behind the
-    * clean-room wall (no legacy source may be present — verification is against specs and vectors,
-    * never against the original code):
+    * Runs ROOTED AT THE TARGET REPO (`--repo <target>`) on the implementation branch, behind the clean-room wall (no
+    * legacy source may be present — verification is against specs and vectors, never against the original code):
     *
-    *   1. VECTORS, generated-first: for each spec'd program with no vector file yet, `reasoning`
-    *      generates equivalence vectors from the spec + BDD scenarios (boundary values included) into
-    *      `docs/modernization/vectors/<PROGRAM>.jsonl` — resumable per program like extraction; delete
-    *      a file to regenerate it. Captured-tier vectors (recorded legacy runs, `"tier":"captured"`)
-    *      can be dropped into the same directory by the bank's own capture tooling — same JSONL format.
-    *   2. REPLAY, transport-blind: every vector is piped (JSON on stdin) into the pack's `replay:`
-    *      command, which drives the target implementation and prints the resulting observations as a
-    *      JSON array (the `Equiv.Observation` encoding: `{"type":"record",...}` / `{"type":"db",...}`).
-    *   3. DIFF, deterministic: `Equiv.diff` compares expected vs actual observations under the pack's
-    *      `## Equivalence` policy (ordering, ignored fields). No LLM decides equivalence.
-    *   4. REPORT, per rule: `docs/modernization/equivalence.md` — every rule from the spec pack's
-    *      rules.txt with generated/captured columns kept separate (never summed) and unexercised
-    *      rules listed loudly. The report's hash is appended to provenance.json.
-    *   5. TRIAGE, bounded: mismatches are distilled by `reasoning` into fix specs under
-    *      `docs/specs/fixes/` + appended plan tasks — rerun modernize-implement.sc to pick them up.
-    *      The flow then HALTS non-green so a pipeline can gate on it.
+    *   1. VECTORS, generated-first: for each spec'd program with no vector file yet, `reasoning` generates equivalence
+    *      vectors from the spec + BDD scenarios (boundary values included) into
+    *      `docs/modernization/vectors/<PROGRAM>.jsonl` — resumable per program like extraction; delete a file to
+    *      regenerate it. Captured-tier vectors (recorded legacy runs, `"tier":"captured"`) can be dropped into the same
+    *      directory by the bank's own capture tooling — same JSONL format.
+    *   2. REPLAY, transport-blind: every vector is piped (JSON on stdin) into the pack's `replay:` command, which
+    *      drives the target implementation and prints the resulting observations as a JSON array (the
+    *      `Equiv.Observation` encoding: `{"type":"record",...}` / `{"type":"db",...}`).
+    *   3. DIFF, deterministic: `Equiv.diff` compares expected vs actual observations under the pack's `## Equivalence`
+    *      policy (ordering, ignored fields). No LLM decides equivalence.
+    *   4. REPORT, per rule: `docs/modernization/equivalence.md` — every rule from the spec pack's rules.txt with
+    *      generated/captured columns kept separate (never summed) and unexercised rules listed loudly. The report's
+    *      hash is appended to provenance.json.
+    *   5. TRIAGE, bounded: mismatches are distilled by `reasoning` into fix specs under `docs/specs/fixes/` + appended
+    *      plan tasks — rerun modernize-implement.sc to pick them up. The flow then HALTS non-green so a pipeline can
+    *      gate on it.
     *
-    * Generated vectors prove SPEC CONFORMANCE; captured vectors prove BEHAVIOURAL EQUIVALENCE.
-    * The report keeps the two claims separate — do not let anyone sum them.
+    * Generated vectors prove SPEC CONFORMANCE; captured vectors prove BEHAVIOURAL EQUIVALENCE. The report keeps the two
+    * claims separate — do not let anyone sum them.
     *
-    * Run:  scala-cli run modernize-verify.sc -- --repo ~/services/meridian-transfers
+    * Run: scala-cli run modernize-verify.sc -- --repo ~/services/meridian-transfers
     */
 
   import java.nio.charset.StandardCharsets
@@ -58,12 +57,17 @@ object VerifyFlow:
         val agent = Connectors.coderFromEnv()
         (agent, agent.copy(readOnly = true))
 
-  /** The model-facing vector shape: flat maps only, so structured output stays schema-simple. `kind` is
-    * "record" (an emitted record: `channel` names it, `fields` carries it) or "db" (a mutation: `channel`
-    * is the table, `op` insert/update/delete, `key` addresses the row, `fields` is what's written).
+  /** The model-facing vector shape: flat maps only, so structured output stays schema-simple. `kind` is "record" (an
+    * emitted record: `channel` names it, `fields` carries it) or "db" (a mutation: `channel` is the table, `op`
+    * insert/update/delete, `key` addresses the row, `fields` is what's written).
     */
-  case class GenObservation(kind: String, channel: String, op: String, key: Map[String, String], fields: Map[String, String])
-    derives JsonCodec
+  case class GenObservation(
+    kind: String,
+    channel: String,
+    op: String,
+    key: Map[String, String],
+    fields: Map[String, String],
+  ) derives JsonCodec
   case class GenVector(id: String, rules: List[String], inputs: Map[String, String], observations: List[GenObservation])
     derives JsonCodec
   case class GenVectors(vectors: List[GenVector]) derives JsonCodec
@@ -146,8 +150,8 @@ object VerifyFlow:
     title.toLowerCase.replaceAll("[^a-z0-9]+", "-").stripPrefix("-").stripSuffix("-").take(60)
 
   def generatePrompt(pack: Pack, program: String, spec: String, feature: String, rules: List[String]): String =
-    val packBrief  = pack.prompt("vectors").getOrElse("")
-    val ruleSlice  = rules.mkString("\n")
+    val packBrief = pack.prompt("vectors").getOrElse("")
+    val ruleSlice = rules.mkString("\n")
     s"""$packBrief
        |
        |Generate equivalence test vectors for the program $program from its behavioural spec and BDD
@@ -239,136 +243,142 @@ object VerifyFlow:
       val events     = summon[FlowEvents]
 
       for
-        pack     <- stage("Pack")(Pack.load(packDir))
-        _        <- stage("Wall")(assertWall(pack, workDir, events))
-        specsDir  = workDir.resolve(pack.specsDir)
-        rulesTxt <- readFileOr(specsDir.resolve("rules.txt"), "")
-        universe  = rulesTxt.linesIterator.map(_.strip).filter(_.nonEmpty).toList
-        _        <- ZIO.when(universe.isEmpty)(
-                      events.publish(FlowEvent.Info(
-                        "no rules.txt in the spec pack (extracted before 3.23.0?) — the report will use the " +
-                          "vectors' own rules and cannot flag unexercised ones"
-                      ))
-                    )
-        programs <- stage("Programs")(specPrograms(specsDir))
-        _        <- ZIO.when(programs.isEmpty)(
-                      ZIO.fail(FlowError.Aborted(s"no specs under $specsDir — run modernize-seed.sc first"))
-                    )
-        _        <- stage("Vectors") { // generated-first, resumable per program: delete a file to regenerate
-                      ZIO.foreachDiscard(programs) { program =>
-                        val file = vectorsDir.resolve(s"$program.jsonl")
-                        ZIO
-                          .attemptBlocking(Files.exists(file))
-                          .orDie
-                          .flatMap {
-                            case true  => events.publish(FlowEvent.Info(s"vectors exist for $program — skipping"))
-                            case false =>
-                              for
-                                spec    <- readFileOr(specsDir.resolve(s"$program.md"), "")
-                                feature <- featureFor(workDir.resolve(pack.featuresDir), program)
-                                gen     <- reasoning
-                                             .executeStructured[GenVectors](
-                                               generatePrompt(pack, program, spec, feature, universe),
-                                               SchemaDerivation.derive[GenVectors],
-                                             )
-                                             .mapError(e => FlowError.Llm(e.message, Some(e)))
-                                vectors <- ZIO.foreach(gen.vectors) { g =>
-                                             ZIO.fromEither(toVector(program, g)).mapError(FlowError.PlanParse(_))
-                                           }
-                                _       <- ZIO.when(vectors.isEmpty)(
-                                             ZIO.fail(FlowError.Aborted(s"generator produced no vectors for $program"))
-                                           )
-                                _       <- VectorStore.write(file, vectors)
-                                _       <- events.publish(FlowEvent.Info(s"${vectors.size} vector(s) generated for $program"))
-                              yield ()
-                          }
-                      }
-                    }
+        pack      <- stage("Pack")(Pack.load(packDir))
+        _         <- stage("Wall")(assertWall(pack, workDir, events))
+        specsDir   = workDir.resolve(pack.specsDir)
+        rulesTxt  <- readFileOr(specsDir.resolve("rules.txt"), "")
+        universe   = rulesTxt.linesIterator.map(_.strip).filter(_.nonEmpty).toList
+        _         <- ZIO.when(universe.isEmpty)(
+                       events.publish(FlowEvent.Info(
+                         "no rules.txt in the spec pack (extracted before 3.23.0?) — the report will use the " +
+                           "vectors' own rules and cannot flag unexercised ones"
+                       ))
+                     )
+        programs  <- stage("Programs")(specPrograms(specsDir))
+        _         <- ZIO.when(programs.isEmpty)(
+                       ZIO.fail(FlowError.Aborted(s"no specs under $specsDir — run modernize-seed.sc first"))
+                     )
+        _         <- stage("Vectors") { // generated-first, resumable per program: delete a file to regenerate
+                       ZIO.foreachDiscard(programs) { program =>
+                         val file = vectorsDir.resolve(s"$program.jsonl")
+                         ZIO
+                           .attemptBlocking(Files.exists(file))
+                           .orDie
+                           .flatMap {
+                             case true  => events.publish(FlowEvent.Info(s"vectors exist for $program — skipping"))
+                             case false =>
+                               for
+                                 spec    <- readFileOr(specsDir.resolve(s"$program.md"), "")
+                                 feature <- featureFor(workDir.resolve(pack.featuresDir), program)
+                                 gen     <- reasoning
+                                              .executeStructured[GenVectors](
+                                                generatePrompt(pack, program, spec, feature, universe),
+                                                SchemaDerivation.derive[GenVectors],
+                                              )
+                                              .mapError(e => FlowError.Llm(e.message, Some(e)))
+                                 vectors <- ZIO.foreach(gen.vectors) { g =>
+                                              ZIO.fromEither(toVector(program, g)).mapError(FlowError.PlanParse(_))
+                                            }
+                                 _       <- ZIO.when(vectors.isEmpty)(
+                                              ZIO.fail(FlowError.Aborted(s"generator produced no vectors for $program"))
+                                            )
+                                 _       <- VectorStore.write(file, vectors)
+                                 _       <- events.publish(FlowEvent.Info(s"${vectors.size} vector(s) generated for $program"))
+                               yield ()
+                           }
+                       }
+                     }
         replayCmd <- ZIO
                        .fromOption(pack.replay)
                        .orElseFail(FlowError.Aborted(
                          s"pack '${pack.name}' has no replay: command — add one (reads a vector JSON on stdin, " +
                            "prints the resulting observations as a JSON array on stdout)"
                        ))
-        verdicts <- stage("Replay") {
-                      for
-                        files   <- SpecChecks.matchingFiles(vectorsDir, """.*\.jsonl""").orElseSucceed(Nil)
-                        vectors <- ZIO.foreach(files.sorted)(f => VectorStore.read(vectorsDir.resolve(f))).map(_.flatten)
-                        _       <- ZIO.when(vectors.isEmpty)(
-                                     ZIO.fail(FlowError.Aborted(s"no vectors under $vectorsDir — nothing to replay"))
-                                   )
-                        result  <- ZIO.foreach(vectors) { v =>
-                                     Equiv.replayVector(replayCmd, workDir, v).flatMap {
-                                       case Equiv.Replayed.Crashed(code, problem) =>
-                                         events
-                                           .publish(FlowEvent.Info(
-                                             s"replay failed for ${v.program}/${v.id} (exit $code): ${problem.take(300)}"
-                                           ))
-                                           .as(VectorVerdict(v, v.observations.map(Equiv.Mismatch.Missing(_))))
-                                       case Equiv.Replayed.Observed(actual)       =>
-                                         ZIO.succeed(VectorVerdict(v, Equiv.diff(v.observations, actual, pack.equivalence)))
-                                     }
-                                   }
-                      yield result
-                    }
-        allRules  = if universe.nonEmpty then universe else verdicts.flatMap(_.vector.rules).distinct.sorted
-        failing   = verdicts.filterNot(_.passed)
-        _        <- stage("Report") {
-                      writeFile(workDir.resolve(ModDir).resolve("equivalence.md"), EquivReport.render(verdicts, allRules))
-                    }
-        _        <- ZIO.when(failing.nonEmpty)(stage("Triage") {
-                      for
-                        specText <- readFileOr(specsDir.resolve("traceability.md"), "")
-                        specs    <- ZIO.foreach(programs)(p => readFileOr(specsDir.resolve(s"$p.md"), ""))
-                        outcome  <- reasoning
-                                      .executeStructured[VerifyOutcome](
-                                        triagePrompt(pack, failing, (specText :: specs).mkString("\n\n")),
-                                        SchemaDerivation.derive[VerifyOutcome],
-                                      )
-                                      .mapError(e => FlowError.Llm(e.message, Some(e)))
-                        _        <- ZIO.foreachDiscard(outcome.fixes) { f =>
-                                      writeFile(specsDir.resolve("fixes").resolve(s"fix-${slug(f.title)}.md"),
-                                        s"# ${f.title}\n\n${f.spec}\n")
-                                    }
-                        _        <- ZIO.when(outcome.fixes.nonEmpty) {
-                                      PlanStore
-                                        .load(planFile)
-                                        .someOrFail(FlowError.Aborted(s"no plan at $planFile — run modernize-seed.sc first"))
-                                        .flatMap { plan =>
-                                          val increment = outcome.fixes.map(f => Task(f.taskTitle, f.taskDescription))
-                                          PlanStore.save(planFile, plan.copy(tasks = plan.tasks ++ increment)) *>
-                                            events.publish(FlowEvent.Info(
-                                              s"${increment.size} fix task(s) appended — rerun modernize-implement.sc"
+        verdicts  <- stage("Replay") {
+                       for
+                         files   <- SpecChecks.matchingFiles(vectorsDir, """.*\.jsonl""").orElseSucceed(Nil)
+                         vectors <-
+                           ZIO.foreach(files.sorted)(f => VectorStore.read(vectorsDir.resolve(f))).map(_.flatten)
+                         _       <- ZIO.when(vectors.isEmpty)(
+                                      ZIO.fail(FlowError.Aborted(s"no vectors under $vectorsDir — nothing to replay"))
+                                    )
+                         result  <- ZIO.foreach(vectors) { v =>
+                                      Equiv.replayVector(replayCmd, workDir, v).flatMap {
+                                        case Equiv.Replayed.Crashed(code, problem) =>
+                                          events
+                                            .publish(FlowEvent.Info(
+                                              s"replay failed for ${v.program}/${v.id} (exit $code): ${problem.take(300)}"
                                             ))
-                                        }
+                                            .as(VectorVerdict(v, v.observations.map(Equiv.Mismatch.Missing(_))))
+                                        case Equiv.Replayed.Observed(actual)       =>
+                                          ZIO.succeed(VectorVerdict(
+                                            v,
+                                            Equiv.diff(v.observations, actual, pack.equivalence),
+                                          ))
+                                      }
                                     }
-                      yield ()
-                    })
-        _        <- stage("Provenance") {
-                      val manifest = workDir.resolve(ModDir).resolve("provenance.json")
-                      ZIO
-                        .attemptBlocking(Files.exists(manifest))
-                        .orDie
-                        .flatMap {
-                          case false => events.publish(FlowEvent.Info("no provenance.json — seeded before 3.23.0; skipping"))
-                          case true  =>
-                            Provenance
-                              .hashFiles(workDir, List(s"$ModDir/equivalence.md"))
-                              .flatMap(h => Provenance.extend(manifest)(_.copy(equivalenceReport = h.values.headOption)))
-                              .unit
-                        }
-                    }
-        gCount    = verdicts.count(_.vector.tier == Equiv.Tier.Generated)
-        cCount    = verdicts.count(_.vector.tier == Equiv.Tier.Captured)
-        summary   = s"${verdicts.count(_.passed)}/${verdicts.size} vectors green ($gCount generated, $cCount captured)"
-        _        <- stage("Commit")(
-                      git.commitAll(s"modernize(${pack.name}): verify — $summary" +
-                        (if failing.nonEmpty then s"; ${failing.size} failing triaged" else "")).unit
-                    )
-        _        <- ZIO.when(failing.nonEmpty)(
-                      ZIO.fail(FlowError.Aborted(
-                        s"equivalence not proven: ${failing.size} failing vector(s) — see $ModDir/equivalence.md; " +
-                          "fix specs filed, rerun modernize-implement.sc"
-                      ))
-                    )
+                       yield result
+                     }
+        allRules   = if universe.nonEmpty then universe else verdicts.flatMap(_.vector.rules).distinct.sorted
+        failing    = verdicts.filterNot(_.passed)
+        _         <- stage("Report") {
+                       writeFile(workDir.resolve(ModDir).resolve("equivalence.md"), EquivReport.render(verdicts, allRules))
+                     }
+        _         <- ZIO.when(failing.nonEmpty)(stage("Triage") {
+                       for
+                         specText <- readFileOr(specsDir.resolve("traceability.md"), "")
+                         specs    <- ZIO.foreach(programs)(p => readFileOr(specsDir.resolve(s"$p.md"), ""))
+                         outcome  <- reasoning
+                                       .executeStructured[VerifyOutcome](
+                                         triagePrompt(pack, failing, (specText :: specs).mkString("\n\n")),
+                                         SchemaDerivation.derive[VerifyOutcome],
+                                       )
+                                       .mapError(e => FlowError.Llm(e.message, Some(e)))
+                         _        <- ZIO.foreachDiscard(outcome.fixes) { f =>
+                                       writeFile(
+                                         specsDir.resolve("fixes").resolve(s"fix-${slug(f.title)}.md"),
+                                         s"# ${f.title}\n\n${f.spec}\n",
+                                       )
+                                     }
+                         _        <- ZIO.when(outcome.fixes.nonEmpty) {
+                                       PlanStore
+                                         .load(planFile)
+                                         .someOrFail(FlowError.Aborted(s"no plan at $planFile — run modernize-seed.sc first"))
+                                         .flatMap { plan =>
+                                           val increment = outcome.fixes.map(f => Task(f.taskTitle, f.taskDescription))
+                                           PlanStore.save(planFile, plan.copy(tasks = plan.tasks ++ increment)) *>
+                                             events.publish(FlowEvent.Info(
+                                               s"${increment.size} fix task(s) appended — rerun modernize-implement.sc"
+                                             ))
+                                         }
+                                     }
+                       yield ()
+                     })
+        _         <- stage("Provenance") {
+                       val manifest = workDir.resolve(ModDir).resolve("provenance.json")
+                       ZIO
+                         .attemptBlocking(Files.exists(manifest))
+                         .orDie
+                         .flatMap {
+                           case false => events.publish(FlowEvent.Info("no provenance.json — seeded before 3.23.0; skipping"))
+                           case true  =>
+                             Provenance
+                               .hashFiles(workDir, List(s"$ModDir/equivalence.md"))
+                               .flatMap(h => Provenance.extend(manifest)(_.copy(equivalenceReport = h.values.headOption)))
+                               .unit
+                         }
+                     }
+        gCount     = verdicts.count(_.vector.tier == Equiv.Tier.Generated)
+        cCount     = verdicts.count(_.vector.tier == Equiv.Tier.Captured)
+        summary    = s"${verdicts.count(_.passed)}/${verdicts.size} vectors green ($gCount generated, $cCount captured)"
+        _         <- stage("Commit")(
+                       git.commitAll(s"modernize(${pack.name}): verify — $summary" +
+                         (if failing.nonEmpty then s"; ${failing.size} failing triaged" else "")).unit
+                     )
+        _         <- ZIO.when(failing.nonEmpty)(
+                       ZIO.fail(FlowError.Aborted(
+                         s"equivalence not proven: ${failing.size} failing vector(s) — see $ModDir/equivalence.md; " +
+                           "fix specs filed, rerun modernize-implement.sc"
+                       ))
+                     )
       yield summary

--- a/modules/llm4zio-modernize/src/main/scala/llm4zio/modernize/VerifyFlow.scala
+++ b/modules/llm4zio-modernize/src/main/scala/llm4zio/modernize/VerifyFlow.scala
@@ -1,0 +1,374 @@
+package llm4zio.modernize
+
+object VerifyFlow:
+
+  /** Legacy-modernization phase 4 of 5: prove the implementation equivalent to its specs — per rule,
+    * with a deterministic diff, and an auditor-facing report.
+    *
+    *   modernize-extract.sc → (human approves) → modernize-seed.sc → modernize-implement.sc
+    *     → modernize-verify.sc → modernize-review.sc
+    *
+    * Runs ROOTED AT THE TARGET REPO (`--repo <target>`) on the implementation branch, behind the
+    * clean-room wall (no legacy source may be present — verification is against specs and vectors,
+    * never against the original code):
+    *
+    *   1. VECTORS, generated-first: for each spec'd program with no vector file yet, `reasoning`
+    *      generates equivalence vectors from the spec + BDD scenarios (boundary values included) into
+    *      `docs/modernization/vectors/<PROGRAM>.jsonl` — resumable per program like extraction; delete
+    *      a file to regenerate it. Captured-tier vectors (recorded legacy runs, `"tier":"captured"`)
+    *      can be dropped into the same directory by the bank's own capture tooling — same JSONL format.
+    *   2. REPLAY, transport-blind: every vector is piped (JSON on stdin) into the pack's `replay:`
+    *      command, which drives the target implementation and prints the resulting observations as a
+    *      JSON array (the `Equiv.Observation` encoding: `{"type":"record",...}` / `{"type":"db",...}`).
+    *   3. DIFF, deterministic: `Equiv.diff` compares expected vs actual observations under the pack's
+    *      `## Equivalence` policy (ordering, ignored fields). No LLM decides equivalence.
+    *   4. REPORT, per rule: `docs/modernization/equivalence.md` — every rule from the spec pack's
+    *      rules.txt with generated/captured columns kept separate (never summed) and unexercised
+    *      rules listed loudly. The report's hash is appended to provenance.json.
+    *   5. TRIAGE, bounded: mismatches are distilled by `reasoning` into fix specs under
+    *      `docs/specs/fixes/` + appended plan tasks — rerun modernize-implement.sc to pick them up.
+    *      The flow then HALTS non-green so a pipeline can gate on it.
+    *
+    * Generated vectors prove SPEC CONFORMANCE; captured vectors prove BEHAVIOURAL EQUIVALENCE.
+    * The report keeps the two claims separate — do not let anyone sum them.
+    *
+    * Run:  scala-cli run modernize-verify.sc -- --repo ~/services/meridian-transfers
+    */
+
+  import java.nio.charset.StandardCharsets
+  import java.nio.file.{ Files, Path }
+
+  import scala.jdk.CollectionConverters.*
+
+  import zio.json.*
+  import zio.json.ast.Json
+  import zio.{ IO, ZIO }
+
+  import llm4zio.core.SchemaDerivation
+  import llm4zio.flow.*
+  import llm4zio.runner.*
+
+  val ProModel: String = "gemini-2.5-pro" // point these at whatever your `gemini` CLI offers
+  val ModDir: String   = "docs/modernization"
+
+  val (coderCfg, reasoningCfg) =
+    Env.get("LLM4ZIO_CODER").map(_.trim.toLowerCase).filter(_.nonEmpty) match
+      case None | Some("gemini") => (gemini, gemini.withModel(ProModel).copy(readOnly = true))
+      case Some(_)               =>
+        val agent = Connectors.coderFromEnv()
+        (agent, agent.copy(readOnly = true))
+
+  /** The model-facing vector shape: flat maps only, so structured output stays schema-simple. `kind` is
+    * "record" (an emitted record: `channel` names it, `fields` carries it) or "db" (a mutation: `channel`
+    * is the table, `op` insert/update/delete, `key` addresses the row, `fields` is what's written).
+    */
+  case class GenObservation(kind: String, channel: String, op: String, key: Map[String, String], fields: Map[String, String])
+    derives JsonCodec
+  case class GenVector(id: String, rules: List[String], inputs: Map[String, String], observations: List[GenObservation])
+    derives JsonCodec
+  case class GenVectors(vectors: List[GenVector]) derives JsonCodec
+
+  /** Verify's triage outcome: only fixes — improvements and lessons belong to modernize-review.sc. */
+  case class FixSpec(title: String, spec: String, taskTitle: String, taskDescription: String) derives JsonCodec
+  case class VerifyOutcome(fixes: List[FixSpec]) derives JsonCodec
+
+  /** The enforced clean-room wall: refuse to run with legacy source inside the target workspace. */
+  def assertWall(pack: Pack, root: Path, events: FlowEvents): IO[FlowError, Unit] =
+    pack.sources match
+      case None        => events.publish(FlowEvent.Info("pack has no sources regex — wall check skipped"))
+      case Some(regex) =>
+        Wall.check(root, regex).flatMap {
+          case Wall.Result.Clean           =>
+            events.publish(FlowEvent.Info("clean-room wall: no legacy source in the target workspace"))
+          case Wall.Result.Breached(paths) =>
+            val shown = paths.take(10).mkString(", ")
+            val more  = if paths.size > 10 then s" (+${paths.size - 10} more)" else ""
+            ZIO.fail(FlowError.Aborted(
+              s"clean-room wall breached — legacy source inside the target workspace: $shown$more. " +
+                "Equivalence is proven against specs and vectors, never against the original code."
+            ))
+        }
+
+  def writeFile(path: Path, content: String): IO[FlowError, Unit] =
+    ZIO
+      .attemptBlocking {
+        Option(path.getParent).foreach(Files.createDirectories(_))
+        Files.write(path, content.getBytes(StandardCharsets.UTF_8))
+        ()
+      }
+      .mapError(e => FlowError.Persistence(s"failed to write $path", Some(e)))
+
+  def readFileOr(path: Path, fallback: String): IO[FlowError, String] =
+    ZIO
+      .attemptBlocking(if Files.exists(path) then Files.readString(path) else fallback)
+      .mapError(e => FlowError.Persistence(s"failed to read $path", Some(e)))
+
+  /** The spec'd programs: top-level `<NAME>.md` files under the pack's specs dir, indexes aside. */
+  def specPrograms(specsDir: Path): IO[FlowError, List[String]] =
+    ZIO
+      .attemptBlocking {
+        if !Files.isDirectory(specsDir) then Nil
+        else
+          val stream = Files.list(specsDir)
+          try
+            stream
+              .iterator()
+              .asScala
+              .filter(p => Files.isRegularFile(p) && p.getFileName.toString.endsWith(".md"))
+              .map(_.getFileName.toString.stripSuffix(".md"))
+              .filterNot(Set("traceability", "mapping", "README"))
+              .toList
+              .sorted
+          finally stream.close()
+      }
+      .mapError(e => FlowError.Persistence(s"failed to list specs under $specsDir", Some(e)))
+
+  /** The program's .feature file under the pack's features dir, matched by case-insensitive stem. */
+  def featureFor(featuresDir: Path, program: String): IO[FlowError, String] =
+    ZIO
+      .attemptBlocking {
+        if !Files.isDirectory(featuresDir) then ""
+        else
+          val stream = Files.walk(featuresDir)
+          try
+            stream
+              .iterator()
+              .asScala
+              .filter(p => Files.isRegularFile(p) && p.getFileName.toString.endsWith(".feature"))
+              .find(_.getFileName.toString.stripSuffix(".feature").equalsIgnoreCase(program))
+              .map(Files.readString)
+              .getOrElse("")
+          finally stream.close()
+      }
+      .mapError(e => FlowError.Persistence(s"failed to read features under $featuresDir", Some(e)))
+
+  def slug(title: String): String =
+    title.toLowerCase.replaceAll("[^a-z0-9]+", "-").stripPrefix("-").stripSuffix("-").take(60)
+
+  def generatePrompt(pack: Pack, program: String, spec: String, feature: String, rules: List[String]): String =
+    val packBrief  = pack.prompt("vectors").getOrElse("")
+    val ruleSlice  = rules.mkString("\n")
+    s"""$packBrief
+       |
+       |Generate equivalence test vectors for the program $program from its behavioural spec and BDD
+       |scenarios below. Vectors are the generated tier: they prove spec conformance, so cover every
+       |rule the spec states — normal paths, boundary values (thresholds exactly at/over/under), and
+       |error paths (rejects, insufficient funds, validation order).
+       |
+       |For each vector:
+       |- "id": short kebab-case name describing the case.
+       |- "rules": the source units it exercises, chosen ONLY from this list (the ones this program's
+       |  spec cites): use the exact names.
+       |$ruleSlice
+       |- "inputs": a flat string map — the fields the replay harness needs to drive one execution
+       |  (amounts as plain decimal strings, dates ISO, codes verbatim from the spec).
+       |- "observations": the EXACT outcomes the spec promises, in order. kind "record" for emitted
+       |  records ("channel" names the output, "fields" carries values, "op" and "key" empty); kind
+       |  "db" for database mutations ("channel" = table, "op" = insert/update/delete, "key" addresses
+       |  the row, "fields" = the values written). Every amount, status, and reason code must come
+       |  from the spec — never invent values.
+       |
+       |Aim for 5–8 vectors: the happy path, each boundary, each reject.
+       |
+       |Spec:
+       |$spec
+       |
+       |Scenarios:
+       |$feature""".stripMargin
+
+  def toVector(program: String, g: GenVector): Either[String, EquivVector] =
+    g.observations
+      .foldLeft[Either[String, List[Equiv.Observation]]](Right(Nil)) { (acc, o) =>
+        acc.flatMap { done =>
+          o.kind.toLowerCase match
+            case "record" => Right(done :+ Equiv.Observation.Record(o.channel, o.fields))
+            case "db"     => Right(done :+ Equiv.Observation.DbMutation(o.channel, o.op, o.key, o.fields))
+            case other    => Left(s"vector ${g.id}: unknown observation kind '$other' (expected record|db)")
+        }
+      }
+      .map { obs =>
+        EquivVector(
+          schema = 1,
+          program = program,
+          id = g.id,
+          tier = Equiv.Tier.Generated,
+          rules = g.rules,
+          inputs = Json.Obj(g.inputs.toList.map((k, v) => k -> Json.Str(v))*),
+          observations = obs,
+        )
+      }
+
+  def triagePrompt(pack: Pack, failing: List[VectorVerdict], specText: String): String =
+    val details = failing
+      .map { v =>
+        val ms = v.mismatches
+          .map {
+            case Equiv.Mismatch.FieldDiff(at, field, e, a) => s"  - $at: $field expected $e, actual $a"
+            case Equiv.Mismatch.Missing(o)                 => s"  - missing: $o"
+            case Equiv.Mismatch.Unexpected(o)              => s"  - unexpected: $o"
+          }
+          .mkString("\n")
+        s"- ${v.vector.program} ${v.vector.id} (rules: ${v.vector.rules.mkString(", ")})\n$ms"
+      }
+      .mkString("\n")
+    s"""${pack.prompt("review").getOrElse("")}
+       |
+       |The equivalence harness replayed test vectors against the implementation and found the
+       |mismatches below. For each DISTINCT root cause produce one fix: a short spec document
+       |(Markdown: the rule violated, expected vs actual behaviour, the failing vector ids) and a
+       |plan task (title + description naming the spec rules). Group mismatches sharing a cause.
+       |If a mismatch reveals a wrong or ambiguous SPEC rather than wrong code, say so explicitly
+       |in that fix document — spec gaps go back to extraction, not to the coder.
+       |
+       |Mismatches:
+       |$details
+       |
+       |Specs under test:
+       |$specText""".stripMargin
+
+  def run(args: Array[String]): Unit =
+    flow(
+      args,
+      coder = coderCfg,
+      reasoning = Some(reasoningCfg),
+      defaultPrompt = Some("Prove the implementation equivalent to its spec pack"),
+    ):
+      val packDir    = workspace.resolve(Env.getOrElse("LLM4ZIO_PACK", "packs/cobol-springboot"))
+      val planFile   = workDir.resolve(ModDir).resolve("plan.md")
+      val vectorsDir = workDir.resolve(ModDir).resolve("vectors")
+      val events     = summon[FlowEvents]
+
+      for
+        pack     <- stage("Pack")(Pack.load(packDir))
+        _        <- stage("Wall")(assertWall(pack, workDir, events))
+        specsDir  = workDir.resolve(pack.specsDir)
+        rulesTxt <- readFileOr(specsDir.resolve("rules.txt"), "")
+        universe  = rulesTxt.linesIterator.map(_.strip).filter(_.nonEmpty).toList
+        _        <- ZIO.when(universe.isEmpty)(
+                      events.publish(FlowEvent.Info(
+                        "no rules.txt in the spec pack (extracted before 3.23.0?) — the report will use the " +
+                          "vectors' own rules and cannot flag unexercised ones"
+                      ))
+                    )
+        programs <- stage("Programs")(specPrograms(specsDir))
+        _        <- ZIO.when(programs.isEmpty)(
+                      ZIO.fail(FlowError.Aborted(s"no specs under $specsDir — run modernize-seed.sc first"))
+                    )
+        _        <- stage("Vectors") { // generated-first, resumable per program: delete a file to regenerate
+                      ZIO.foreachDiscard(programs) { program =>
+                        val file = vectorsDir.resolve(s"$program.jsonl")
+                        ZIO
+                          .attemptBlocking(Files.exists(file))
+                          .orDie
+                          .flatMap {
+                            case true  => events.publish(FlowEvent.Info(s"vectors exist for $program — skipping"))
+                            case false =>
+                              for
+                                spec    <- readFileOr(specsDir.resolve(s"$program.md"), "")
+                                feature <- featureFor(workDir.resolve(pack.featuresDir), program)
+                                gen     <- reasoning
+                                             .executeStructured[GenVectors](
+                                               generatePrompt(pack, program, spec, feature, universe),
+                                               SchemaDerivation.derive[GenVectors],
+                                             )
+                                             .mapError(e => FlowError.Llm(e.message, Some(e)))
+                                vectors <- ZIO.foreach(gen.vectors) { g =>
+                                             ZIO.fromEither(toVector(program, g)).mapError(FlowError.PlanParse(_))
+                                           }
+                                _       <- ZIO.when(vectors.isEmpty)(
+                                             ZIO.fail(FlowError.Aborted(s"generator produced no vectors for $program"))
+                                           )
+                                _       <- VectorStore.write(file, vectors)
+                                _       <- events.publish(FlowEvent.Info(s"${vectors.size} vector(s) generated for $program"))
+                              yield ()
+                          }
+                      }
+                    }
+        replayCmd <- ZIO
+                       .fromOption(pack.replay)
+                       .orElseFail(FlowError.Aborted(
+                         s"pack '${pack.name}' has no replay: command — add one (reads a vector JSON on stdin, " +
+                           "prints the resulting observations as a JSON array on stdout)"
+                       ))
+        verdicts <- stage("Replay") {
+                      for
+                        files   <- SpecChecks.matchingFiles(vectorsDir, """.*\.jsonl""").orElseSucceed(Nil)
+                        vectors <- ZIO.foreach(files.sorted)(f => VectorStore.read(vectorsDir.resolve(f))).map(_.flatten)
+                        _       <- ZIO.when(vectors.isEmpty)(
+                                     ZIO.fail(FlowError.Aborted(s"no vectors under $vectorsDir — nothing to replay"))
+                                   )
+                        result  <- ZIO.foreach(vectors) { v =>
+                                     Equiv.replayVector(replayCmd, workDir, v).flatMap {
+                                       case Equiv.Replayed.Crashed(code, problem) =>
+                                         events
+                                           .publish(FlowEvent.Info(
+                                             s"replay failed for ${v.program}/${v.id} (exit $code): ${problem.take(300)}"
+                                           ))
+                                           .as(VectorVerdict(v, v.observations.map(Equiv.Mismatch.Missing(_))))
+                                       case Equiv.Replayed.Observed(actual)       =>
+                                         ZIO.succeed(VectorVerdict(v, Equiv.diff(v.observations, actual, pack.equivalence)))
+                                     }
+                                   }
+                      yield result
+                    }
+        allRules  = if universe.nonEmpty then universe else verdicts.flatMap(_.vector.rules).distinct.sorted
+        failing   = verdicts.filterNot(_.passed)
+        _        <- stage("Report") {
+                      writeFile(workDir.resolve(ModDir).resolve("equivalence.md"), EquivReport.render(verdicts, allRules))
+                    }
+        _        <- ZIO.when(failing.nonEmpty)(stage("Triage") {
+                      for
+                        specText <- readFileOr(specsDir.resolve("traceability.md"), "")
+                        specs    <- ZIO.foreach(programs)(p => readFileOr(specsDir.resolve(s"$p.md"), ""))
+                        outcome  <- reasoning
+                                      .executeStructured[VerifyOutcome](
+                                        triagePrompt(pack, failing, (specText :: specs).mkString("\n\n")),
+                                        SchemaDerivation.derive[VerifyOutcome],
+                                      )
+                                      .mapError(e => FlowError.Llm(e.message, Some(e)))
+                        _        <- ZIO.foreachDiscard(outcome.fixes) { f =>
+                                      writeFile(specsDir.resolve("fixes").resolve(s"fix-${slug(f.title)}.md"),
+                                        s"# ${f.title}\n\n${f.spec}\n")
+                                    }
+                        _        <- ZIO.when(outcome.fixes.nonEmpty) {
+                                      PlanStore
+                                        .load(planFile)
+                                        .someOrFail(FlowError.Aborted(s"no plan at $planFile — run modernize-seed.sc first"))
+                                        .flatMap { plan =>
+                                          val increment = outcome.fixes.map(f => Task(f.taskTitle, f.taskDescription))
+                                          PlanStore.save(planFile, plan.copy(tasks = plan.tasks ++ increment)) *>
+                                            events.publish(FlowEvent.Info(
+                                              s"${increment.size} fix task(s) appended — rerun modernize-implement.sc"
+                                            ))
+                                        }
+                                    }
+                      yield ()
+                    })
+        _        <- stage("Provenance") {
+                      val manifest = workDir.resolve(ModDir).resolve("provenance.json")
+                      ZIO
+                        .attemptBlocking(Files.exists(manifest))
+                        .orDie
+                        .flatMap {
+                          case false => events.publish(FlowEvent.Info("no provenance.json — seeded before 3.23.0; skipping"))
+                          case true  =>
+                            Provenance
+                              .hashFiles(workDir, List(s"$ModDir/equivalence.md"))
+                              .flatMap(h => Provenance.extend(manifest)(_.copy(equivalenceReport = h.values.headOption)))
+                              .unit
+                        }
+                    }
+        gCount    = verdicts.count(_.vector.tier == Equiv.Tier.Generated)
+        cCount    = verdicts.count(_.vector.tier == Equiv.Tier.Captured)
+        summary   = s"${verdicts.count(_.passed)}/${verdicts.size} vectors green ($gCount generated, $cCount captured)"
+        _        <- stage("Commit")(
+                      git.commitAll(s"modernize(${pack.name}): verify — $summary" +
+                        (if failing.nonEmpty then s"; ${failing.size} failing triaged" else "")).unit
+                    )
+        _        <- ZIO.when(failing.nonEmpty)(
+                      ZIO.fail(FlowError.Aborted(
+                        s"equivalence not proven: ${failing.size} failing vector(s) — see $ModDir/equivalence.md; " +
+                          "fix specs filed, rerun modernize-implement.sc"
+                      ))
+                    )
+      yield summary


### PR DESCRIPTION
Wave 5 of the bank-modernization master plan — the product graduation.

- **`llm4zio-modernize` module**: the six flows behind one subcommand main; direct ports of the `.sc` scripts (still the authoring surface). Operator never edits Scala: `cs launch io.github.riccardomerolla:llm4zio-modernize_3:4.0.0 -- <phase> -- --repo <dir>`.
- **`modernize.conf`**: env-first config with a KEY=value file filling gaps — seats/endpoints are deployment choices, packs stay estate knowledge.
- **OCI image** (`ghcr.io/riccardomerolla/llm4zio-modernize`): ghcr workflow gated on Maven Central sync; classpath baked at build time for air-gapped use.
- **Pages workflow**: docs + benchmark page on main pushes (bench numbers manually refreshed — CI never runs benches).
- **Local-model lane** documented: on-prem extract/gate seats via OpenAI-compatible endpoints, measured before claimed.

Full suite green (`testFull` across all five modules); Main smoke-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)