### PR TITLE
modernize-survey: LLM graph-refine step (v4.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.1.0] - 2026-07-27
+
+### Added
+
+- **Survey graph refine (LLM, evidence-gated).** Complex estates defeat the survey
+  regexes — dynamic `CALL WS-PGM` variables, JCL symbolic parameters (`EXEC PGM=&PGM`),
+  PROC expansions leave real dependencies unlinked. `modernize-survey` (script and
+  `llm4zio-modernize` phase) now runs a GRAPH REFINE stage between the deterministic
+  graph and triage: `reasoning` (read-only, rooted at the legacy repo) reads the sources
+  and proposes the edges the regexes missed, each with the establishing source statement
+  as evidence. The new `flow.Survey.merge` validates the proposals — self-loops, edges
+  naming units outside the inventory, and links the regexes already found are dropped —
+  and survivors land in `graph.json` with an `llm-` kind prefix so LLM-derived links
+  stay distinguishable (the inventory footnotes them). Kept AND dropped proposals, with
+  evidence, are written to `docs/modernization/graph-refine.md` as the audit trail.
+  Skip the pass with `LLM4ZIO_GRAPH_REFINE=off`.
+
+### Changed
+
+- **Example version pins synced.** All `examples/*.sc`, `examples/java/*.java`,
+  `README.md`, and `docs/pilot-playbook.md` now pin 4.1.0 (they had drifted across
+  3.19.0 and 4.0.0).
+
 ## [3.19.0] - 2026-07-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ subcommand main (`survey|extract|seed|implement|verify|review`), configured by
 your pack + env/`modernize.conf`:
 
 ```bash
-cs launch io.github.riccardomerolla:llm4zio-modernize_3:4.0.0 -- survey -- --repo ~/estates/your-legacy
+cs launch io.github.riccardomerolla:llm4zio-modernize_3:4.1.0 -- survey -- --repo ~/estates/your-legacy
 ```
 
 or, air-gapped/CI, the OCI image `ghcr.io/riccardomerolla/llm4zio-modernize`.

--- a/docs/legacy-modernization.md
+++ b/docs/legacy-modernization.md
@@ -27,10 +27,16 @@ modernize-survey.sc ──▶ (human approves waves) ──▶ modernize-extract
 order" — deterministic-first (`flow.Survey`): one inventory node per source file
 (size = lines + coverage units), one dependency edge per `## Survey:` regex match
 (`CALL`, `COPY`, `EXEC PGM=`) → `inventory.md` + `graph.json`, committed and
-auditable at any estate size. The LLM enters only for what regexes cannot decide:
-classifying each unit **rewrite / retire / wrap** (wrap = keep + front with an
-API; building wraps is out of scope), resolving dynamic `CALL` variables, and
-proposing dependency-coherent **waves**. The wave plan lands with an unchecked
+auditable at any estate size. The LLM enters only for what regexes cannot decide.
+First a **graph-refine** pass: complex estates defeat the regexes (dynamic
+`CALL WS-PGM` variables, JCL symbolic parameters, PROC expansions), so `reasoning`
+reads the sources and proposes the missed links — each needs the establishing
+source statement as evidence, `Survey.merge` drops anything not between known
+units or already found, and survivors land in `graph.json` with an `llm-` kind
+(audit trail in `graph-refine.md`; `LLM4ZIO_GRAPH_REFINE=off` skips the pass).
+Then triage: classifying each unit **rewrite / retire / wrap** (wrap = keep +
+front with an API; building wraps is out of scope) and proposing
+dependency-coherent **waves**. The wave plan lands with an unchecked
 approval marker — and when `bench-results.jsonl` exists from `modernize-bench.sc`
 runs, it carries a per-wave **cost projection from measured runs**. After
 approval, `LLM4ZIO_WAVE=wave-1` scopes extraction to that wave's programs.

--- a/docs/pilot-playbook.md
+++ b/docs/pilot-playbook.md
@@ -35,7 +35,7 @@ the authoring surface, best when you are customizing flows. The **operator
 surface** is the published product, no repo clone and no Scala:
 
 ```bash
-cs launch io.github.riccardomerolla:llm4zio-modernize_3:4.0.0 -- <phase> -- --repo <dir>
+cs launch io.github.riccardomerolla:llm4zio-modernize_3:4.1.0 -- <phase> -- --repo <dir>
 ```
 
 or the OCI image for air-gapped/CI use

--- a/examples/ado-implement.sc
+++ b/examples/ado-implement.sc
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla::llm4zio-runner:3.19.0"
+//> using dep "io.github.riccardomerolla::llm4zio-runner:4.1.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/examples/ado-spec.sc
+++ b/examples/ado-spec.sc
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla::llm4zio-runner:3.19.0"
+//> using dep "io.github.riccardomerolla::llm4zio-runner:4.1.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/examples/bench-report.sc
+++ b/examples/bench-report.sc
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla::llm4zio-runner:3.19.0"
+//> using dep "io.github.riccardomerolla::llm4zio-runner:4.1.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/examples/costs.sc
+++ b/examples/costs.sc
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla::llm4zio-runner:3.19.0"
+//> using dep "io.github.riccardomerolla::llm4zio-runner:4.1.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/examples/epic.sc
+++ b/examples/epic.sc
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla::llm4zio-runner:3.19.0"
+//> using dep "io.github.riccardomerolla::llm4zio-runner:4.1.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/examples/handoff-build.sc
+++ b/examples/handoff-build.sc
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla::llm4zio-runner:3.19.0"
+//> using dep "io.github.riccardomerolla::llm4zio-runner:4.1.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/examples/handoff-plan.sc
+++ b/examples/handoff-plan.sc
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla::llm4zio-runner:3.19.0"
+//> using dep "io.github.riccardomerolla::llm4zio-runner:4.1.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/examples/implement-enhanced-pr.sc
+++ b/examples/implement-enhanced-pr.sc
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla::llm4zio-runner:3.19.0"
+//> using dep "io.github.riccardomerolla::llm4zio-runner:4.1.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/examples/implement-enhanced.sc
+++ b/examples/implement-enhanced.sc
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla::llm4zio-runner:3.19.0"
+//> using dep "io.github.riccardomerolla::llm4zio-runner:4.1.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/examples/implement-interactive.sc
+++ b/examples/implement-interactive.sc
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla::llm4zio-runner:3.19.0"
+//> using dep "io.github.riccardomerolla::llm4zio-runner:4.1.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/examples/implement-live.sc
+++ b/examples/implement-live.sc
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla::llm4zio-runner:3.19.0"
+//> using dep "io.github.riccardomerolla::llm4zio-runner:4.1.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/examples/implement.sc
+++ b/examples/implement.sc
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla::llm4zio-runner:3.19.0"
+//> using dep "io.github.riccardomerolla::llm4zio-runner:4.1.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/examples/issue-pr-bugfix.sc
+++ b/examples/issue-pr-bugfix.sc
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla::llm4zio-runner:3.19.0"
+//> using dep "io.github.riccardomerolla::llm4zio-runner:4.1.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/examples/issue-pr.sc
+++ b/examples/issue-pr.sc
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla::llm4zio-runner:3.19.0"
+//> using dep "io.github.riccardomerolla::llm4zio-runner:4.1.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/examples/java/AdoImplement.java
+++ b/examples/java/AdoImplement.java
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla:llm4zio-java:3.19.0"
+//> using dep "io.github.riccardomerolla:llm4zio-java:4.1.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/examples/java/AdoSpec.java
+++ b/examples/java/AdoSpec.java
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla:llm4zio-java:3.19.0"
+//> using dep "io.github.riccardomerolla:llm4zio-java:4.1.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/examples/java/Epic.java
+++ b/examples/java/Epic.java
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla:llm4zio-java:3.19.0"
+//> using dep "io.github.riccardomerolla:llm4zio-java:4.1.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/examples/java/Implement.java
+++ b/examples/java/Implement.java
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla:llm4zio-java:3.19.0"
+//> using dep "io.github.riccardomerolla:llm4zio-java:4.1.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/examples/java/ImplementEnhanced.java
+++ b/examples/java/ImplementEnhanced.java
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla:llm4zio-java:3.19.0"
+//> using dep "io.github.riccardomerolla:llm4zio-java:4.1.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/examples/java/ImplementEnhancedPr.java
+++ b/examples/java/ImplementEnhancedPr.java
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla:llm4zio-java:3.19.0"
+//> using dep "io.github.riccardomerolla:llm4zio-java:4.1.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/examples/java/IssuePr.java
+++ b/examples/java/IssuePr.java
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla:llm4zio-java:3.19.0"
+//> using dep "io.github.riccardomerolla:llm4zio-java:4.1.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/examples/java/IssuePrBugfix.java
+++ b/examples/java/IssuePrBugfix.java
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla:llm4zio-java:3.19.0"
+//> using dep "io.github.riccardomerolla:llm4zio-java:4.1.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/examples/java/JudgeGate.java
+++ b/examples/java/JudgeGate.java
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla:llm4zio-java:3.19.0"
+//> using dep "io.github.riccardomerolla:llm4zio-java:4.1.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/examples/java/JudgeSuite.java
+++ b/examples/java/JudgeSuite.java
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla:llm4zio-java:3.19.0"
+//> using dep "io.github.riccardomerolla:llm4zio-java:4.1.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/examples/java/Local.java
+++ b/examples/java/Local.java
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla:llm4zio-java:3.19.0"
+//> using dep "io.github.riccardomerolla:llm4zio-java:4.1.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/examples/java/LocalClaude.java
+++ b/examples/java/LocalClaude.java
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla:llm4zio-java:3.19.0"
+//> using dep "io.github.riccardomerolla:llm4zio-java:4.1.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/examples/java/Pipeline.java
+++ b/examples/java/Pipeline.java
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla:llm4zio-java:3.19.0"
+//> using dep "io.github.riccardomerolla:llm4zio-java:4.1.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/examples/java/ReverseEngineer.java
+++ b/examples/java/ReverseEngineer.java
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla:llm4zio-java:3.19.0"
+//> using dep "io.github.riccardomerolla:llm4zio-java:4.1.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/examples/java/Sdd.java
+++ b/examples/java/Sdd.java
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla:llm4zio-java:3.19.0"
+//> using dep "io.github.riccardomerolla:llm4zio-java:4.1.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/examples/judge-gate.sc
+++ b/examples/judge-gate.sc
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla::llm4zio-runner:3.19.0"
+//> using dep "io.github.riccardomerolla::llm4zio-runner:4.1.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/examples/judge-suite.sc
+++ b/examples/judge-suite.sc
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla::llm4zio-runner:3.19.0"
+//> using dep "io.github.riccardomerolla::llm4zio-runner:4.1.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/examples/local-claude.sc
+++ b/examples/local-claude.sc
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla::llm4zio-runner:3.19.0"
+//> using dep "io.github.riccardomerolla::llm4zio-runner:4.1.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/examples/local.sc
+++ b/examples/local.sc
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla::llm4zio-runner:3.19.0"
+//> using dep "io.github.riccardomerolla::llm4zio-runner:4.1.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/examples/modernize-bench.sc
+++ b/examples/modernize-bench.sc
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla::llm4zio-runner:3.19.0"
+//> using dep "io.github.riccardomerolla::llm4zio-runner:4.1.0"
 //> using scala "3.8.3"
 //> using jvm 21
 
@@ -56,7 +56,7 @@ import llm4zio.eval.*
 import llm4zio.flow.*
 import llm4zio.runner.*
 
-val Llm4zioVersion = "3.19.0"
+val Llm4zioVersion = "4.1.0"
 val MaxGateRounds  = 3
 val ImplFixRounds  = 2
 val AnalystTurns   = 48

--- a/examples/modernize-extract.sc
+++ b/examples/modernize-extract.sc
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla::llm4zio-runner:4.0.0"
+//> using dep "io.github.riccardomerolla::llm4zio-runner:4.1.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/examples/modernize-implement.sc
+++ b/examples/modernize-implement.sc
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla::llm4zio-runner:4.0.0"
+//> using dep "io.github.riccardomerolla::llm4zio-runner:4.1.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/examples/modernize-review.sc
+++ b/examples/modernize-review.sc
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla::llm4zio-runner:4.0.0"
+//> using dep "io.github.riccardomerolla::llm4zio-runner:4.1.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/examples/modernize-seed.sc
+++ b/examples/modernize-seed.sc
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla::llm4zio-runner:4.0.0"
+//> using dep "io.github.riccardomerolla::llm4zio-runner:4.1.0"
 //> using scala "3.8.3"
 //> using jvm 21
 
@@ -44,7 +44,7 @@ import llm4zio.flow.*
 import llm4zio.runner.*
 
 val ModDir         = "docs/modernization"
-val Llm4zioVersion = "4.0.0" // keep in step with the `using dep` header pin
+val Llm4zioVersion = "4.1.0" // keep in step with the `using dep` header pin
 
 def writeFile(path: Path, content: String): IO[FlowError, Unit] =
   ZIO

--- a/examples/modernize-survey.sc
+++ b/examples/modernize-survey.sc
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla::llm4zio-runner:4.0.0"
+//> using dep "io.github.riccardomerolla::llm4zio-runner:4.1.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/examples/modernize-survey.sc
+++ b/examples/modernize-survey.sc
@@ -15,11 +15,17 @@
   *      `sources:` regex (size = lines + coverage units), one edge per `## Survey:` rule match
   *      (CALL / COPY / EXEC PGM=…). Written as `docs/modernization/inventory.md` (auditable
   *      Markdown) + `graph.json` (machine-readable), committed.
-  *   2. TRIAGE (LLM, bounded to the graph): `reasoning` classifies each unit
+  *   2. GRAPH REFINE (LLM, evidence-gated): complex estates defeat the regexes — dynamic CALLs
+  *      (`CALL WS-PGM`), JCL symbolic parameters (`EXEC PGM=&PGM`), PROC expansions. `reasoning`
+  *      (read-only, rooted at the repo) reads the sources and proposes the edges the regexes
+  *      missed, each with the source statement as evidence; `Survey.merge` validates them
+  *      (known units only, no duplicates, no self-loops) and tags survivors `llm-…` so they
+  *      stay distinguishable from regex-derived edges. Audit trail (kept AND dropped, with
+  *      evidence) in `docs/modernization/graph-refine.md`. Skip with LLM4ZIO_GRAPH_REFINE=off.
+  *   3. TRIAGE (LLM, bounded to the graph): `reasoning` classifies each unit
   *      rewrite | retire | wrap (wrap = keep and front with an API — classified here,
-  *      implementing wraps is out of scope), resolves what the regexes could not (dynamic CALL
-  *      variables), and proposes dependency-coherent WAVES.
-  *   3. WAVE PLAN (human-gated): `docs/modernization/wave-plan.md` carries the waves, the
+  *      implementing wraps is out of scope) and proposes dependency-coherent WAVES.
+  *   4. WAVE PLAN (human-gated): `docs/modernization/wave-plan.md` carries the waves, the
   *      per-unit dispositions, and — when `bench-results.jsonl` exists next to the scripts — a
   *      per-wave cost/duration projection from real measured runs (`bench-report --project`).
   *      The plan gets an UNCHECKED approval marker: a person reviews, flips it, and only then
@@ -57,6 +63,13 @@ case class WaveSlice(name: String, programs: List[String], rationale: String) de
 
 case class SurveyOutcome(triage: List[NodeTriage], waves: List[WaveSlice], notes: List[String]) derives JsonCodec
 
+/** One regex-missed dependency the LLM found by reading the sources: endpoints must be inventory units and `evidence`
+  * cites the statement that establishes the link (`Survey.merge` drops anything else).
+  */
+case class RefinedEdge(from: String, to: String, kind: String, evidence: String) derives JsonCodec
+
+case class GraphRefinement(edges: List[RefinedEdge], notes: List[String]) derives JsonCodec
+
 def writeFile(path: Path, content: String): IO[FlowError, Unit] =
   ZIO
     .attemptBlocking {
@@ -66,9 +79,55 @@ def writeFile(path: Path, content: String): IO[FlowError, Unit] =
     }
     .mapError(e => FlowError.Persistence(s"failed to write $path", Some(e)))
 
+def refinePrompt(graph: SurveyGraph): String =
+  s"""You are refining the dependency graph of a legacy estate. The graph below was built
+     |deterministically — one node per source file, one edge per regex match (CALL / COPY /
+     |EXEC PGM=…). Regexes miss links in complex sources: dynamic CALLs (CALL WS-PROGRAM),
+     |JCL symbolic parameters (EXEC PGM=&PGM), PROC expansions, control cards naming programs.
+     |You have read-only access to the estate — read the sources (each node's "path" names its
+     |file) and find the dependency edges the regexes missed. Prioritise the suspicious shapes:
+     |jobs with fewer outgoing edges than steps, programs nothing references, units with
+     |degree 0.
+     |
+     |Produce:
+     |- "edges": ONLY links the graph does not already have, and ONLY between the units listed
+     |  below (use the exact unit names). Each edge: "from" (the referencing unit), "to" (the
+     |  referenced unit), "kind" (how the link is made: dynamic-call, proc-step, control-card,
+     |  …), and "evidence" (file, line, and the statement that establishes the link — no
+     |  evidence, no edge). Calls to external/system programs are NOT edges; put them in
+     |  "notes".
+     |- "notes": references you could not resolve to a unit — dynamic variables whose value you
+     |  could not trace, external systems. Empty if none.
+     |
+     |Units: ${graph.nodes.map(_.name).sorted.mkString(", ")}
+     |
+     |Graph (JSON):
+     |${graph.toJson}""".stripMargin
+
+def renderRefine(refinement: GraphRefinement, kept: List[SurveyEdge]): String =
+  val keptKeys = kept.map(e => (e.from, e.to)).toSet
+  val cell     = (s: String) => s.linesIterator.mkString(" ").replace("|", "\\|")
+  val rows     = refinement.edges.map { e =>
+    val status = if keptKeys((e.from, e.to)) then "added" else "dropped — duplicate, self-loop, or unknown unit"
+    s"| ${e.from} | ${e.to} | ${e.kind} | $status | ${cell(e.evidence)} |"
+  }
+  val notes    =
+    if refinement.notes.isEmpty then Nil
+    else "## Unresolved" :: "" :: refinement.notes.map(n => s"- ${cell(n)}")
+  (List(
+    "# Graph refine (LLM)",
+    "",
+    s"${kept.size} of ${refinement.edges.size} proposed edge(s) merged into `graph.json` (kind prefixed `llm-`).",
+    "Each carries the source statement that establishes it — verify before trusting a wave built on it.",
+    "",
+    "| From | To | Kind | Status | Evidence |",
+    "| ---- | -- | ---- | ------ | -------- |",
+  ) ++ rows ++ List("") ++ notes).mkString("\n") + "\n"
+
 def triagePrompt(graph: SurveyGraph, inventory: String): String =
-  s"""You are triaging a legacy estate for modernization. Below are its deterministic
-     |inventory and dependency graph (regex-derived from the source — trust them).
+  s"""You are triaging a legacy estate for modernization. Below are its inventory and
+     |dependency graph (regex-derived from the source, plus `llm-…` edges the graph-refine
+     |step grounded in the source with evidence — trust them).
      |
      |Produce:
      |- "triage": for EVERY unit in the inventory, a disposition:
@@ -145,10 +204,36 @@ flow(
                      _ <- events.publish(FlowEvent.Info(s"${g.nodes.size} unit(s), ${g.edges.size} edge(s)"))
                    yield g
                  }
+    refined   <- stage("Graph refine") {
+                   if sys.env.get("LLM4ZIO_GRAPH_REFINE").map(_.trim.toLowerCase).exists(Set("off", "0", "false"))
+                   then
+                     events
+                       .publish(FlowEvent.Info("LLM4ZIO_GRAPH_REFINE=off — regex graph ships unrefined"))
+                       .as(graph)
+                   else
+                     for
+                       r     <- reasoning
+                                  .executeStructured[GraphRefinement](
+                                    refinePrompt(graph),
+                                    SchemaDerivation.derive[GraphRefinement],
+                                  )
+                                  .mapError(e => FlowError.Llm(e.message, Some(e)))
+                       merged = Survey.merge(graph, r.edges.map(e => SurveyEdge(e.from, e.to, e.kind)))
+                       kept   = merged.edges.filter(_.kind.startsWith("llm-"))
+                       _     <- writeFile(modDir.resolve("graph-refine.md"), renderRefine(r, kept))
+                       _     <- ZIO.when(kept.nonEmpty)(
+                                  writeFile(modDir.resolve("inventory.md"), Survey.renderInventory(merged)) *>
+                                    writeFile(modDir.resolve("graph.json"), merged.toJsonPretty)
+                                )
+                       _     <- events.publish(FlowEvent.Info(
+                                  s"${kept.size} regex-missed edge(s) merged (${r.edges.size} proposed by the LLM)"
+                                ))
+                     yield merged
+                 }
     outcome   <- stage("Triage") {
                    reasoning
                      .executeStructured[SurveyOutcome](
-                       triagePrompt(graph, Survey.renderInventory(graph)),
+                       triagePrompt(refined, Survey.renderInventory(refined)),
                        SchemaDerivation.derive[SurveyOutcome],
                      )
                      .mapError(e => FlowError.Llm(e.message, Some(e)))
@@ -177,16 +262,16 @@ flow(
                           }
                       }
                   }
-    planMd     = renderWavePlan(outcome, graph, projection)
+    planMd     = renderWavePlan(outcome, refined, projection)
     _         <- stage("Wave plan")(
                    writeFile(modDir.resolve("wave-plan.md"), ApprovalGate.withDraftMarker(planMd))
                  )
     _         <- stage("Commit")(
-                   git.commitAll(s"modernize(${pack.name}): survey — ${graph.nodes.size} unit(s), " +
+                   git.commitAll(s"modernize(${pack.name}): survey — ${refined.nodes.size} unit(s), " +
                      s"${outcome.waves.size} wave(s) proposed").unit
                  )
     _         <- events.publish(FlowEvent.Info(
                    s"review $ModDir/wave-plan.md, flip '- [x] Approved', then run modernize-extract.sc " +
                      "(LLM4ZIO_WAVE=<name> scopes it to one wave)"
                  ))
-  yield s"units=${graph.nodes.size} waves=${outcome.waves.size}"
+  yield s"units=${refined.nodes.size} waves=${outcome.waves.size}"

--- a/examples/modernize-verify.sc
+++ b/examples/modernize-verify.sc
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla::llm4zio-runner:4.0.0"
+//> using dep "io.github.riccardomerolla::llm4zio-runner:4.1.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/examples/pipeline.sc
+++ b/examples/pipeline.sc
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla::llm4zio-runner:3.19.0"
+//> using dep "io.github.riccardomerolla::llm4zio-runner:4.1.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/examples/reverse-engineer.sc
+++ b/examples/reverse-engineer.sc
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla::llm4zio-runner:3.19.0"
+//> using dep "io.github.riccardomerolla::llm4zio-runner:4.1.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/examples/sdd.sc
+++ b/examples/sdd.sc
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla::llm4zio-runner:3.19.0"
+//> using dep "io.github.riccardomerolla::llm4zio-runner:4.1.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/examples/tools/cobol-capture.sc
+++ b/examples/tools/cobol-capture.sc
@@ -1,4 +1,4 @@
-//> using dep "io.github.riccardomerolla::llm4zio-runner:4.0.0"
+//> using dep "io.github.riccardomerolla::llm4zio-runner:4.1.0"
 //> using scala "3.8.3"
 //> using jvm 21
 

--- a/modules/llm4zio-flow/src/main/scala/llm4zio/flow/Survey.scala
+++ b/modules/llm4zio-flow/src/main/scala/llm4zio/flow/Survey.scala
@@ -69,17 +69,34 @@ object Survey:
       }
       .mapError(e => FlowError.Persistence(s"failed to survey $root", Some(e)))
 
+  /** Merge LLM-refined edges into a regex-derived graph — the refine bookend for estates where the survey regexes
+    * cannot see every link (dynamic `CALL WS-PGM` variables, JCL symbolic parameters, PROC expansions). Refined edges
+    * are validated, not trusted: self-loops, edges naming units the inventory does not contain, and links the
+    * deterministic pass already found (same from/to, any kind) are all dropped. What survives lands with its kind
+    * prefixed `llm-`, so LLM-derived links stay distinguishable from regex-derived ones in `graph.json` and the
+    * inventory.
+    */
+  def merge(graph: SurveyGraph, refined: List[SurveyEdge]): SurveyGraph =
+    val known    = graph.nodes.map(_.name).toSet
+    val existing = graph.edges.map(e => (e.from, e.to)).toSet
+    val kept     = refined
+      .filter(e => e.from != e.to && known(e.from) && known(e.to) && !existing((e.from, e.to)))
+      .distinctBy(e => (e.from, e.to))
+      .map(e => e.copy(kind = if e.kind.startsWith("llm-") then e.kind else s"llm-${e.kind}"))
+    graph.copy(edges = graph.edges ++ kept)
+
   /** The inventory as Markdown: one row per node with size and degree signals; nodes nothing references and that
     * reference nothing are flagged `unreferenced` — the deterministic retire-candidate floor (entry points like jobs
     * have outgoing edges, so they never trip it).
     */
   def renderInventory(graph: SurveyGraph): String =
-    val rows = graph.nodes.sortBy(_.name).map { n =>
+    val rows    = graph.nodes.sortBy(_.name).map { n =>
       val in    = graph.incoming(n.name).size
       val out   = graph.outgoing(n.name).size
       val flags = if in == 0 && out == 0 then "unreferenced — retire candidate?" else ""
       s"| ${n.name} | ${n.path} | ${n.lines} | ${n.units} | $in | $out | $flags |"
     }
+    val refined = graph.edges.count(_.kind.startsWith("llm-"))
     (List(
       "# Estate inventory",
       "",
@@ -89,6 +106,13 @@ object Survey:
       "",
       s"${graph.nodes.size} unit(s), ${graph.edges.size} edge(s). Edges and counts are regex-derived",
       "(`## Survey:` / `## Coverage:` rules in the pack) — deterministic, auditable, re-runnable.",
+    ) ++ (
+      if refined == 0 then Nil
+      else
+        List(
+          s"$refined edge(s) with an `llm-` kind came from the LLM graph-refine step — source-grounded",
+          "links the regexes missed; evidence in `graph-refine.md`.",
+        )
     )).mkString("", "\n", "\n")
 
   /** `cobol/ACCTXFR.cbl` → `ACCTXFR`. */

--- a/modules/llm4zio-flow/src/test/scala/llm4zio/flow/SurveySpec.scala
+++ b/modules/llm4zio-flow/src/test/scala/llm4zio/flow/SurveySpec.scala
@@ -98,4 +98,45 @@ object SurveySpec extends ZIOSpecDefault:
         )
       }
     },
+    test("merge keeps refined edges between known units and tags their kind llm-") {
+      val merged = Survey.merge(baseGraph, List(SurveyEdge("ACCTXFR", "INTCALC", "dynamic-call")))
+      assertTrue(
+        merged.edges.contains(SurveyEdge("ACCTXFR", "INTCALC", "llm-dynamic-call")),
+        merged.edges.contains(SurveyEdge("XFERDLY", "ACCTXFR", "exec-pgm")),
+      )
+    },
+    test("merge drops self-loops, edges naming unknown units, and links the regexes already found") {
+      val merged = Survey.merge(
+        baseGraph,
+        List(
+          SurveyEdge("ACCTXFR", "ACCTXFR", "dynamic-call"), // self-loop
+          SurveyEdge("ACCTXFR", "NOWHERE", "dynamic-call"), // unknown target
+          SurveyEdge("GHOST", "INTCALC", "dynamic-call"),   // unknown source
+          SurveyEdge("XFERDLY", "ACCTXFR", "proc-step"),    // already found deterministically
+          SurveyEdge("ACCTXFR", "INTCALC", "dynamic-call"), // kept
+          SurveyEdge("ACCTXFR", "INTCALC", "control-card"), // duplicate endpoints of a kept edge
+        ),
+      )
+      assertTrue(merged.edges == baseGraph.edges :+ SurveyEdge("ACCTXFR", "INTCALC", "llm-dynamic-call"))
+    },
+    test("merge does not double-prefix a kind already tagged llm-") {
+      val merged = Survey.merge(baseGraph, List(SurveyEdge("ACCTXFR", "INTCALC", "llm-dynamic-call")))
+      assertTrue(merged.edges.contains(SurveyEdge("ACCTXFR", "INTCALC", "llm-dynamic-call")))
+    },
+    test("renderInventory footnotes LLM-refined edges only when present") {
+      val merged = Survey.merge(baseGraph, List(SurveyEdge("ACCTXFR", "INTCALC", "dynamic-call")))
+      assertTrue(
+        Survey.renderInventory(merged).contains("LLM graph-refine"),
+        !Survey.renderInventory(baseGraph).contains("LLM graph-refine"),
+      )
+    },
+  )
+
+  private val baseGraph = SurveyGraph(
+    nodes = List(
+      SurveyNode("jobs/XFERDLY.jcl", "XFERDLY", 1, 1),
+      SurveyNode("cobol/ACCTXFR.cbl", "ACCTXFR", 5, 1),
+      SurveyNode("cobol/INTCALC.cbl", "INTCALC", 4, 1),
+    ),
+    edges = List(SurveyEdge("XFERDLY", "ACCTXFR", "exec-pgm")),
   )

--- a/modules/llm4zio-modernize/src/main/scala/llm4zio/modernize/SurveyFlow.scala
+++ b/modules/llm4zio-modernize/src/main/scala/llm4zio/modernize/SurveyFlow.scala
@@ -14,10 +14,16 @@ object SurveyFlow:
     *   1. GRAPH (deterministic, `flow.Survey` — no LLM): one node per file matching the pack's `sources:` regex (size =
     *      lines + coverage units), one edge per `## Survey:` rule match (CALL / COPY / EXEC PGM=…). Written as
     *      `docs/modernization/inventory.md` (auditable Markdown) + `graph.json` (machine-readable), committed.
-    *   2. TRIAGE (LLM, bounded to the graph): `reasoning` classifies each unit rewrite | retire | wrap (wrap = keep and
-    *      front with an API — classified here, implementing wraps is out of scope), resolves what the regexes could not
-    *      (dynamic CALL variables), and proposes dependency-coherent WAVES.
-    *   3. WAVE PLAN (human-gated): `docs/modernization/wave-plan.md` carries the waves, the per-unit dispositions, and
+    *   2. GRAPH REFINE (LLM, evidence-gated): complex estates defeat the regexes — dynamic CALLs (`CALL WS-PGM`), JCL
+    *      symbolic parameters (`EXEC PGM=&PGM`), PROC expansions. `reasoning` (read-only, rooted at the repo) reads the
+    *      sources and proposes the edges the regexes missed, each with the source statement as evidence; `Survey.merge`
+    *      validates them (known units only, no duplicates, no self-loops) and tags survivors `llm-…` so they stay
+    *      distinguishable from regex-derived edges. Audit trail (kept AND dropped, with evidence) in
+    *      `docs/modernization/graph-refine.md`. Skip with LLM4ZIO_GRAPH_REFINE=off.
+    *   3. TRIAGE (LLM, bounded to the graph): `reasoning` classifies each unit rewrite | retire | wrap (wrap = keep and
+    *      front with an API — classified here, implementing wraps is out of scope) and proposes dependency-coherent
+    *      WAVES.
+    *   4. WAVE PLAN (human-gated): `docs/modernization/wave-plan.md` carries the waves, the per-unit dispositions, and
     *      — when `bench-results.jsonl` exists next to the scripts — a per-wave cost/duration projection from real
     *      measured runs (`bench-report --project`). The plan gets an UNCHECKED approval marker: a person reviews, flips
     *      it, and only then does extraction start. Scope extraction to one wave with LLM4ZIO_WAVE=<name>.
@@ -54,6 +60,13 @@ object SurveyFlow:
 
   case class SurveyOutcome(triage: List[NodeTriage], waves: List[WaveSlice], notes: List[String]) derives JsonCodec
 
+  /** One regex-missed dependency the LLM found by reading the sources: endpoints must be inventory units and `evidence`
+    * cites the statement that establishes the link (`Survey.merge` drops anything else).
+    */
+  case class RefinedEdge(from: String, to: String, kind: String, evidence: String) derives JsonCodec
+
+  case class GraphRefinement(edges: List[RefinedEdge], notes: List[String]) derives JsonCodec
+
   def writeFile(path: Path, content: String): IO[FlowError, Unit] =
     ZIO
       .attemptBlocking {
@@ -63,9 +76,55 @@ object SurveyFlow:
       }
       .mapError(e => FlowError.Persistence(s"failed to write $path", Some(e)))
 
+  def refinePrompt(graph: SurveyGraph): String =
+    s"""You are refining the dependency graph of a legacy estate. The graph below was built
+       |deterministically — one node per source file, one edge per regex match (CALL / COPY /
+       |EXEC PGM=…). Regexes miss links in complex sources: dynamic CALLs (CALL WS-PROGRAM),
+       |JCL symbolic parameters (EXEC PGM=&PGM), PROC expansions, control cards naming programs.
+       |You have read-only access to the estate — read the sources (each node's "path" names its
+       |file) and find the dependency edges the regexes missed. Prioritise the suspicious shapes:
+       |jobs with fewer outgoing edges than steps, programs nothing references, units with
+       |degree 0.
+       |
+       |Produce:
+       |- "edges": ONLY links the graph does not already have, and ONLY between the units listed
+       |  below (use the exact unit names). Each edge: "from" (the referencing unit), "to" (the
+       |  referenced unit), "kind" (how the link is made: dynamic-call, proc-step, control-card,
+       |  …), and "evidence" (file, line, and the statement that establishes the link — no
+       |  evidence, no edge). Calls to external/system programs are NOT edges; put them in
+       |  "notes".
+       |- "notes": references you could not resolve to a unit — dynamic variables whose value you
+       |  could not trace, external systems. Empty if none.
+       |
+       |Units: ${graph.nodes.map(_.name).sorted.mkString(", ")}
+       |
+       |Graph (JSON):
+       |${graph.toJson}""".stripMargin
+
+  def renderRefine(refinement: GraphRefinement, kept: List[SurveyEdge]): String =
+    val keptKeys = kept.map(e => (e.from, e.to)).toSet
+    val cell     = (s: String) => s.linesIterator.mkString(" ").replace("|", "\\|")
+    val rows     = refinement.edges.map { e =>
+      val status = if keptKeys((e.from, e.to)) then "added" else "dropped — duplicate, self-loop, or unknown unit"
+      s"| ${e.from} | ${e.to} | ${e.kind} | $status | ${cell(e.evidence)} |"
+    }
+    val notes    =
+      if refinement.notes.isEmpty then Nil
+      else "## Unresolved" :: "" :: refinement.notes.map(n => s"- ${cell(n)}")
+    (List(
+      "# Graph refine (LLM)",
+      "",
+      s"${kept.size} of ${refinement.edges.size} proposed edge(s) merged into `graph.json` (kind prefixed `llm-`).",
+      "Each carries the source statement that establishes it — verify before trusting a wave built on it.",
+      "",
+      "| From | To | Kind | Status | Evidence |",
+      "| ---- | -- | ---- | ------ | -------- |",
+    ) ++ rows ++ List("") ++ notes).mkString("\n") + "\n"
+
   def triagePrompt(graph: SurveyGraph, inventory: String): String =
-    s"""You are triaging a legacy estate for modernization. Below are its deterministic
-       |inventory and dependency graph (regex-derived from the source — trust them).
+    s"""You are triaging a legacy estate for modernization. Below are its inventory and
+       |dependency graph (regex-derived from the source, plus `llm-…` edges the graph-refine
+       |step grounded in the source with evidence — trust them).
        |
        |Produce:
        |- "triage": for EVERY unit in the inventory, a disposition:
@@ -143,10 +202,36 @@ object SurveyFlow:
                           _ <- events.publish(FlowEvent.Info(s"${g.nodes.size} unit(s), ${g.edges.size} edge(s)"))
                         yield g
                       }
+        refined    <- stage("Graph refine") {
+                        if Env.get("LLM4ZIO_GRAPH_REFINE").map(_.trim.toLowerCase).exists(Set("off", "0", "false"))
+                        then
+                          events
+                            .publish(FlowEvent.Info("LLM4ZIO_GRAPH_REFINE=off — regex graph ships unrefined"))
+                            .as(graph)
+                        else
+                          for
+                            r     <- reasoning
+                                       .executeStructured[GraphRefinement](
+                                         refinePrompt(graph),
+                                         SchemaDerivation.derive[GraphRefinement],
+                                       )
+                                       .mapError(e => FlowError.Llm(e.message, Some(e)))
+                            merged = Survey.merge(graph, r.edges.map(e => SurveyEdge(e.from, e.to, e.kind)))
+                            kept   = merged.edges.filter(_.kind.startsWith("llm-"))
+                            _     <- writeFile(modDir.resolve("graph-refine.md"), renderRefine(r, kept))
+                            _     <- ZIO.when(kept.nonEmpty)(
+                                       writeFile(modDir.resolve("inventory.md"), Survey.renderInventory(merged)) *>
+                                         writeFile(modDir.resolve("graph.json"), merged.toJsonPretty)
+                                     )
+                            _     <- events.publish(FlowEvent.Info(
+                                       s"${kept.size} regex-missed edge(s) merged (${r.edges.size} proposed by the LLM)"
+                                     ))
+                          yield merged
+                      }
         outcome    <- stage("Triage") {
                         reasoning
                           .executeStructured[SurveyOutcome](
-                            triagePrompt(graph, Survey.renderInventory(graph)),
+                            triagePrompt(refined, Survey.renderInventory(refined)),
                             SchemaDerivation.derive[SurveyOutcome],
                           )
                           .mapError(e => FlowError.Llm(e.message, Some(e)))
@@ -175,16 +260,16 @@ object SurveyFlow:
                               }
                           }
                       }
-        planMd      = renderWavePlan(outcome, graph, projection)
+        planMd      = renderWavePlan(outcome, refined, projection)
         _          <- stage("Wave plan")(
                         writeFile(modDir.resolve("wave-plan.md"), ApprovalGate.withDraftMarker(planMd))
                       )
         _          <- stage("Commit")(
-                        git.commitAll(s"modernize(${pack.name}): survey — ${graph.nodes.size} unit(s), " +
+                        git.commitAll(s"modernize(${pack.name}): survey — ${refined.nodes.size} unit(s), " +
                           s"${outcome.waves.size} wave(s) proposed").unit
                       )
         _          <- events.publish(FlowEvent.Info(
                         s"review $ModDir/wave-plan.md, flip '- [x] Approved', then run modernize-extract.sc " +
                           "(LLM4ZIO_WAVE=<name> scopes it to one wave)"
                       ))
-      yield s"units=${graph.nodes.size} waves=${outcome.waves.size}"
+      yield s"units=${refined.nodes.size} waves=${outcome.waves.size}"


### PR DESCRIPTION
## What

The deterministic GRAPH step of `modernize-survey` can't link sources it can't regex: dynamic `CALL WS-PGM` variables, JCL symbolic parameters (`EXEC PGM=&PGM`), PROC expansions. The reported case: a JCL job whose references to its step COBOL programs never became edges. This adds an evidence-gated **GRAPH REFINE** stage between Graph and Triage:

- **`flow.Survey.merge`** (new, tested): validates LLM-proposed edges — drops self-loops, edges naming units outside the inventory, and links the regexes already found; survivors get their kind prefixed `llm-` so LLM-derived links stay distinguishable in `graph.json`, and `renderInventory` footnotes them.
- **`modernize-survey.sc` + `modernize.SurveyFlow`**: `reasoning` (read-only, rooted at the legacy repo) reads the sources and proposes the missed edges, each with the establishing source statement as evidence — no evidence, no edge. Kept AND dropped proposals land in `docs/modernization/graph-refine.md` as the audit trail. Triage and the wave plan run over the refined graph. `LLM4ZIO_GRAPH_REFINE=off` skips the pass.

## Release 4.1.0

- CHANGELOG entry for 4.1.0.
- Every example pin synced to 4.1.0: `examples/*.sc`, `examples/java/*.java`, `README.md`, `docs/pilot-playbook.md`, and the `Llm4zioVersion` vals in `modernize-seed.sc`/`modernize-bench.sc` (they had drifted across 3.19.0 and 4.0.0).
- Tag `v4.1.0` after merge triggers `ci-release`.

## Tests

- 4 new `SurveySpec` tests for `merge` + inventory footnote; full suite 328 passed, `sbt check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018AfU8Jbmp8PNZLFQ3RKA9i

---
_Generated by [Claude Code](https://claude.ai/code/session_018AfU8Jbmp8PNZLFQ3RKA9i)_