### PR TITLE
ci(release): fix no-op guard path — target/sona-staging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,8 +136,10 @@ jobs:
       - name: Guard against a silent no-op publish
         # `ci-release` exits 0 on its "doing nothing" guard paths; a release run
         # that uploaded nothing must fail loudly, not create a tag and release.
+        # The bundle lands in target/sona-staging (sbt-sonatype's dir name) — the
+        # v4.1.0 run published fine and then failed here on the misspelled path.
         run: |
-          test -d target/sonatype-staging && find target/sonatype-staging -name '*.pom' | grep -q . \
+          test -d target/sona-staging && find target/sona-staging -name '*.pom' | grep -q . \
             || { echo "ci-release produced no staged artifacts — publish did not happen" >&2; exit 1; }
 
       - name: Push tag


### PR DESCRIPTION
The v4.1.0 [re-run](https://github.com/riccardomerolla/llm4zio/actions/runs/30256053528) published correctly — `Tag push detected, publishing a stable release`, all five artifacts signed, bundle uploaded, deployment `io.github.riccardomerolla:llm4zio:4.1.0` reached **PUBLISHED**, and all five 4.1.0 artifacts are now live on repo1.maven.org — but the run then went red on the staged-artifact guard, which checked `target/sonatype-staging`. sbt-sonatype's bundle directory is `target/sona-staging`. One-line path fix so future release dispatches don't false-fail after a successful publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018AfU8Jbmp8PNZLFQ3RKA9i

---
_Generated by [Claude Code](https://claude.ai/code/session_018AfU8Jbmp8PNZLFQ3RKA9i)_