### PR TITLE
fix: v4.0.0 release CI — modernize It config + Pages excludes

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,6 +27,8 @@ jobs:
         run: |
           mkdir -p _site_src
           cp -R docs/* _site_src/
+          # internal working notes; code fences in them break Jekyll's Liquid pass
+          rm -rf _site_src/superpowers _site_src/findings _site_src/deep-dive
           [ -f examples/benchmark.md ] && cp examples/benchmark.md _site_src/benchmark.md || true
           [ -f _site_src/index.md ] || cp _site_src/legacy-modernization.md _site_src/index.md
       - uses: actions/jekyll-build-pages@v1

--- a/build.sbt
+++ b/build.sbt
@@ -171,6 +171,8 @@ lazy val llm4zioJava = (project in file("modules/llm4zio-java"))
 // the operator surface. See .claude/plans/bank-modernization-master-plan.md.
 lazy val llm4zioModernize = (project in file("modules/llm4zio-modernize"))
   .dependsOn(llm4zioRunner, llm4zioFlow, llm4zioCore)
+  .configs(It)
+  .settings(inConfig(It)(Defaults.testSettings)*)
   .settings(
     name                 := "llm4zio-modernize",
     description          := "The llm4zio legacy-modernization pipeline as a runnable product",


### PR DESCRIPTION
The v4.0.0 tag CI failed in the publish job: llm4zio-modernize's zioTestDeps reference the `it` configuration the module never declared, so the ivy descriptor write blew up. Adds `.configs(It)` like every other module — `publishLocal` verified. Also fixes the Pages build (Liquid chokes on code fences in internal docs notes; they're now excluded from the site).

🤖 Generated with [Claude Code](https://claude.com/claude-code)