### PR TITLE
ci: dispatchable Release workflow (unblocks v4.1.0)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,100 @@
+name: Release
+
+# Cuts a release without a manually pushed tag: dispatch with a version, and the
+# workflow gates on the full test battery, tags HEAD of the branch it ran on,
+# publishes to Maven Central, pushes the tag, and creates the GitHub release.
+# Exists because sandboxed agent sessions (and anyone without a local clone) can
+# merge to main but cannot push tags — same reason oci.yml is dispatchable.
+#
+# The tag is pushed with GITHUB_TOKEN, which by design does not re-trigger the
+# tag-push workflows (ci.yml publish, oci.yml) — no double publish. Dispatch
+# oci.yml with the same version afterwards for the container image; it waits
+# for Maven Central sync itself.
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release (e.g. 4.1.0) — tags v<version>"
+        required: true
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Tag, publish, release
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Validate version and tag availability
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+        run: |
+          echo "$INPUT_VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+([.-][A-Za-z0-9.-]+)?$' \
+            || { echo "refusing suspicious version '$INPUT_VERSION'" >&2; exit 1; }
+          if git ls-remote --exit-code origin "refs/tags/v$INPUT_VERSION" >/dev/null 2>&1; then
+            echo "tag v$INPUT_VERSION already exists on origin" >&2; exit 1
+          fi
+
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          cache: 'sbt'
+
+      - name: Setup SBT
+        uses: sbt/setup-sbt@v1
+
+      - name: Check, test, integration-test
+        # Same single --batch battery as ci.yml (see the sbt-server wedge note there):
+        # a dispatched release must gate on green even if HEAD never went through a PR.
+        run: sbt --batch --no-colors "; check ; testFull ; llm4zioFlow/It/testFull ; llm4zioRunner/It/testFull ; llm4zioJava/It/testFull"
+
+      - name: Tag HEAD
+        # Local (unpushed) tag first: sbt-dynver derives 4.1.0 from it for ci-release.
+        # The push happens only after a successful publish, so a failed run leaves
+        # no half-released tag on origin.
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "v$INPUT_VERSION" -m "Release v$INPUT_VERSION"
+
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v7
+        with:
+          gpg_private_key: ${{ secrets.PGP_SECRET }}
+          passphrase: ${{ secrets.PGP_PASSPHRASE }}
+
+      - name: Publish to Maven Central
+        run: sbt --batch --no-colors ci-release
+        env:
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+
+      - name: Push tag
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+        run: git push origin "refs/tags/v$INPUT_VERSION"
+
+      - name: Create GitHub Release
+        if: success()
+        uses: ncipollo/release-action@v1
+        with:
+          tag: v${{ github.event.inputs.version }}
+          name: Release v${{ github.event.inputs.version }}
+          body: "See CHANGELOG.md for detailed release notes."
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

v4.1.0 is merged to `main` (#712) but unreleased: publishing is gated on a `v*` tag push, and sandboxed agent sessions cannot push tags (the session git gateway 403s any ref outside the designated work branch). Same gap that gave `oci.yml` its `workflow_dispatch`.

This adds `.github/workflows/release.yml` — `workflow_dispatch` with a `version` input:

1. validates the version and refuses if the tag already exists on origin;
2. runs the full ci.yml test battery (`check; testFull; It/testFull ×3`) so a dispatched release gates on green;
3. tags HEAD **locally** so sbt-dynver versions `ci-release` correctly;
4. publishes to Maven Central (`sbt ci-release`, same secrets as ci.yml);
5. only after a successful publish: pushes the tag and creates the GitHub release — a failed publish leaves no half-released tag on origin.

`GITHUB_TOKEN` tag pushes deliberately don't re-trigger the tag-push workflows, so there's no double publish; `oci.yml` gets dispatched separately with the same version (it waits for Maven Central sync itself).

## After merge

Dispatch `Release` with `version: 4.1.0`, then `OCI image` with `4.1.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018AfU8Jbmp8PNZLFQ3RKA9i

---
_Generated by [Claude Code](https://claude.ai/code/session_018AfU8Jbmp8PNZLFQ3RKA9i)_